### PR TITLE
feat(cli): add `pickle init` and `pickle check` for project initialization and validation

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -26,8 +26,6 @@
         "@pickle-spec/runner": "workspace:*",
         "@pickle-spec/spec": "workspace:*",
         "@pickle-spec/web": "workspace:*",
-      },
-      "devDependencies": {
         "@types/bun": "latest",
         "typescript": "^5.9.3",
       },

--- a/packages/cli/index.ts
+++ b/packages/cli/index.ts
@@ -1,1 +1,4 @@
+export { loadConfig, validateConfig } from './src/config'
 export type { PickleConfig, ServerConfig } from './src/config'
+export { checkProject, initializeProject } from './src/project'
+export type { ProjectCommandOptions } from './src/project'

--- a/packages/cli/index.ts
+++ b/packages/cli/index.ts
@@ -1,4 +1,1 @@
-export { loadConfig, validateConfig } from './src/config'
 export type { PickleConfig, ServerConfig } from './src/config'
-export { checkProject, initializeProject } from './src/project'
-export type { ProjectCommandOptions } from './src/project'

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -20,9 +20,7 @@
   "dependencies": {
     "@pickle-spec/runner": "workspace:*",
     "@pickle-spec/spec": "workspace:*",
-    "@pickle-spec/web": "workspace:*"
-  },
-  "devDependencies": {
+    "@pickle-spec/web": "workspace:*",
     "@types/bun": "latest",
     "typescript": "^5.9.3"
   }

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -1,24 +1,18 @@
 #!/usr/bin/env bun
 
-import type { ExecutionTargetAdapter, ExecutionTargetProfile } from '@pickle-spec/runner'
+import type { ExecutionTargetAdapter } from '@pickle-spec/runner'
 import { resolveRunConfiguration, runScenarios } from '@pickle-spec/runner'
 import { parseSpecificationFile, selectScenarios, type SelectionOptions } from '@pickle-spec/spec'
 import {
   createWebAdapter,
   type WebAdapterOptions,
-  type WebAutomationFactory,
 } from '@pickle-spec/web'
 import { resolve } from 'node:path'
 import { pathToFileURL } from 'node:url'
 import { loadConfig, type PickleConfig } from './config'
+import type { Extensions } from './extensions'
 import { checkProject, initializeProject } from './project'
 import { startServer } from './server'
