### PR TITLE
feat: auto-detect package manager in pickle init

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -7,6 +7,7 @@ import { parseFeatureFiles, filterPicklesByTag } from './parser'
 import { runFeatures, cancelRun } from './runner'
 import { reportSummary, reportError, reportCancelled } from './reporter'
 import { generateHtmlReport } from './html-report'
+import { detectPackageManager, getRunCommand, getAddCommand } from './package-manager'
 import pc from 'picocolors'
 
 const pkg = await Bun.file(resolve(import.meta.dir, '../package.json')).json()
@@ -100,7 +101,7 @@ program
 
 program
   .command('init')
-  .description('Create a starter pickle.config.ts')
+  .description('Create a starter pickle.config.ts and install pickle-spec')
   .action(async () => {
     const configPath = 'pickle.config.ts'
     const file = Bun.file(configPath)
@@ -110,15 +111,18 @@ program
       process.exit(1)
     }
 
+    const pm = await detectPackageManager()
+    const runCmd = getRunCommand(pm)
+
     const configContent = `import { defineConfig } from 'pickle-spec'
 
 export default defineConfig({
   server: {
-    command: 'bun run dev',
+    command: '${runCmd} dev',
     port: 3000,
     url: 'http://localhost:3000',
   },
-  stagehand: {
+  browser: {
     env: 'LOCAL',
     modelName: 'claude-4-6-sonnet-latest',
     headless: true,
@@ -127,7 +131,24 @@ export default defineConfig({
 `
 
     await Bun.write(configPath, configContent)
-    console.log(`Created ${configPath}`)
+    console.log(pc.green(`Created ${configPath}`))
+    console.log(pc.dim(`  Detected package manager: ${pm}`))
+
+    console.log(`\nInstalling pickle-spec...`)
+    const addCmd = getAddCommand(pm)
+    const proc = Bun.spawn(addCmd.split(' ').concat('pickle-spec'), {
+      stdout: 'inherit',
+      stderr: 'inherit',
+      cwd: process.cwd(),
+    })
+    const exitCode = await proc.exited
+
+    if (exitCode !== 0) {
+      reportError(`Failed to install pickle-spec (exit code ${exitCode})`)
+      process.exit(1)
+    }
+
+    console.log(pc.green(`\nPickle-spec is ready!`))
   })
 
 program.parse()

--- a/src/package-manager.ts
+++ b/src/package-manager.ts
@@ -1,0 +1,29 @@
+import { resolve } from 'path'
+
+export type PackageManager = 'bun' | 'pnpm' | 'yarn' | 'npm'
+
+const lockFiles: [string, PackageManager][] = [
+  ['bun.lockb', 'bun'],
+  ['bun.lock', 'bun'],
+  ['pnpm-lock.yaml', 'pnpm'],
+  ['yarn.lock', 'yarn'],
+  ['package-lock.json', 'npm'],
+]
+
+export async function detectPackageManager(cwd = process.cwd()): Promise<PackageManager> {
+  for (const [lockFile, pm] of lockFiles) {
+    if (await Bun.file(resolve(cwd, lockFile)).exists()) {
+      return pm
+    }
+  }
+  return 'npm'
+}
+
+export function getRunCommand(pm: PackageManager): string {
+  return `${pm} run`
+}
+
+export function getAddCommand(pm: PackageManager): string {
+  if (pm === 'npm') return 'npm install'
+  return `${pm} add`
+}


### PR DESCRIPTION
## Summary
- Adds package manager detection (bun, pnpm, yarn, npm) to `pickle init` command
- Generates config with correct run command for the detected PM (e.g., 'pnpm run dev')
- Auto-installs pickle-spec dependency after creating config
- Improves user feedback with colored output and package manager info

## Test plan
- Run `pickle init` in projects with bun.lockb, pnpm-lock.yaml, yarn.lock, package-lock.json
- Verify correct PM is detected and used in generated config
- Verify pickle-spec is installed as a dependency