-
-interface Extensions {
-  adapter?: ExecutionTargetAdapter
-  executionTargetProfile?: ExecutionTargetProfile
-  webAutomationFactory?: WebAutomationFactory
-}
 
 interface RunArguments {
   pattern?: string
@@ -147,17 +141,12 @@ function configuredAdapter(
 async function run(argv: string[]): Promise<number> {
   const args = parseRunArguments(argv)
   const config = await loadConfig(args.configPath)
-  const extensions = await loadExtensions(args.extensionsPath)
   const controller = new AbortController()
   const onSigint = () => controller.abort()
   process.on('SIGINT', onSigint)
   let server: Awaited<ReturnType<typeof startServer>>
 
   try {
-    server = await startServer({
-      ...config.server,
-      ...(args.reuseServer ? { reuseExisting: true } : {}),
-    })
     const specifications = await discoverSpecifications(
       args.pattern ?? config.specifications ?? 'features/**/*.feature',
       args.language ?? config.language,
@@ -169,6 +158,7 @@ async function run(argv: string[]): Promise<number> {
     })
     if (selections.length === 0) throw new Error('No Scenarios match the current selection')
 
+    const extensions = await loadExtensions(args.extensionsPath)
     const web = configuredWebOptions(config, args)
     const resolvedConfiguration = resolveRunConfiguration({
       schemaVersion: config.schemaVersion,
@@ -181,7 +171,10 @@ async function run(argv: string[]): Promise<number> {
       },
     }, {
       adapter: configuredAdapter(extensions, web),
-      executionTargetProfile: extensions.executionTargetProfile,
+    })
+    server = await startServer({
+      ...config.server,
+      ...(args.reuseServer ? { reuseExisting: true } : {}),
     })
     const runs = await runScenarios({
       selections,

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -11,6 +11,7 @@ import {
 import { resolve } from 'node:path'
 import { pathToFileURL } from 'node:url'
 import { loadConfig, type PickleConfig } from './config'
+import { checkProject, initializeProject } from './project'
 import { startServer } from './server'
 
 interface Extensions {
@@ -205,8 +206,32 @@ async function run(argv: string[]): Promise<number> {
   }
 }
 
+function projectOptions(argv: string[]): { configPath?: string; extensionsPath?: string } {
+  const options: { configPath?: string; extensionsPath?: string } = {}
+  for (let index = 1; index < argv.length; index++) {
+    const flag = argv[index]!
+    if (flag === '--config') options.configPath = valueAfter(argv, index++)
+    else if (flag === '--extensions') options.extensionsPath = valueAfter(argv, index++)
+    else throw new Error(`Unknown option: ${flag}`)
+  }
+  return options
+}
+
+async function main(argv: string[]): Promise<number> {
+  if (argv[0] === 'init') {
+    if (argv.length > 1) throw new Error('Usage: pickle init')
+    await initializeProject()
+    return 0
+  }
+  if (argv[0] === 'check') {
+    await checkProject({ ...projectOptions(argv), report: console.log })
+    return 0
+  }
+  return run(argv)
+}
+
 try {
-  process.exitCode = await run(Bun.argv.slice(2))
+  process.exitCode = await main(Bun.argv.slice(2))
 } catch (error) {
   console.error(error instanceof Error ? error.message : String(error))
   process.exitCode = 2

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -1,6 +1,10 @@
-import type { ExecutionTargetProfile } from '@pickle-spec/runner'
-import type { SelectionOptions } from '@pickle-spec/spec'
-import type { WebAdapterOptions } from '@pickle-spec/web'
+import {
+  validateRunConfiguration,
+  type ExecutionTargetProfile,
+  type RunConfiguration,
+} from '@pickle-spec/runner'
+import { validateSelectionOptions, type SelectionOptions } from '@pickle-spec/spec'
+import { validateWebAdapterOptions, type WebAdapterOptions } from '@pickle-spec/web'
 import { resolve } from 'node:path'
 
 export interface ServerConfig {
@@ -29,11 +33,26 @@ export interface PickleConfig {
   server?: ServerConfig
 }
 
+export function runConfigurationFrom(config: PickleConfig): RunConfiguration {
+  return {
+    schemaVersion: config.schemaVersion,
+    executionTargetProfile: config.executionTargetProfile ?? { id: config.web ? 'web' : 'custom' },
+    concurrency: config.concurrency,
+    execution: config.execution,
+  }
+}
+
 function record(value: unknown, field: string): Record<string, unknown> {
   if (typeof value !== 'object' || value === null || Array.isArray(value)) {
     throw new Error(`${field} must be an object`)
   }
   return value as Record<string, unknown>
+}
+
+function knownFields(value: Record<string, unknown>, fields: readonly string[], parent: string): void {
+  for (const field of Object.keys(value)) {
+    if (!fields.includes(field)) throw new Error(`${parent}.${field} is not supported`)
+  }
 }
 
 function optionalString(value: unknown, field: string): void {
@@ -48,33 +67,33 @@ function optionalPositiveInteger(value: unknown, field: string): void {
   }
 }
 
-export function validateConfig(value: unknown): PickleConfig {
+function validateConfig(value: unknown): PickleConfig {
   const config = record(value, 'configuration')
-  if (config.schemaVersion !== 1) {
-    throw new Error(`Unsupported configuration schemaVersion: ${String(config.schemaVersion)}`)
-  }
+  knownFields(config, [
+    'schemaVersion', 'language', 'specifications', 'executionTargetProfile', 'web',
+    'selection', 'execution', 'concurrency', 'server',
+  ], 'configuration')
   optionalString(config.language, 'language')
-  if (
-    config.specifications !== undefined
-    && typeof config.specifications !== 'string'
-    && !(Array.isArray(config.specifications) && config.specifications.every(item => typeof item === 'string'))
-  ) {
+  if (typeof config.specifications === 'string' && !config.specifications.trim()) {
+    throw new Error('specifications paths must not be empty')
+  }
+  if (Array.isArray(config.specifications) && config.specifications.length === 0) {
+    throw new Error('specifications must contain at least one path')
+  }
+  if (config.specifications !== undefined && typeof config.specifications !== 'string'
+    && !(Array.isArray(config.specifications)
+      && config.specifications.every(item => typeof item === 'string' && item.trim()))) {
     throw new Error('specifications must be a string or an array of strings')
   }
-  if (config.executionTargetProfile !== undefined) {
-    const profile = record(config.executionTargetProfile, 'executionTargetProfile')
-    if (typeof profile.id !== 'string' || !profile.id.trim()) {
-      throw new Error('executionTargetProfile.id must not be empty')
-    }
-  }
   if (config.web !== undefined) {
-    const web = record(config.web, 'web')
-    if (typeof web.baseUrl !== 'string' || !web.baseUrl.trim()) {
-      throw new Error('web.baseUrl must not be empty')
-    }
+    validateWebAdapterOptions(config.web)
   }
   if (config.server !== undefined) {
     const server = record(config.server, 'server')
+    knownFields(server, [
+      'command', 'url', 'port', 'startupTimeoutMs', 'pollIntervalMs', 'readinessPath',
+      'reuseExisting',
+    ], 'server')
     optionalString(server.command, 'server.command')
     optionalString(server.url, 'server.url')
     optionalString(server.readinessPath, 'server.readinessPath')
@@ -84,19 +103,24 @@ export function validateConfig(value: unknown): PickleConfig {
     if (server.reuseExisting !== undefined && typeof server.reuseExisting !== 'boolean') {
       throw new Error('server.reuseExisting must be a boolean')
     }
-  }
-  if (config.selection !== undefined) record(config.selection, 'selection')
-  if (config.execution !== undefined) {
-    const execution = record(config.execution, 'execution')
-    optionalPositiveInteger(execution.scenarioTimeoutMs, 'execution.scenarioTimeoutMs')
-    optionalPositiveInteger(execution.stepTimeoutMs, 'execution.stepTimeoutMs')
-    const retries = execution.infrastructureRetries
-    if (retries !== undefined && (!Number.isInteger(retries) || (retries as number) < 0)) {
-      throw new Error('execution.infrastructureRetries must be a non-negative integer')
+    if (server.command && !server.url && !server.port) {
+      throw new Error('server.command requires server.url or server.port')
+    }
+    if (server.url !== undefined) {
+      try {
+        new URL(server.url as string)
+      } catch {
+        throw new Error('server.url must be a valid URL')
+      }
+    }
+    if (typeof server.port === 'number' && server.port > 65_535) {
+      throw new Error('server.port must be less than or equal to 65535')
     }
   }
-  optionalPositiveInteger(config.concurrency, 'concurrency')
-  return config as unknown as PickleConfig
+  if (config.selection !== undefined) validateSelectionOptions(config.selection)
+  const validatedConfig = config as unknown as PickleConfig
+  validateRunConfiguration(runConfigurationFrom(validatedConfig))
+  return validatedConfig
 }
 
 function removeJsonComments(source: string): string {

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -42,7 +42,13 @@ function optionalString(value: unknown, field: string): void {
   }
 }
 
-function validateConfig(value: unknown): PickleConfig {
+function optionalPositiveInteger(value: unknown, field: string): void {
+  if (value !== undefined && (!Number.isInteger(value) || (value as number) < 1)) {
+    throw new Error(`${field} must be an integer greater than or equal to 1`)
+  }
+}
+
+export function validateConfig(value: unknown): PickleConfig {
   const config = record(value, 'configuration')
   if (config.schemaVersion !== 1) {
     throw new Error(`Unsupported configuration schemaVersion: ${String(config.schemaVersion)}`)
@@ -71,9 +77,25 @@ function validateConfig(value: unknown): PickleConfig {
     const server = record(config.server, 'server')
     optionalString(server.command, 'server.command')
     optionalString(server.url, 'server.url')
+    optionalString(server.readinessPath, 'server.readinessPath')
+    optionalPositiveInteger(server.port, 'server.port')
+    optionalPositiveInteger(server.startupTimeoutMs, 'server.startupTimeoutMs')
+    optionalPositiveInteger(server.pollIntervalMs, 'server.pollIntervalMs')
+    if (server.reuseExisting !== undefined && typeof server.reuseExisting !== 'boolean') {
+      throw new Error('server.reuseExisting must be a boolean')
+    }
   }
   if (config.selection !== undefined) record(config.selection, 'selection')
-  if (config.execution !== undefined) record(config.execution, 'execution')
+  if (config.execution !== undefined) {
+    const execution = record(config.execution, 'execution')
+    optionalPositiveInteger(execution.scenarioTimeoutMs, 'execution.scenarioTimeoutMs')
+    optionalPositiveInteger(execution.stepTimeoutMs, 'execution.stepTimeoutMs')
+    const retries = execution.infrastructureRetries
+    if (retries !== undefined && (!Number.isInteger(retries) || (retries as number) < 0)) {
+      throw new Error('execution.infrastructureRetries must be a non-negative integer')
+    }
+  }
+  optionalPositiveInteger(config.concurrency, 'concurrency')
   return config as unknown as PickleConfig
 }
 
@@ -129,5 +151,10 @@ export async function loadConfig(configPath?: string): Promise<PickleConfig> {
     throw new Error(`Configuration file not found: ${selectedPath}`)
   }
 
-  return validateConfig(JSON.parse(removeJsonComments(await Bun.file(absolutePath).text())))
+  try {
+    return validateConfig(JSON.parse(removeJsonComments(await Bun.file(absolutePath).text())))
+  } catch (error) {
+    const reason = error instanceof Error ? error.message : String(error)
+    throw new Error(`Invalid configuration ${selectedPath}: ${reason}. Correct the value and run pickle check again.`)
+  }
 }

--- a/packages/cli/src/extension-validation.ts
+++ b/packages/cli/src/extension-validation.ts
@@ -1,0 +1,127 @@
+import type { RunExtensionManifest } from '@pickle-spec/runner'
+import { dirname, relative, resolve } from 'node:path'
+import ts from 'typescript'
+
+function extensionModuleSpecifier(from: string, to: string): string {
+  const path = relative(dirname(from), to).replaceAll('\\', '/')
+  return path.startsWith('.') ? path : `./${path}`
+}
+
+function diagnosticMessage(diagnostic: ts.Diagnostic): string {
+  return ts.flattenDiagnosticMessageText(diagnostic.messageText, ' ')
+}
+
+function diagnosticReason(diagnostics: readonly ts.Diagnostic[]): string {
+  return [...new Set(diagnostics.map(diagnosticMessage))].join('; ')
+}
+
+function isRelevantSemanticDiagnostic(
+  program: ts.Program,
+  diagnostic: ts.Diagnostic,
+  validationPath: string,
+): boolean {
+  if (diagnostic.category !== ts.DiagnosticCategory.Error) return false
+  if (diagnostic.code === 2307 && /^Cannot find module '(?:node|bun):/.test(
+    diagnosticMessage(diagnostic),
+  )) return false
+  if (!diagnostic.file) return false
+  return resolve(diagnostic.file.fileName) === validationPath
+    || !program.isSourceFileFromExternalLibrary(diagnostic.file)
+}
+
+function extensionProvidesAdapter(
+  typeChecker: ts.TypeChecker,
+  defaultExport: ts.Symbol,
+  sourceFile: ts.SourceFile,
+): boolean {
+  const exportedSymbol = defaultExport.flags & ts.SymbolFlags.Alias
+    ? typeChecker.getAliasedSymbol(defaultExport)
+    : defaultExport
+  const declaration = exportedSymbol.valueDeclaration ?? exportedSymbol.declarations?.[0] ?? sourceFile
+  const extensionType = typeChecker.getTypeOfSymbolAtLocation(exportedSymbol, declaration)
+  const adapter = extensionType.getProperty('adapter')
+  const adapterDeclaration = adapter?.valueDeclaration ?? adapter?.declarations?.[0] ?? sourceFile
+  const adapterType = adapter && typeChecker.getTypeOfSymbolAtLocation(adapter, adapterDeclaration)
+
+  return Boolean(adapter && !(adapter.flags & ts.SymbolFlags.Optional)
+    && adapterType && !(adapterType.flags & ts.TypeFlags.Undefined))
+}
+
+export function validateExtensions(path: string): Pick<RunExtensionManifest, 'adapterAvailable'> {
+  const validationPath = resolve(import.meta.dir, '__extension_validation__.ts')
+  const validationSource = `
+import extensions from ${JSON.stringify(extensionModuleSpecifier(validationPath, path))}
+import type { Extensions } from './extensions'
+
+type ExpectedExtensions = Extensions
+type ExactExtensions<Actual extends ExpectedExtensions> =
+  Actual & Record<Exclude<keyof Actual, keyof ExpectedExtensions>, never>
+declare function validate<Actual extends ExpectedExtensions>(
+  extensions: ExactExtensions<Actual>,
+): void
+validate(extensions)
+`
+  const compilerOptions: ts.CompilerOptions = {
+    allowImportingTsExtensions: true,
+    allowJs: true,
+    module: ts.ModuleKind.Preserve,
+    moduleResolution: ts.ModuleResolutionKind.Bundler,
+    noEmit: true,
+    skipLibCheck: true,
+    strict: false,
+    target: ts.ScriptTarget.ESNext,
+    types: ['bun'],
+  }
+  const host = ts.createCompilerHost(compilerOptions)
+  const getSourceFile = host.getSourceFile.bind(host)
+  host.fileExists = fileName => resolve(fileName) === validationPath || ts.sys.fileExists(fileName)
+  host.readFile = fileName => resolve(fileName) === validationPath
+    ? validationSource
+    : ts.sys.readFile(fileName)
+  host.getSourceFile = (fileName, languageVersion, onError, shouldCreateNewSourceFile) => {
+    if (resolve(fileName) === validationPath) {
+      return ts.createSourceFile(fileName, validationSource, languageVersion, true, ts.ScriptKind.TS)
+    }
+    return getSourceFile(fileName, languageVersion, onError, shouldCreateNewSourceFile)
+  }
+
+  const program = ts.createProgram([validationPath], compilerOptions, host)
+  const syntaxDiagnostics = program.getSyntacticDiagnostics()
+    .filter(diagnostic => diagnostic.category === ts.DiagnosticCategory.Error)
+  if (syntaxDiagnostics.length > 0) {
+    throw new Error(
+      `Cannot validate ${relative(process.cwd(), path)}: ${diagnosticReason(syntaxDiagnostics)}. `
+      + 'Fix its imports or syntax and run pickle check again.',
+    )
+  }
+
+  const typeChecker = program.getTypeChecker()
+  const sourceFile = program.getSourceFile(path)
+  const moduleSymbol = sourceFile && typeChecker.getSymbolAtLocation(sourceFile)
+  const defaultExport = moduleSymbol && typeChecker
+    .getExportsOfModule(moduleSymbol)
+    .find(symbol => symbol.name === 'default')
+  if (!defaultExport) {
+    throw new Error(
+      `${relative(process.cwd(), path)} must provide a default export. `
+      + 'Export the extension object as default and run pickle check again.',
+    )
+  }
+
+  const semanticDiagnostics = program.getSemanticDiagnostics()
+    .filter(diagnostic => isRelevantSemanticDiagnostic(program, diagnostic, validationPath))
+  if (semanticDiagnostics.length > 0) {
+    const correction = semanticDiagnostics.some(diagnostic =>
+      resolve(diagnostic.file?.fileName ?? '') !== validationPath)
+      ? 'Fix its imports or syntax and run pickle check again.'
+      : 'Correct the extension default export and run pickle check again.'
+    throw new Error(
+      `Cannot validate ${relative(process.cwd(), path)}: `
+      + `${diagnosticReason(semanticDiagnostics)}. ${correction}`,
+    )
+  }
+
+  return {
+    adapterAvailable: extensionProvidesAdapter(typeChecker, defaultExport, sourceFile),
+  }
+}

--- a/packages/cli/src/extensions.ts
+++ b/packages/cli/src/extensions.ts
@@ -1,0 +1,7 @@
+import type { ExecutionTargetAdapter } from '@pickle-spec/runner'
+import type { WebAutomationFactory } from '@pickle-spec/web'
+
+export interface Extensions {
+  adapter?: ExecutionTargetAdapter
+  webAutomationFactory?: WebAutomationFactory
+}

--- a/packages/cli/src/project.ts
+++ b/packages/cli/src/project.ts
@@ -1,6 +1,8 @@
+import { validateProjectRunConfiguration } from '@pickle-spec/runner'
+import { parseSpecificationFile } from '@pickle-spec/spec'
 import { relative, resolve } from 'node:path'
-import { pathToFileURL } from 'node:url'
-import { loadConfig, type PickleConfig } from './config'
+import { loadConfig, runConfigurationFrom, type PickleConfig } from './config'
+import { validateExtensions } from './extension-validation'
 
 const CONFIG_PATH = 'pickle.config.jsonc'
 const EXTENSIONS_PATH = 'pickle.extensions.ts'
@@ -23,7 +25,7 @@ export default {
 }
 `
 
-export interface ProjectCommandOptions {
+interface ProjectCommandOptions {
   cwd?: string
   configPath?: string
   extensionsPath?: string
@@ -44,30 +46,28 @@ export async function initializeProject(options: ProjectCommandOptions = {}): Pr
   }
 }
 
-async function importExtensions(path: string): Promise<Record<string, unknown>> {
-  try {
-    const module = await import(`${pathToFileURL(path).href}?check=${Date.now()}`)
-    const extensions = module.default
-    if (typeof extensions !== 'object' || extensions === null || Array.isArray(extensions)) {
-      throw new Error('the default export must be an object')
-    }
-    return extensions as Record<string, unknown>
-  } catch (error) {
-    const reason = error instanceof Error ? error.message : String(error)
-    throw new Error(`Cannot import ${relative(process.cwd(), path)}: ${reason}. Fix its imports and default export.`)
-  }
-}
-
 async function validateSpecificationPaths(config: PickleConfig, cwd: string): Promise<void> {
   const patterns = config.specifications ?? 'features/**/*.feature'
+  const specificationPaths = new Set<string>()
   for (const pattern of Array.isArray(patterns) ? patterns : [patterns]) {
     let found = false
-    for await (const _ of new Bun.Glob(pattern).scan({ cwd, onlyFiles: true })) {
+    for await (const path of new Bun.Glob(pattern).scan({ cwd, onlyFiles: true })) {
       found = true
-      break
+      specificationPaths.add(resolve(cwd, path))
     }
     if (!found) {
       throw new Error(`Specification path ${JSON.stringify(pattern)} matches no files. Add a Specification or correct specifications in the configuration.`)
+    }
+  }
+  for (const path of [...specificationPaths].sort()) {
+    try {
+      await parseSpecificationFile(path, config.language)
+    } catch (error) {
+      const reason = error instanceof Error ? error.message : String(error)
+      throw new Error(
+        `Invalid Specification ${relative(cwd, path)}: ${reason}. `
+        + 'Correct the Specification and run pickle check again.',
+      )
     }
   }
 }
@@ -87,15 +87,12 @@ export async function checkProject(options: ProjectCommandOptions = {}): Promise
   try {
     process.chdir(cwd)
     const config = await loadConfig(configPath)
-    const extensions = await importExtensions(extensionsPath)
+    const extensions = validateExtensions(extensionsPath)
+    validateProjectRunConfiguration(runConfigurationFrom(config), {
+      ...extensions,
+      fallbackAdapterAvailable: Boolean(config.web),
+    })
     await validateSpecificationPaths(config, cwd)
-    if (!config.web && !extensions.adapter) {
-      throw new Error('No execution target is configured. Configure web.baseUrl or export an adapter from the extensions file.')
-    }
-    if (extensions.adapter !== undefined && (typeof extensions.adapter !== 'object' || extensions.adapter === null
-      || typeof (extensions.adapter as { openSession?: unknown }).openSession !== 'function')) {
-      throw new Error('extensions.adapter must provide openSession. Export a valid execution-target adapter.')
-    }
     options.report?.(`Project is valid (${relative(cwd, configPath)}, ${relative(cwd, extensionsPath)})`)
   } finally {
     process.chdir(previousCwd)

--- a/packages/cli/src/project.ts
+++ b/packages/cli/src/project.ts
@@ -1,0 +1,103 @@
+import { relative, resolve } from 'node:path'
+import { pathToFileURL } from 'node:url'
+import { loadConfig, type PickleConfig } from './config'
+
+const CONFIG_PATH = 'pickle.config.jsonc'
+const EXTENSIONS_PATH = 'pickle.extensions.ts'
+
+const initialConfig = `{
+  // Pickle Spec project configuration.
+  "schemaVersion": 1,
+  "specifications": "features/**/*.feature",
+  "executionTargetProfile": { "id": "custom" }
+}
+`
+
+const initialExtensions = `// Add execution-target integrations here. Importing this file must not start resources.
+export default {
+  adapter: {
+    async openSession() {
+      throw new Error('Configure an execution target in pickle.extensions.ts before running scenarios')
+    },
+  },
+}
+`
+
+export interface ProjectCommandOptions {
+  cwd?: string
+  configPath?: string
+  extensionsPath?: string
+  report?: (message: string) => void
+}
+
+export async function initializeProject(options: ProjectCommandOptions = {}): Promise<void> {
+  const cwd = resolve(options.cwd ?? process.cwd())
+  const report = options.report ?? console.log
+  for (const [path, contents] of [[CONFIG_PATH, initialConfig], [EXTENSIONS_PATH, initialExtensions]] as const) {
+    const absolutePath = resolve(cwd, path)
+    if (await Bun.file(absolutePath).exists()) {
+      report(`Skipped ${path}: file already exists`)
+      continue
+    }
+    await Bun.write(absolutePath, contents)
+    report(`Created ${path}`)
+  }
+}
+
+async function importExtensions(path: string): Promise<Record<string, unknown>> {
+  try {
+    const module = await import(`${pathToFileURL(path).href}?check=${Date.now()}`)
+    const extensions = module.default
+    if (typeof extensions !== 'object' || extensions === null || Array.isArray(extensions)) {
+      throw new Error('the default export must be an object')
+    }
+    return extensions as Record<string, unknown>
+  } catch (error) {
+    const reason = error instanceof Error ? error.message : String(error)
+    throw new Error(`Cannot import ${relative(process.cwd(), path)}: ${reason}. Fix its imports and default export.`)
+  }
+}
+
+async function validateSpecificationPaths(config: PickleConfig, cwd: string): Promise<void> {
+  const patterns = config.specifications ?? 'features/**/*.feature'
+  for (const pattern of Array.isArray(patterns) ? patterns : [patterns]) {
+    let found = false
+    for await (const _ of new Bun.Glob(pattern).scan({ cwd, onlyFiles: true })) {
+      found = true
+      break
+    }
+    if (!found) {
+      throw new Error(`Specification path ${JSON.stringify(pattern)} matches no files. Add a Specification or correct specifications in the configuration.`)
+    }
+  }
+}
+
+export async function checkProject(options: ProjectCommandOptions = {}): Promise<void> {
+  const cwd = resolve(options.cwd ?? process.cwd())
+  const configPath = resolve(cwd, options.configPath ?? CONFIG_PATH)
+  const extensionsPath = resolve(cwd, options.extensionsPath ?? EXTENSIONS_PATH)
+  if (!(await Bun.file(configPath).exists())) {
+    throw new Error(`Configuration file not found: ${relative(cwd, configPath)}. Run pickle init or pass --config <path>.`)
+  }
+  if (!(await Bun.file(extensionsPath).exists())) {
+    throw new Error(`Extensions file not found: ${relative(cwd, extensionsPath)}. Run pickle init or pass --extensions <path>.`)
+  }
+
+  const previousCwd = process.cwd()
+  try {
+    process.chdir(cwd)
+    const config = await loadConfig(configPath)
+    const extensions = await importExtensions(extensionsPath)
+    await validateSpecificationPaths(config, cwd)
+    if (!config.web && !extensions.adapter) {
+      throw new Error('No execution target is configured. Configure web.baseUrl or export an adapter from the extensions file.')
+    }
+    if (extensions.adapter !== undefined && (typeof extensions.adapter !== 'object' || extensions.adapter === null
+      || typeof (extensions.adapter as { openSession?: unknown }).openSession !== 'function')) {
+      throw new Error('extensions.adapter must provide openSession. Export a valid execution-target adapter.')
+    }
+    options.report?.(`Project is valid (${relative(cwd, configPath)}, ${relative(cwd, extensionsPath)})`)
+  } finally {
+    process.chdir(previousCwd)
+  }
+}

--- a/packages/cli/src/workspace.test.ts
+++ b/packages/cli/src/workspace.test.ts
@@ -108,6 +108,41 @@ export default {
     expect(stdout).not.toContain('Stagehand')
   })
 
+  test('initializes a project without overwriting files and checks it without opening a session', async () => {
+    const project = join(workspace, 'initialized-project')
+    await mkdir(join(project, 'features'), { recursive: true })
+    await Bun.write(join(project, 'features', 'example.feature'), `Feature: Example\n  Scenario: Safe check\n    Then validation is offline`)
+
+    const first = Bun.spawnSync({ cmd: [pickleCommand, 'init'], cwd: project, env: { ...Bun.env } })
+    expect(first.exitCode).toBe(0)
+    expect(first.stdout.toString()).toContain('Created pickle.config.jsonc')
+    expect(first.stdout.toString()).toContain('Created pickle.extensions.ts')
+
+    const originalExtensions = await Bun.file(join(project, 'pickle.extensions.ts')).text()
+    const second = Bun.spawnSync({ cmd: [pickleCommand, 'init'], cwd: project, env: { ...Bun.env } })
+    expect(second.exitCode).toBe(0)
+    expect(second.stdout.toString()).toContain('Skipped pickle.config.jsonc: file already exists')
+    expect(second.stdout.toString()).toContain('Skipped pickle.extensions.ts: file already exists')
+    expect(await Bun.file(join(project, 'pickle.extensions.ts')).text()).toBe(originalExtensions)
+
+    const checked = Bun.spawnSync({ cmd: [pickleCommand, 'check'], cwd: project, env: { ...Bun.env } })
+    expect(checked.exitCode).toBe(0)
+    expect(checked.stdout.toString()).toContain('Project is valid')
+    expect(checked.stderr.toString()).toBe('')
+  })
+
+  test('check reports the reason and corrective action for validation failures', async () => {
+    const project = join(workspace, 'invalid-project')
+    await mkdir(project, { recursive: true })
+    await Bun.write(join(project, 'pickle.config.jsonc'), '{ "schemaVersion": 99 }')
+    await Bun.write(join(project, 'pickle.extensions.ts'), 'export default {}')
+
+    const checked = Bun.spawnSync({ cmd: [pickleCommand, 'check'], cwd: project, env: { ...Bun.env } })
+    expect(checked.exitCode).toBe(2)
+    expect(checked.stderr.toString()).toContain('Unsupported configuration schemaVersion: 99')
+    expect(checked.stderr.toString()).toContain('Correct the value and run pickle check again')
+  })
+
   test('the deterministic adapter models every kernel outcome', async () => {
     const cases = [
       { outcome: 'passed', exitCode: 0 },

--- a/packages/cli/src/workspace.test.ts
+++ b/packages/cli/src/workspace.test.ts
@@ -1,11 +1,47 @@
 import { afterAll, beforeAll, describe, expect, test } from 'bun:test'
 import { mkdir, mkdtemp, rm, symlink } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
-import { join, resolve } from 'node:path'
+import { dirname, join, resolve } from 'node:path'
 
 describe('public CLI workspace seam', () => {
   let workspace: string
   let pickleCommand: string
+
+  interface CheckProjectFixture {
+    config: unknown
+    extensions?: string
+    specification?: { path: string; source: string }
+  }
+
+  const defaultCheckConfig = {
+    schemaVersion: 1,
+    specifications: 'features/**/*.feature',
+    web: { baseUrl: 'https://example.com' },
+  }
+  const validSpecification = {
+    path: 'features/example.feature',
+    source: 'Feature: Example\n  Scenario: Validate project\n    Then validation succeeds',
+  }
+
+  async function createCheckProject(name: string, fixture: CheckProjectFixture): Promise<string> {
+    const project = join(workspace, name)
+    await mkdir(project, { recursive: true })
+    if (fixture.specification) {
+      const path = join(project, fixture.specification.path)
+      await mkdir(dirname(path), { recursive: true })
+      await Bun.write(path, fixture.specification.source)
+    }
+    await Bun.write(join(project, 'pickle.config.jsonc'), JSON.stringify(fixture.config))
+    await Bun.write(
+      join(project, 'pickle.extensions.ts'),
+      fixture.extensions ?? 'export default {}',
+    )
+    return project
+  }
+
+  function runCheck(project: string) {
+    return Bun.spawnSync({ cmd: [pickleCommand, 'check'], cwd: project, env: { ...Bun.env } })
+  }
 
   beforeAll(async () => {
     workspace = await mkdtemp(join(tmpdir(), 'pickle-spec-workspace-'))
@@ -20,11 +56,14 @@ describe('public CLI workspace seam', () => {
   Scenario: Complete a purchase
     Given a product is in the basket
     Then the purchase succeeds`)
+    await Bun.write(join(workspace, 'deterministic.config.jsonc'), JSON.stringify({
+      schemaVersion: 1,
+      executionTargetProfile: { id: 'deterministic' },
+    }))
     await Bun.write(join(workspace, 'pickle.extensions.ts'), `
 const state = process.env.PICKLE_TEST_OUTCOME ?? 'passed'
 
 export default {
-  executionTargetProfile: { id: 'deterministic' },
   adapter: {
     async openSession() {
       return {
@@ -68,6 +107,8 @@ export default {
         pickleCommand,
         'run',
         'purchase.feature',
+        '--config',
+        'deterministic.config.jsonc',
         '--extensions',
         'pickle.extensions.ts',
       ],
@@ -131,13 +172,202 @@ export default {
     expect(checked.stderr.toString()).toBe('')
   })
 
-  test('check reports the reason and corrective action for validation failures', async () => {
-    const project = join(workspace, 'invalid-project')
-    await mkdir(project, { recursive: true })
-    await Bun.write(join(project, 'pickle.config.jsonc'), '{ "schemaVersion": 99 }')
-    await Bun.write(join(project, 'pickle.extensions.ts'), 'export default {}')
+  test('check validates extension imports without evaluating extension code', async () => {
+    const projectName = 'side-effect-free-check'
+    const projectPath = join(workspace, projectName)
+    const marker = join(projectPath, 'extension-evaluated.txt')
+    const project = await createCheckProject(projectName, {
+      config: defaultCheckConfig,
+      specification: validSpecification,
+      extensions: `
+await Bun.write(${JSON.stringify(marker)}, 'executed')
+await import('./missing-adapter.ts')
+export default {}
+`,
+    })
 
-    const checked = Bun.spawnSync({ cmd: [pickleCommand, 'check'], cwd: project, env: { ...Bun.env } })
+    const checked = runCheck(project)
+
+    expect(checked.exitCode).toBe(2)
+    expect(checked.stderr.toString()).toContain('Cannot validate pickle.extensions.ts')
+    expect(checked.stderr.toString()).toContain('missing-adapter.ts')
+    expect(checked.stderr.toString()).toContain('Fix its imports or syntax and run pickle check again')
+    expect(await Bun.file(marker).exists()).toBe(false)
+  })
+
+  test('check rejects invalid imported bindings without evaluating extension code', async () => {
+    const projectName = 'invalid-extension-binding'
+    const projectPath = join(workspace, projectName)
+    const marker = join(projectPath, 'extension-evaluated.txt')
+    const project = await createCheckProject(projectName, {
+      config: defaultCheckConfig,
+      specification: validSpecification,
+      extensions: `
+import { missingAdapter } from './adapter.ts'
+await Bun.write(${JSON.stringify(marker)}, 'executed')
+export default { adapter: missingAdapter }
+`,
+    })
+    await Bun.write(join(project, 'adapter.ts'), 'export const adapter = {}')
+
+    const checked = runCheck(project)
+
+    expect(checked.exitCode).toBe(2)
+    expect(checked.stderr.toString()).toContain("has no exported member 'missingAdapter'")
+    expect(checked.stderr.toString()).toContain('Fix its imports or syntax and run pickle check again')
+    expect(await Bun.file(marker).exists()).toBe(false)
+  })
+
+  test('runner rejects a project without an extension or configured fallback adapter', async () => {
+    const project = await createCheckProject('missing-project-adapter', {
+      config: {
+        schemaVersion: 1,
+        specifications: 'features/**/*.feature',
+      },
+      specification: validSpecification,
+    })
+
+    const checked = runCheck(project)
+
+    expect(checked.exitCode).toBe(2)
+    expect(checked.stderr.toString())
+      .toContain('Configure web.baseUrl or export an adapter from pickle.extensions.ts')
+  })
+
+  test('check requires an extension default export without evaluating it', async () => {
+    const project = await createCheckProject('missing-extension-export', {
+      config: defaultCheckConfig,
+      specification: validSpecification,
+      extensions: 'export const hooks = {}',
+    })
+
+    const checked = runCheck(project)
+
+    expect(checked.exitCode).toBe(2)
+    expect(checked.stderr.toString()).toContain('pickle.extensions.ts must provide a default export')
+    expect(checked.stderr.toString()).toContain('Export the extension object as default and run pickle check again')
+  })
+
+  test('check rejects an invalid extension adapter without evaluating it', async () => {
+    const project = await createCheckProject('invalid-extension-adapter', {
+      config: defaultCheckConfig,
+      specification: validSpecification,
+      extensions: `export default {
+  adapter: {},
+  executionTargetProfile: { id: '' },
+}`,
+    })
+
+    const checked = runCheck(project)
+
+    expect(checked.exitCode).toBe(2)
+    expect(checked.stderr.toString()).toContain("Property 'openSession' is missing")
+    expect(checked.stderr.toString()).toContain('executionTargetProfile')
+    expect(checked.stderr.toString()).toContain('Correct the extension default export and run pickle check again')
+  })
+
+  test('check rejects invalid selection policies', async () => {
+    const project = await createCheckProject('invalid-selection-policy', {
+      config: {
+        ...defaultCheckConfig,
+        selection: { shard: { index: 2, total: 1 } },
+      },
+      specification: validSpecification,
+    })
+
+    const checked = runCheck(project)
+
+    expect(checked.exitCode).toBe(2)
+    expect(checked.stderr.toString()).toContain('selection.shard.index must be less than or equal to selection.shard.total')
+    expect(checked.stderr.toString()).toContain('Correct the value and run pickle check again')
+  })
+
+  test('check rejects invalid web adapter policies', async () => {
+    const project = await createCheckProject('invalid-web-policy', {
+      config: {
+        ...defaultCheckConfig,
+        web: {
+          baseUrl: 'https://example.com',
+          browser: { environment: 'invalid' },
+        },
+      },
+      specification: validSpecification,
+    })
+
+    const checked = runCheck(project)
+
+    expect(checked.exitCode).toBe(2)
+    expect(checked.stderr.toString()).toContain('web.browser.environment must be local or browserbase')
+    expect(checked.stderr.toString()).toContain('Correct the value and run pickle check again')
+  })
+
+  test('check rejects invalid Specifications before execution resources start', async () => {
+    const project = await createCheckProject('invalid-specification', {
+      config: defaultCheckConfig,
+      specification: {
+        path: 'features/invalid.feature',
+        source: 'this is not a valid Specification',
+      },
+    })
+
+    const checked = runCheck(project)
+
+    expect(checked.exitCode).toBe(2)
+    expect(checked.stderr.toString()).toContain('Invalid Specification features/invalid.feature')
+    expect(checked.stderr.toString()).toContain('Correct the Specification and run pickle check again')
+  })
+
+  test('run validates Specifications before starting the configured application server', async () => {
+    const projectName = 'run-validates-before-server'
+    const projectPath = join(workspace, projectName)
+    const marker = join(projectPath, 'server-started.txt')
+    const extensionMarker = join(projectPath, 'extension-evaluated.txt')
+    const project = await createCheckProject(projectName, {
+      config: {
+        ...defaultCheckConfig,
+        server: {
+          command: `bun -e "await Bun.write('${marker}', 'started')"`,
+          url: 'http://127.0.0.1:1',
+          startupTimeoutMs: 50,
+          pollIntervalMs: 10,
+        },
+      },
+      specification: {
+        path: 'features/invalid.feature',
+        source: 'this is not a valid Specification',
+      },
+      extensions: `
+await Bun.write(${JSON.stringify(extensionMarker)}, 'evaluated')
+export default {}
+`,
+    })
+
+    const run = Bun.spawnSync({ cmd: [pickleCommand, 'run'], cwd: project, env: { ...Bun.env } })
+
+    expect(run.exitCode).toBe(2)
+    expect(run.stderr.toString()).toContain('Parser errors')
+    expect(await Bun.file(marker).exists()).toBe(false)
+    expect(await Bun.file(extensionMarker).exists()).toBe(false)
+  })
+
+  test('check rejects an empty Specification path set', async () => {
+    const project = await createCheckProject('empty-specification-paths', {
+      config: { ...defaultCheckConfig, specifications: [] },
+    })
+
+    const checked = runCheck(project)
+
+    expect(checked.exitCode).toBe(2)
+    expect(checked.stderr.toString()).toContain('specifications must contain at least one path')
+    expect(checked.stderr.toString()).toContain('Correct the value and run pickle check again')
+  })
+
+  test('check reports the reason and corrective action for validation failures', async () => {
+    const project = await createCheckProject('invalid-project', {
+      config: { schemaVersion: 99 },
+    })
+
+    const checked = runCheck(project)
     expect(checked.exitCode).toBe(2)
     expect(checked.stderr.toString()).toContain('Unsupported configuration schemaVersion: 99')
     expect(checked.stderr.toString()).toContain('Correct the value and run pickle check again')
@@ -158,6 +388,8 @@ export default {
           pickleCommand,
           'run',
           'purchase.feature',
+          '--config',
+          'deterministic.config.jsonc',
           '--extensions',
           'pickle.extensions.ts',
         ],
@@ -193,6 +425,8 @@ export default {
         pickleCommand,
         'run',
         'purchase.feature',
+        '--config',
+        'deterministic.config.jsonc',
         '--extensions',
         'pickle.extensions.ts',
       ],
@@ -303,10 +537,10 @@ export default {
       new Response(process.stdout).text(),
       new Response(process.stderr).text(),
     ])
-    const records = stdout.trim().split('\n').map(line => JSON.parse(line))
 
     expect(stderr).toBe('')
     expect(exitCode).toBe(0)
+    const records = stdout.trim().split('\n').map(line => JSON.parse(line))
     expect(records.at(-1)).toMatchObject({
       kind: 'test-result',
       result: {

--- a/packages/runner/index.ts
+++ b/packages/runner/index.ts
@@ -1,6 +1,10 @@
 export { runScenario } from './src/run-scenario'
 export { runScenarios } from './src/run-scenarios'
-export { resolveRunConfiguration } from './src/configuration'
+export {
+  resolveRunConfiguration,
+  validateProjectRunConfiguration,
+  validateRunConfiguration,
+} from './src/configuration'
 export type {
   ExecutionTargetAdapter,
   ExecutionTargetProfile,
@@ -21,5 +25,6 @@ export type { RunScenariosInput } from './src/run-scenarios'
 export type {
   ResolvedRunConfiguration,
   RunConfiguration,
+  RunExtensionManifest,
   RunExtensions,
 } from './src/configuration'

--- a/packages/runner/src/configuration.test.ts
+++ b/packages/runner/src/configuration.test.ts
@@ -1,5 +1,10 @@
 import { expect, test } from 'bun:test'
-import { resolveRunConfiguration, type ExecutionTargetAdapter } from '../index'
+import {
+  resolveRunConfiguration,
+  validateProjectRunConfiguration,
+  validateRunConfiguration,
+  type ExecutionTargetAdapter,
+} from '../index'
 
 const adapter: ExecutionTargetAdapter = {
   async openSession() {
@@ -22,12 +27,11 @@ test('combines versioned configuration and extensions into validated runner inpu
     },
   }, {
     adapter,
-    executionTargetProfile: { id: 'extended-web' },
   })
 
   expect(resolved).toEqual({
     adapter,
-    executionTargetProfile: { id: 'extended-web' },
+    executionTargetProfile: { id: 'configured-web' },
     concurrency: 3,
     retry: { infrastructureErrors: 2 },
     timeout: { scenarioMs: 30_000, stepMs: 5_000 },
@@ -39,4 +43,34 @@ test('rejects an unsupported configuration schema before execution', () => {
     schemaVersion: 2 as 1,
     executionTargetProfile: { id: 'web' },
   }, { adapter })).toThrow('Unsupported configuration schemaVersion: 2')
+})
+
+test('validates run policies without requiring an execution adapter', () => {
+  expect(() => validateRunConfiguration({
+    schemaVersion: 1,
+    executionTargetProfile: { id: 'web' },
+    execution: { scenarioTimeoutMs: 0 },
+  })).toThrow('execution.scenarioTimeoutMs must be an integer greater than or equal to 1')
+})
+
+test('combines project configuration with the extension manifest before execution', () => {
+  const configuration = {
+    schemaVersion: 1 as const,
+    executionTargetProfile: { id: 'custom' },
+  }
+
+  expect(validateProjectRunConfiguration(configuration, {
+    adapterAvailable: true,
+    fallbackAdapterAvailable: false,
+  }))
+    .toEqual(configuration)
+  expect(validateProjectRunConfiguration(configuration, {
+    adapterAvailable: false,
+    fallbackAdapterAvailable: true,
+  }))
+    .toEqual(configuration)
+  expect(() => validateProjectRunConfiguration(configuration, {
+    adapterAvailable: false,
+    fallbackAdapterAvailable: false,
+  })).toThrow('Configure web.baseUrl or export an adapter from pickle.extensions.ts')
 })

--- a/packages/runner/src/configuration.ts
+++ b/packages/runner/src/configuration.ts
@@ -17,7 +17,11 @@ export interface RunConfiguration {
 
 export interface RunExtensions {
   adapter: ExecutionTargetAdapter
-  executionTargetProfile?: ExecutionTargetProfile
+}
+
+export interface RunExtensionManifest {
+  adapterAvailable: boolean
+  fallbackAdapterAvailable: boolean
 }
 
 export interface ResolvedRunConfiguration extends ExecutionPolicy {
@@ -26,40 +30,91 @@ export interface ResolvedRunConfiguration extends ExecutionPolicy {
   concurrency: number
 }
 
-function positiveInteger(value: number | undefined, field: string): void {
-  if (value !== undefined && (!Number.isInteger(value) || value < 1)) {
+function record(value: unknown, field: string): Record<string, unknown> {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+    throw new Error(`${field} must be an object`)
+  }
+  return value as Record<string, unknown>
+}
+
+function knownFields(value: Record<string, unknown>, fields: readonly string[], parent: string): void {
+  for (const field of Object.keys(value)) {
+    if (!fields.includes(field)) throw new Error(`${parent}.${field} is not supported`)
+  }
+}
+
+function positiveInteger(value: unknown, field: string): void {
+  if (value !== undefined && (!Number.isInteger(value) || (value as number) < 1)) {
     throw new Error(`${field} must be an integer greater than or equal to 1`)
   }
+}
+
+function validateExecutionTargetProfile(value: unknown): void {
+  const profile = record(value, 'executionTargetProfile')
+  knownFields(profile, ['id'], 'executionTargetProfile')
+  if (typeof profile.id !== 'string' || !profile.id.trim()) {
+    throw new Error('executionTargetProfile.id must not be empty')
+  }
+}
+
+export function validateRunConfiguration(value: unknown): RunConfiguration {
+  const configuration = record(value, 'run configuration')
+  knownFields(configuration, [
+    'schemaVersion', 'executionTargetProfile', 'concurrency', 'execution',
+  ], 'run configuration')
+  if (configuration.schemaVersion !== 1) {
+    throw new Error(`Unsupported configuration schemaVersion: ${String(configuration.schemaVersion)}`)
+  }
+  validateExecutionTargetProfile(configuration.executionTargetProfile)
+  positiveInteger(configuration.concurrency, 'concurrency')
+  if (configuration.execution !== undefined) {
+    const execution = record(configuration.execution, 'execution')
+    knownFields(execution, [
+      'infrastructureRetries', 'scenarioTimeoutMs', 'stepTimeoutMs',
+    ], 'execution')
+    positiveInteger(execution.scenarioTimeoutMs, 'execution.scenarioTimeoutMs')
+    positiveInteger(execution.stepTimeoutMs, 'execution.stepTimeoutMs')
+    const retries = execution.infrastructureRetries
+    if (retries !== undefined && (!Number.isInteger(retries) || (retries as number) < 0)) {
+      throw new Error('execution.infrastructureRetries must be a non-negative integer')
+    }
+  }
+  return configuration as unknown as RunConfiguration
+}
+
+export function validateProjectRunConfiguration(
+  configuration: unknown,
+  extensions: RunExtensionManifest,
+): RunConfiguration {
+  const validatedConfiguration = validateRunConfiguration(configuration)
+  if (!extensions.adapterAvailable && !extensions.fallbackAdapterAvailable) {
+    throw new Error(
+      'No execution target is configured. '
+      + 'Configure web.baseUrl or export an adapter from pickle.extensions.ts.',
+    )
+  }
+  return validatedConfiguration
 }
 
 export function resolveRunConfiguration(
   configuration: RunConfiguration,
   extensions: RunExtensions,
 ): ResolvedRunConfiguration {
-  if (configuration.schemaVersion !== 1) {
-    throw new Error(`Unsupported configuration schemaVersion: ${configuration.schemaVersion}`)
+  const validatedConfiguration = validateRunConfiguration(configuration)
+  if (typeof extensions.adapter !== 'object' || extensions.adapter === null
+    || typeof extensions.adapter.openSession !== 'function') {
+    throw new Error('extensions.adapter must provide openSession')
   }
-  const executionTargetProfile = extensions.executionTargetProfile
-    ?? configuration.executionTargetProfile
-  if (!executionTargetProfile.id?.trim()) {
-    throw new Error('executionTargetProfile.id must not be empty')
-  }
-  positiveInteger(configuration.concurrency, 'concurrency')
-  positiveInteger(configuration.execution?.scenarioTimeoutMs, 'execution.scenarioTimeoutMs')
-  positiveInteger(configuration.execution?.stepTimeoutMs, 'execution.stepTimeoutMs')
-  const retries = configuration.execution?.infrastructureRetries
-  if (retries !== undefined && (!Number.isInteger(retries) || retries < 0)) {
-    throw new Error('execution.infrastructureRetries must be a non-negative integer')
-  }
+  const retries = validatedConfiguration.execution?.infrastructureRetries
 
   return {
     adapter: extensions.adapter,
-    executionTargetProfile,
-    concurrency: configuration.concurrency ?? 1,
+    executionTargetProfile: validatedConfiguration.executionTargetProfile,
+    concurrency: validatedConfiguration.concurrency ?? 1,
     retry: { infrastructureErrors: retries ?? 0 },
     timeout: {
-      scenarioMs: configuration.execution?.scenarioTimeoutMs,
-      stepMs: configuration.execution?.stepTimeoutMs,
+      scenarioMs: validatedConfiguration.execution?.scenarioTimeoutMs,
+      stepMs: validatedConfiguration.execution?.stepTimeoutMs,
     },
   }
 }

--- a/packages/spec/index.ts
+++ b/packages/spec/index.ts
@@ -1,5 +1,5 @@
 export { parseSpecification, parseSpecificationFile } from './src/specification'
-export { selectScenarios } from './src/selection'
+export { selectScenarios, validateSelectionOptions } from './src/selection'
 export type {
   ParseSpecificationInput,
   Scenario,

--- a/packages/spec/src/selection.test.ts
+++ b/packages/spec/src/selection.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from 'bun:test'
 import {
   selectScenarios,
+  validateSelectionOptions,
   type Scenario,
   type Specification,
 } from '../index'
@@ -47,7 +48,14 @@ describe('selectScenarios', () => {
 
   test('rejects invalid shard coordinates', () => {
     expect(() => selectScenarios([], { shard: { index: 2, total: 1 } }))
-      .toThrow('shard.index must be less than or equal to shard.total')
+      .toThrow('selection.shard.index must be less than or equal to selection.shard.total')
+  })
+
+  test('rejects unsupported characters in tag expressions', () => {
+    expect(() => validateSelectionOptions({ tagExpression: '@smoke !' }))
+      .toThrow('Unexpected character "!" in tag expression')
+    expect(() => validateSelectionOptions({ tagExpression: '@smoke,' }))
+      .toThrow('Unexpected character "," in tag expression')
   })
 
   test('does not assign ignored Scenarios to a shard or count them as shard positions', () => {

--- a/packages/spec/src/selection.ts
+++ b/packages/spec/src/selection.ts
@@ -25,8 +25,24 @@ function normalizedTag(tag: string): string {
   return tag.startsWith('@') ? tag : `@${tag}`
 }
 
+function tagExpressionTokens(expression: string): string[] {
+  const tokens: string[] = []
+  const tokenPattern = /\(|\)|(?:and|or|not)\b|@?[A-Za-z0-9:_-]+/iy
+  let index = 0
+  while (index < expression.length) {
+    while (index < expression.length && /\s/.test(expression[index]!)) index++
+    if (index === expression.length) break
+    tokenPattern.lastIndex = index
+    const match = tokenPattern.exec(expression)
+    if (!match) throw new Error(`Unexpected character "${expression[index]}" in tag expression`)
+    tokens.push(match[0])
+    index = tokenPattern.lastIndex
+  }
+  return tokens
+}
+
 function parseTagExpression(expression: string): TagExpressionNode {
-  const tokens = expression.match(/\(|\)|\b(?:and|or|not)\b|@?[A-Za-z0-9:_-]+/gi) ?? []
+  const tokens = tagExpressionTokens(expression)
   let index = 0
 
   function consume(): string {
@@ -85,25 +101,57 @@ function matchesTagExpression(node: TagExpressionNode, tags: readonly string[]):
   }
 }
 
-function validateShard(shard: Shard): void {
-  if (!Number.isInteger(shard.index) || shard.index < 1) {
-    throw new Error('shard.index must be an integer greater than or equal to 1')
+function record(value: unknown, field: string): Record<string, unknown> {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+    throw new Error(`${field} must be an object`)
   }
-  if (!Number.isInteger(shard.total) || shard.total < 1) {
-    throw new Error('shard.total must be an integer greater than or equal to 1')
+  return value as Record<string, unknown>
+}
+
+function knownFields(value: Record<string, unknown>, fields: readonly string[], parent: string): void {
+  for (const field of Object.keys(value)) {
+    if (!fields.includes(field)) throw new Error(`${parent}.${field} is not supported`)
   }
-  if (shard.index > shard.total) {
-    throw new Error('shard.index must be less than or equal to shard.total')
+}
+
+function optionalString(value: unknown, field: string): void {
+  if (value !== undefined && typeof value !== 'string') {
+    throw new Error(`${field} must be a string`)
   }
+}
+
+function validateShard(value: unknown): void {
+  const shard = record(value, 'selection.shard')
+  knownFields(shard, ['index', 'total'], 'selection.shard')
+  if (!Number.isInteger(shard.index) || (shard.index as number) < 1) {
+    throw new Error('selection.shard.index must be an integer greater than or equal to 1')
+  }
+  if (!Number.isInteger(shard.total) || (shard.total as number) < 1) {
+    throw new Error('selection.shard.total must be an integer greater than or equal to 1')
+  }
+  if ((shard.index as number) > (shard.total as number)) {
+    throw new Error('selection.shard.index must be less than or equal to selection.shard.total')
+  }
+}
+
+export function validateSelectionOptions(value: unknown): SelectionOptions {
+  const options = record(value, 'selection')
+  knownFields(options, ['scenarioName', 'tagExpression', 'shard'], 'selection')
+  optionalString(options.scenarioName, 'selection.scenarioName')
+  optionalString(options.tagExpression, 'selection.tagExpression')
+  if (options.tagExpression) parseTagExpression(options.tagExpression as string)
+  if (options.shard !== undefined) validateShard(options.shard)
+  return options as unknown as SelectionOptions
 }
 
 export function selectScenarios(
   specifications: readonly Specification[],
   options: SelectionOptions = {},
 ): ScenarioSelection[] {
-  const name = options.scenarioName?.trim().toLowerCase()
-  const tagExpression = options.tagExpression
-    ? parseTagExpression(options.tagExpression)
+  const validatedOptions = validateSelectionOptions(options)
+  const name = validatedOptions.scenarioName?.trim().toLowerCase()
+  const tagExpression = validatedOptions.tagExpression
+    ? parseTagExpression(validatedOptions.tagExpression)
     : undefined
 
   const selected = [...specifications]
@@ -112,10 +160,9 @@ export function selectScenarios(
     .filter(({ scenario }) => !name || scenario.name.toLowerCase().includes(name))
     .filter(({ scenario }) => !tagExpression || matchesTagExpression(tagExpression, scenario.tags))
 
-  if (!options.shard) return selected
-  validateShard(options.shard)
+  if (!validatedOptions.shard) return selected
 
   return selected
     .filter(({ scenario }) => !scenario.tags.includes('@ignore'))
-    .filter((_, index) => index % options.shard!.total === options.shard!.index - 1)
+    .filter((_, index) => index % validatedOptions.shard!.total === validatedOptions.shard!.index - 1)
 }

--- a/packages/web/index.ts
+++ b/packages/web/index.ts
@@ -1,4 +1,4 @@
-export { createWebAdapter } from './src/web-adapter'
+export { createWebAdapter, validateWebAdapterOptions } from './src/web-adapter'
 export type {
   BrowserOptions,
   ScreenshotOptions,

--- a/packages/web/src/web-adapter.ts
+++ b/packages/web/src/web-adapter.ts
@@ -42,6 +42,84 @@ export interface WebAdapterOptions {
   screenshots?: ScreenshotOptions
 }
 
+function record(value: unknown, field: string): Record<string, unknown> {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+    throw new Error(`${field} must be an object`)
+  }
+  return value as Record<string, unknown>
+}
+
+function knownFields(value: Record<string, unknown>, fields: readonly string[], parent: string): void {
+  for (const field of Object.keys(value)) {
+    if (!fields.includes(field)) throw new Error(`${parent}.${field} is not supported`)
+  }
+}
+
+function optionalString(value: unknown, field: string): void {
+  if (value !== undefined && typeof value !== 'string') throw new Error(`${field} must be a string`)
+}
+
+function optionalBoolean(value: unknown, field: string): void {
+  if (value !== undefined && typeof value !== 'boolean') throw new Error(`${field} must be a boolean`)
+}
+
+function optionalPositiveInteger(value: unknown, field: string): void {
+  if (value !== undefined && (!Number.isInteger(value) || (value as number) < 1)) {
+    throw new Error(`${field} must be an integer greater than or equal to 1`)
+  }
+}
+
+export function validateWebAdapterOptions(value: unknown): WebAdapterOptions {
+  const web = record(value, 'web')
+  knownFields(web, ['baseUrl', 'browser', 'screenshots'], 'web')
+  if (typeof web.baseUrl !== 'string' || !web.baseUrl.trim()) {
+    throw new Error('web.baseUrl must not be empty')
+  }
+  try {
+    new URL(web.baseUrl)
+  } catch {
+    throw new Error('web.baseUrl must be a valid URL')
+  }
+
+  if (web.browser !== undefined) {
+    const browser = record(web.browser, 'web.browser')
+    knownFields(browser, [
+      'environment', 'modelName', 'modelApiKey', 'headless', 'browserbaseApiKey',
+      'browserbaseProjectId', 'cache', 'selfHeal', 'domSettleTimeoutMs', 'observeTimeoutMs',
+      'actTimeoutMs', 'navigationTimeoutMs',
+    ], 'web.browser')
+    if (browser.environment !== undefined && browser.environment !== 'local' && browser.environment !== 'browserbase') {
+      throw new Error('web.browser.environment must be local or browserbase')
+    }
+    optionalString(browser.modelName, 'web.browser.modelName')
+    optionalString(browser.modelApiKey, 'web.browser.modelApiKey')
+    optionalString(browser.browserbaseApiKey, 'web.browser.browserbaseApiKey')
+    optionalString(browser.browserbaseProjectId, 'web.browser.browserbaseProjectId')
+    optionalBoolean(browser.headless, 'web.browser.headless')
+    optionalBoolean(browser.cache, 'web.browser.cache')
+    optionalBoolean(browser.selfHeal, 'web.browser.selfHeal')
+    optionalPositiveInteger(browser.domSettleTimeoutMs, 'web.browser.domSettleTimeoutMs')
+    optionalPositiveInteger(browser.observeTimeoutMs, 'web.browser.observeTimeoutMs')
+    optionalPositiveInteger(browser.actTimeoutMs, 'web.browser.actTimeoutMs')
+    optionalPositiveInteger(browser.navigationTimeoutMs, 'web.browser.navigationTimeoutMs')
+  }
+
+  if (web.screenshots !== undefined) {
+    const screenshots = record(web.screenshots, 'web.screenshots')
+    knownFields(screenshots, ['mode', 'outputDir', 'format', 'fullPage'], 'web.screenshots')
+    if (screenshots.mode !== undefined && !['off', 'on-failure', 'on-step'].includes(screenshots.mode as string)) {
+      throw new Error('web.screenshots.mode must be off, on-failure, or on-step')
+    }
+    optionalString(screenshots.outputDir, 'web.screenshots.outputDir')
+    if (screenshots.format !== undefined && screenshots.format !== 'png' && screenshots.format !== 'jpeg') {
+      throw new Error('web.screenshots.format must be png or jpeg')
+    }
+    optionalBoolean(screenshots.fullPage, 'web.screenshots.fullPage')
+  }
+
+  return web as unknown as WebAdapterOptions
+}
+
 export interface WebObservedAction {
   description: string
   handle: unknown
@@ -220,11 +298,12 @@ export function createWebAdapter(
   options: WebAdapterOptions,
   factory: WebAutomationFactory = stagehandFactory,
 ): ExecutionTargetAdapter {
+  const validatedOptions = validateWebAdapterOptions(options)
   return {
     capabilities: ['web', 'screenshots'],
     async openSession(input) {
       const automation = await factory.open({
-        browser: options.browser ?? {},
+        browser: validatedOptions.browser ?? {},
         signal: input.signal,
       })
       let closed = false
@@ -244,7 +323,7 @@ export function createWebAdapter(
         step: ScenarioStep,
         state: StepExecution['state'],
       ): Promise<TestArtifact | undefined> {
-        const screenshotOptions = options.screenshots
+        const screenshotOptions = validatedOptions.screenshots
         const mode = screenshotOptions?.mode ?? 'off'
         if (mode === 'off') return undefined
         if (mode === 'on-failure' && state !== 'failed' && state !== 'infrastructure-error') {
@@ -288,7 +367,7 @@ export function createWebAdapter(
 
       async function ensureNavigation(signal?: AbortSignal): Promise<void> {
         if (navigated) return
-        await automation.navigate(options.baseUrl, signal)
+        await automation.navigate(validatedOptions.baseUrl, signal)
         navigated = true
       }
 
@@ -302,7 +381,7 @@ export function createWebAdapter(
           try {
             const navigation = prompt.match(navigationPattern)
             if (navigation) {
-              const url = navigationUrl(options.baseUrl, navigation[1]!.trim())
+              const url = navigationUrl(validatedOptions.baseUrl, navigation[1]!.trim())
               await automation.navigate(url, operationSignal)
               navigated = true
               return finish(step, {


### PR DESCRIPTION
### Motivation

- Provide a lightweight, offline project initialization and validation flow so a new or existing repository can receive declarative configuration and an extensions entry point without starting browsers, servers, or models.
- Harden configuration validation and surface actionable errors so users can correct schema, timeout, retry, and server fields before attempting execution.

### Description

- Add a new `packages/cli/src/project.ts` with `initializeProject` to create `pickle.config.jsonc` and `pickle.extensions.ts` (reporting skipped writes) and `checkProject` to validate configuration, safely import the extensions module, verify specification globs, and confirm an execution target is present without opening sessions.
- Integrate `init` and `check` command handling into the public CLI in `packages/cli/src/cli.ts` (via a new `main` dispatcher and `projectOptions` helper) so users can run `pickle init` and `pickle check` from the `pickle` CLI.
- Strengthen configuration validation in `packages/cli/src/config.ts` by exporting `validateConfig`, adding `optionalPositiveInteger` checks, validating `server` fields (`readinessPath`, `port`, `startupTimeoutMs`, `pollIntervalMs`, `reuseExisting`), validating `execution` timeouts and non-negative `infrastructureRetries`, validating `concurrency`, and wrapping parse errors with an actionable message.
- Export the new project APIs from `packages/cli/index.ts` so other packages can reuse `initializeProject` and `checkProject`.

### Testing

- Ran `bun install` to populate dependencies and then `bun run typecheck`, and TypeScript typechecks completed successfully.
- Ran the test suite with `bun run test` (via Turborepo) and all package tests passed, including newly added workspace tests in `packages/cli/src/workspace.test.ts` that exercise `init`/`check` behavior and the validation failure message.
- Ran `git diff --check` and repository checks in the environment; no test failures were reported during automated runs.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a80b4eddec48322a36efab710416785)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `pickle init` and `pickle check` to scaffold a project and validate configuration, extensions, and Specifications offline. Run now validates Specifications before starting the application server or evaluating extensions, preventing side effects on invalid projects.

- `pickle init` creates `pickle.config.jsonc` and `pickle.extensions.ts` if missing; `pickle check [--config <path>] [--extensions <path>]` validates without starting resources and reports “Project is valid”.
- Validates extensions via TypeScript without executing them: requires a default export and reports whether an adapter is available.
- Ensures specification globs match files and parses each Specification; errors include actionable messages.
- Strengthens config validation by reusing `validateRunConfiguration` in `@pickle-spec/runner`, `validateSelectionOptions` in `@pickle-spec/spec`, and `validateWebAdapterOptions` in `@pickle-spec/web`. Enforces known fields; validates `server.url` (URL), `server.port` (1–65535), `readinessPath`, timeouts, polling, `reuseExisting` (boolean), selection policies, and web/browser/screenshot options. `loadConfig` wraps errors with corrective guidance.
- `@pickle-spec/runner` adds `validateRunConfiguration` and `validateProjectRunConfiguration`; `resolveRunConfiguration` now validates inputs and requires `extensions.adapter.openSession`. Execution target profile is derived from config only.
- CLI dispatch adds `init`/`check`; `run` loads extensions and starts the server only after Specifications and configuration are validated. `packages/cli/index.ts` exports `initializeProject`, `checkProject`, and `ProjectCommandOptions`.

**Migration**
- Move any `executionTargetProfile` from `pickle.extensions.ts` into `pickle.config.jsonc`; extensions no longer supply it.
- Ensure `pickle.extensions.ts` has a default export; export an adapter or configure `web.baseUrl`.
- Fix invalid configuration values to pass `pickle check`; CLI validation failures exit with code 2 and include corrective messages.

<sup>Written for commit 8726027a7986d3edca0c3ac816c8266deba6d510. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/victor-teles/pickle-spec/pull/32?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

