### PR TITLE
Give Specifications durable identity and lifecycle

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   check:
-    name: Type Check & Test
+    name: Lint, Type Check & Test
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -18,6 +18,9 @@ jobs:
           bun-version: latest
 
       - run: bun install --frozen-lockfile
+
+      - name: Lint and format
+        run: bunx biome ci .
 
       - name: Type check
         run: bun run typecheck

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,6 +20,9 @@ jobs:
 
       - run: bun install --frozen-lockfile
 
+      - name: Lint and format
+        run: bunx biome ci .
+
       - name: Type check
         run: bun run typecheck
 

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,3 @@
+{
+  "recommendations": ["biomejs.biome"]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,21 @@
+{
+  "editor.defaultFormatter": "biomejs.biome",
+  "[javascript]": {
+    "editor.defaultFormatter": "biomejs.biome"
+  },
+  "[javascriptreact]": {
+    "editor.defaultFormatter": "biomejs.biome"
+  },
+  "[typescript]": {
+    "editor.defaultFormatter": "biomejs.biome"
+  },
+  "[typescriptreact]": {
+    "editor.defaultFormatter": "biomejs.biome"
+  },
+  "[json]": {
+    "editor.defaultFormatter": "biomejs.biome"
+  },
+  "[jsonc]": {
+    "editor.defaultFormatter": "biomejs.biome"
+  }
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,1 @@
+CLAUDE.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,7 +12,7 @@ This repository is a Bun + Turborepo monorepo:
 - `packages/cli` — executable package composition
 - `apps/example` — sample Specifications
 
-Use `bun run typecheck` and `bun run test` from the repo root. Those scripts run through Turborepo.
+Use `bun run lint`, `bun run typecheck`, and `bun run test` from the repo root. Typecheck and test run through Turborepo. Lint and format use Biome from the repo root.
 
 Default to using Bun instead of Node.js.
 
@@ -42,9 +42,24 @@ Use `bun test` to run tests.
 import { test, expect } from "bun:test";
 
 test("hello world", () => {
-  expect(1).toBe(1);
+ expect(1).toBe(1);
 });
 ```
+
+## Lint and format
+
+Use Biome from the repo root. Do not add ESLint or Prettier.
+
+```sh
+bun run lint
+bun run format
+```
+
+`bun run lint` checks formatting, import order, and lint rules. `bun run format` applies safe fixes. Configuration lives in `biome.json`.
+
+Write new TypeScript with 2-space indent, single quotes, and semicolons only when needed. Name variables in camelCase. Do not declare `SCREAMING_SNAKE_CASE` constants. Object keys may use CONSTANT_CASE when they match external names such as environment variables.
+
+After you change TypeScript or JSON files, run `bun run lint` before you finish.
 
 ## Frontend
 

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ To install dependencies and run the repository checks, use:
 
 ```bash
 bun install --frozen-lockfile
+bun run lint
 bun run typecheck
 bun run test
 ```

--- a/biome.json
+++ b/biome.json
@@ -1,0 +1,55 @@
+{
+  "$schema": "https://biomejs.dev/schemas/2.5.8/schema.json",
+  "vcs": {
+    "enabled": true,
+    "clientKind": "git",
+    "useIgnoreFile": true
+  },
+  "files": {
+    "ignoreUnknown": true,
+    "includes": ["**", "!**/bun.lock"]
+  },
+  "formatter": {
+    "enabled": true,
+    "indentStyle": "space",
+    "indentWidth": 2
+  },
+  "linter": {
+    "enabled": true,
+    "rules": {
+      "preset": "recommended",
+      "style": {
+        "noNonNullAssertion": "off",
+        "useNamingConvention": {
+          "level": "error",
+          "options": {
+            "conventions": [
+              {
+                "selector": { "kind": "variable" },
+                "formats": ["camelCase"]
+              },
+              {
+                "selector": { "kind": "objectLiteralMember" },
+                "formats": ["camelCase", "CONSTANT_CASE", "PascalCase"]
+              }
+            ]
+          }
+        }
+      }
+    }
+  },
+  "javascript": {
+    "formatter": {
+      "quoteStyle": "single",
+      "semicolons": "asNeeded"
+    }
+  },
+  "assist": {
+    "enabled": true,
+    "actions": {
+      "source": {
+        "organizeImports": "on"
+      }
+    }
+  }
+}

--- a/bun.lock
+++ b/bun.lock
@@ -5,6 +5,7 @@
     "": {
       "name": "sum-ai",
       "devDependencies": {
+        "@biomejs/biome": "2.5.8",
         "@types/bun": "latest",
         "turbo": "^2.8.1",
         "typescript": "^5.9.3",
@@ -69,6 +70,24 @@
     },
   },
   "packages": {
+    "@biomejs/biome": ["@biomejs/biome@2.5.8", "", { "optionalDependencies": { "@biomejs/cli-darwin-arm64": "2.5.8", "@biomejs/cli-darwin-x64": "2.5.8", "@biomejs/cli-linux-arm64": "2.5.8", "@biomejs/cli-linux-arm64-musl": "2.5.8", "@biomejs/cli-linux-x64": "2.5.8", "@biomejs/cli-linux-x64-musl": "2.5.8", "@biomejs/cli-win32-arm64": "2.5.8", "@biomejs/cli-win32-x64": "2.5.8" }, "bin": { "biome": "bin/biome" } }, "sha512-aeAeeJB9fSDc7Gq+2GqpQxA0qBj6gj1k2R6L1cYqGePKP/baIq1WX8y6B+D+nRsO5ViQL22K/8IwbqERW0q1nw=="],
+
+    "@biomejs/cli-darwin-arm64": ["@biomejs/cli-darwin-arm64@2.5.8", "", { "os": "darwin", "cpu": "arm64" }, "sha512-mk1QON9PHllvvLN5gU3f4rMxeh4syK5p9OvKyWH6/W8ueh04uaC8TUXXByhGufWf/y5mQc03ZLM45zU+cmqMjA=="],
+
+    "@biomejs/cli-darwin-x64": ["@biomejs/cli-darwin-x64@2.5.8", "", { "os": "darwin", "cpu": "x64" }, "sha512-bsGwFMBNyHPyiLSsQcZJxdoRrg1V4JL+d7wEsvUBczlP9U9lwM+7mzQHxI4o1mhBsTmdOBbAb6fHU3Z3snN45w=="],
+
+    "@biomejs/cli-linux-arm64": ["@biomejs/cli-linux-arm64@2.5.8", "", { "os": "linux", "cpu": "arm64" }, "sha512-XmFiA0WPYFC+uiUDC8WRFzAIH9bo7vwQLav38Uoq4ETC+T/+uBi0TsYGJECkugY3r8USl3jc+Ae2/irAF6F2lQ=="],
+
+    "@biomejs/cli-linux-arm64-musl": ["@biomejs/cli-linux-arm64-musl@2.5.8", "", { "os": "linux", "cpu": "arm64" }, "sha512-VcJNbstduTHx83NGAdhp78/JOcP45BZHXL7yNsfI1uGzdUgegAz2s+mSoT7wK6PBNzLoqG0zDOXaz/RQYVtSiw=="],
+
+    "@biomejs/cli-linux-x64": ["@biomejs/cli-linux-x64@2.5.8", "", { "os": "linux", "cpu": "x64" }, "sha512-S5wcm9OBDvLHodD4PUaN488hCpco9QD/9ZxuYJiw4euWtr/oQvLR72z2ixItH8Wd5BCm6FZaeb+YNvOoM1xHtQ=="],
+
+    "@biomejs/cli-linux-x64-musl": ["@biomejs/cli-linux-x64-musl@2.5.8", "", { "os": "linux", "cpu": "x64" }, "sha512-kKmiyokeISRGq2FLwvr+TzsgBusfxaZ0FZNLcOYOpCK/78tRrEjeEBLvq3xLZMpqbANgJdRPI7vZX8ZL37u9/w=="],
+
+    "@biomejs/cli-win32-arm64": ["@biomejs/cli-win32-arm64@2.5.8", "", { "os": "win32", "cpu": "arm64" }, "sha512-nILH0mzm3Hi3iEdd7o7GpB8kBR/mSQwfQG/tyBqyNrY2GFtcgwfV9nV8xLmbtUpMNY/Oi0Ml1XgfR4flOdq+AA=="],
+
+    "@biomejs/cli-win32-x64": ["@biomejs/cli-win32-x64@2.5.8", "", { "os": "win32", "cpu": "x64" }, "sha512-I2czzXTY61f3nFJxXoMDq80t7MivxDEnCjE+8sDKoFfcKMaoQdkqhIFQ3KyY0XLzeSpUBYeNAXgD+iOV/BU0VA=="],
+
     "@browserbasehq/sdk": ["@browserbasehq/sdk@2.18.0", "", { "dependencies": { "@types/node": "^18.11.18", "@types/node-fetch": "^2.6.4", "abort-controller": "^3.0.0", "agentkeepalive": "^4.2.1", "form-data-encoder": "1.7.2", "formdata-node": "^4.3.2", "node-fetch": "^2.6.7" } }, "sha512-uX1kiOB3lBWvt0sdIszGZkroLj+xvo7d6CC8ORn1mqPLq76Y4fJFDGdbdLWggDF3LxtnmwJCRVgSrLo3V9RctQ=="],
 
     "@browserbasehq/stagehand": ["@browserbasehq/stagehand@4.0.1", "", { "dependencies": { "@browserbasehq/sdk": "^2.16.0", "@opentelemetry/api": "1.9.1", "@opentelemetry/core": "2.9.0", "chrome-launcher": "^1.2.1", "zod": "4.4.3" } }, "sha512-nWeXNp6dg8Hw4OnMzNrDfmtWQwPJO8jaRTa9HBemMm6D3872NxyzRxCJ4175AhGG4Qkvc2LuZFQCvif3yu0Rew=="],

--- a/package.json
+++ b/package.json
@@ -1,13 +1,19 @@
 {
   "name": "pickle-spec-monorepo",
   "private": true,
-  "workspaces": ["apps/*", "packages/*"],
+  "workspaces": [
+    "apps/*",
+    "packages/*"
+  ],
   "scripts": {
     "typecheck": "turbo run typecheck",
     "test": "turbo run test",
+    "lint": "biome check .",
+    "format": "biome check --write .",
     "run:example": "turbo run run:example --filter=@pickle-spec/example"
   },
   "devDependencies": {
+    "@biomejs/biome": "2.5.8",
     "@types/bun": "latest",
     "turbo": "^2.8.1",
     "typescript": "^5.9.3"

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -2,16 +2,16 @@
 
 import type { ExecutionTargetAdapter } from '@pickle-spec/runner'
 import { resolveRunConfiguration, runScenarios } from '@pickle-spec/runner'
-import { parseSpecificationFile, selectScenarios, type SelectionOptions } from '@pickle-spec/spec'
+import { parseSpecification, selectScenarios, validateSpecificationMetadata, type SelectionOptions } from '@pickle-spec/spec'
 import {
   createWebAdapter,
   type WebAdapterOptions,
 } from '@pickle-spec/web'
-import { resolve } from 'node:path'
+import { relative, resolve } from 'node:path'
 import { pathToFileURL } from 'node:url'
 import { loadConfig, type PickleConfig } from './config'
 import type { Extensions } from './extensions'
-import { checkProject, initializeProject } from './project'
+import { checkProject, initializeProject, migrateProject } from './project'
 import { startServer } from './server'
 
 interface RunArguments {
@@ -111,7 +111,20 @@ async function discoverSpecifications(patterns: string | string[], language?: st
     const description = Array.isArray(patterns) ? patterns.join(', ') : patterns
     throw new Error(`No specifications found matching: ${description}`)
   }
-  return Promise.all([...paths].sort().map(path => parseSpecificationFile(path, language)))
+  const files = await Promise.all([...paths].sort().map(async path => ({
+    uri: relative(process.cwd(), path),
+    source: await Bun.file(path).text(),
+  })))
+  try {
+    validateSpecificationMetadata(files, language)
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error))
+  }
+  return files.map(file => parseSpecification({
+    source: file.source,
+    uri: file.uri,
+    language,
+  }))
 }
 
 function configuredWebOptions(config: PickleConfig, args: RunArguments): WebAdapterOptions | undefined {
@@ -210,6 +223,17 @@ function projectOptions(argv: string[]): { configPath?: string; extensionsPath?:
   return options
 }
 
+function migrateOptions(argv: string[]): { configPath?: string; yes?: boolean } {
+  const options: { configPath?: string; yes?: boolean } = {}
+  for (let index = 1; index < argv.length; index++) {
+    const flag = argv[index]!
+    if (flag === '--config') options.configPath = valueAfter(argv, index++)
+    else if (flag === '--yes' || flag === '-y') options.yes = true
+    else throw new Error(`Unknown option: ${flag}`)
+  }
+  return options
+}
+
 async function main(argv: string[]): Promise<number> {
   if (argv[0] === 'init') {
     if (argv.length > 1) throw new Error('Usage: pickle init')
@@ -218,6 +242,10 @@ async function main(argv: string[]): Promise<number> {
   }
   if (argv[0] === 'check') {
     await checkProject({ ...projectOptions(argv), report: console.log })
+    return 0
+  }
+  if (argv[0] === 'migrate') {
+    await migrateProject({ ...migrateOptions(argv), report: console.log })
     return 0
   }
   return run(argv)

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -1,14 +1,16 @@
 #!/usr/bin/env bun
 
-import type { ExecutionTargetAdapter } from '@pickle-spec/runner'
-import { resolveRunConfiguration, runScenarios } from '@pickle-spec/runner'
-import { parseSpecification, selectScenarios, validateSpecificationMetadata, type SelectionOptions } from '@pickle-spec/spec'
-import {
-  createWebAdapter,
-  type WebAdapterOptions,
-} from '@pickle-spec/web'
 import { relative, resolve } from 'node:path'
 import { pathToFileURL } from 'node:url'
+import type { ExecutionTargetAdapter } from '@pickle-spec/runner'
+import { resolveRunConfiguration, runScenarios } from '@pickle-spec/runner'
+import {
+  parseSpecification,
+  type SelectionOptions,
+  selectScenarios,
+  validateSpecificationMetadata,
+} from '@pickle-spec/spec'
+import { createWebAdapter, type WebAdapterOptions } from '@pickle-spec/web'
 import { loadConfig, type PickleConfig } from './config'
 import type { Extensions } from './extensions'
 import { checkProject, initializeProject, migrateProject } from './project'
@@ -32,14 +34,17 @@ interface RunArguments {
 function integer(value: string, flag: string, minimum: number): number {
   const parsed = Number(value)
   if (!Number.isSafeInteger(parsed) || parsed < minimum) {
-    throw new Error(`${flag} requires an integer greater than or equal to ${minimum}`)
+    throw new Error(
+      `${flag} requires an integer greater than or equal to ${minimum}`,
+    )
   }
   return parsed
 }
 
 function valueAfter(argv: string[], index: number): string {
   const value = argv[index + 1]
-  if (!value || value.startsWith('--')) throw new Error(`${argv[index]} requires a value`)
+  if (!value || value.startsWith('--'))
+    throw new Error(`${argv[index]} requires a value`)
   return value
 }
 
@@ -50,7 +55,8 @@ function parseShard(value: string): { index: number; total: number } {
 }
 
 function parseRunArguments(argv: string[]): RunArguments {
-  if (argv[0] !== 'run') throw new Error('Usage: pickle run [specifications] [options]')
+  if (argv[0] !== 'run')
+    throw new Error('Usage: pickle run [specifications] [options]')
   const args: RunArguments = { selection: {} }
   let index = 1
   if (argv[index] && !argv[index]!.startsWith('-')) args.pattern = argv[index++]
@@ -58,24 +64,46 @@ function parseRunArguments(argv: string[]): RunArguments {
   while (index < argv.length) {
     const flag = argv[index]!
     switch (flag) {
-      case '--config': args.configPath = valueAfter(argv, index++); break
-      case '--extensions': args.extensionsPath = valueAfter(argv, index++); break
-      case '--scenario': args.selection.scenarioName = valueAfter(argv, index++); break
+      case '--config':
+        args.configPath = valueAfter(argv, index++)
+        break
+      case '--extensions':
+        args.extensionsPath = valueAfter(argv, index++)
+        break
+      case '--scenario':
+        args.selection.scenarioName = valueAfter(argv, index++)
+        break
       case '--tag':
-      case '-t': args.selection.tagExpression = valueAfter(argv, index++); break
-      case '--shard': args.selection.shard = parseShard(valueAfter(argv, index++)); break
-      case '--retries': args.retries = integer(valueAfter(argv, index++), flag, 0); break
+      case '-t':
+        args.selection.tagExpression = valueAfter(argv, index++)
+        break
+      case '--shard':
+        args.selection.shard = parseShard(valueAfter(argv, index++))
+        break
+      case '--retries':
+        args.retries = integer(valueAfter(argv, index++), flag, 0)
+        break
       case '--concurrency':
-      case '-j': args.concurrency = integer(valueAfter(argv, index++), flag, 1); break
+      case '-j':
+        args.concurrency = integer(valueAfter(argv, index++), flag, 1)
+        break
       case '--language':
-      case '-l': args.language = valueAfter(argv, index++); break
+      case '-l':
+        args.language = valueAfter(argv, index++)
+        break
       case '--scenario-timeout': {
         args.scenarioTimeoutMs = integer(valueAfter(argv, index++), flag, 1)
         break
       }
-      case '--step-timeout': args.stepTimeoutMs = integer(valueAfter(argv, index++), flag, 1); break
-      case '--reuse-server': args.reuseServer = true; break
-      case '--headed': args.headed = true; break
+      case '--step-timeout':
+        args.stepTimeoutMs = integer(valueAfter(argv, index++), flag, 1)
+        break
+      case '--reuse-server':
+        args.reuseServer = true
+        break
+      case '--headed':
+        args.headed = true
+        break
       case '--screenshot': {
         const mode = valueAfter(argv, index++)
         if (!['off', 'on-failure', 'on-step'].includes(mode)) {
@@ -84,7 +112,8 @@ function parseRunArguments(argv: string[]): RunArguments {
         args.screenshotMode = mode as RunArguments['screenshotMode']
         break
       }
-      default: throw new Error(`Unknown option: ${flag}`)
+      default:
+        throw new Error(`Unknown option: ${flag}`)
     }
     index++
   }
@@ -98,36 +127,48 @@ async function loadExtensions(path?: string): Promise<Extensions> {
     if (!path) return {}
     throw new Error(`Extensions file not found: ${selectedPath}`)
   }
-  return ((await import(pathToFileURL(absolutePath).href)).default ?? {}) as Extensions
+  return ((await import(pathToFileURL(absolutePath).href)).default ??
+    {}) as Extensions
 }
 
-async function discoverSpecifications(patterns: string | string[], language?: string) {
+async function discoverSpecifications(
+  patterns: string | string[],
+  language?: string,
+) {
   const paths = new Set<string>()
   for (const pattern of Array.isArray(patterns) ? patterns : [patterns]) {
     const glob = new Bun.Glob(pattern)
-    for await (const path of glob.scan({ cwd: process.cwd(), absolute: true })) paths.add(path)
+    for await (const path of glob.scan({ cwd: process.cwd(), absolute: true }))
+      paths.add(path)
   }
   if (paths.size === 0) {
     const description = Array.isArray(patterns) ? patterns.join(', ') : patterns
     throw new Error(`No specifications found matching: ${description}`)
   }
-  const files = await Promise.all([...paths].sort().map(async path => ({
-    uri: relative(process.cwd(), path),
-    source: await Bun.file(path).text(),
-  })))
+  const files = await Promise.all(
+    [...paths].sort().map(async (path) => ({
+      uri: relative(process.cwd(), path),
+      source: await Bun.file(path).text(),
+    })),
+  )
   try {
     validateSpecificationMetadata(files, language)
   } catch (error) {
     console.error(error instanceof Error ? error.message : String(error))
   }
-  return files.map(file => parseSpecification({
-    source: file.source,
-    uri: file.uri,
-    language,
-  }))
+  return files.map((file) =>
+    parseSpecification({
+      source: file.source,
+      uri: file.uri,
+      language,
+    }),
+  )
 }
 
-function configuredWebOptions(config: PickleConfig, args: RunArguments): WebAdapterOptions | undefined {
+function configuredWebOptions(
+  config: PickleConfig,
+  args: RunArguments,
+): WebAdapterOptions | undefined {
   if (!config.web) return undefined
   return {
     ...config.web,
@@ -147,7 +188,10 @@ function configuredAdapter(
   web: WebAdapterOptions | undefined,
 ): ExecutionTargetAdapter {
   if (extensions.adapter) return extensions.adapter
-  if (!web) throw new Error('Configure web.baseUrl or export an adapter from pickle.extensions.ts')
+  if (!web)
+    throw new Error(
+      'Configure web.baseUrl or export an adapter from pickle.extensions.ts',
+    )
   return createWebAdapter(web, extensions.webAutomationFactory)
 }
 
@@ -169,22 +213,30 @@ async function run(argv: string[]): Promise<number> {
       ...args.selection,
       shard: args.selection.shard ?? config.selection?.shard,
     })
-    if (selections.length === 0) throw new Error('No Scenarios match the current selection')
+    if (selections.length === 0)
+      throw new Error('No Scenarios match the current selection')
 
     const extensions = await loadExtensions(args.extensionsPath)
     const web = configuredWebOptions(config, args)
-    const resolvedConfiguration = resolveRunConfiguration({
-      schemaVersion: config.schemaVersion,
-      executionTargetProfile: config.executionTargetProfile ?? { id: web ? 'web' : 'custom' },
-      concurrency: args.concurrency ?? config.concurrency,
-      execution: {
-        infrastructureRetries: args.retries ?? config.execution?.infrastructureRetries,
-        stepTimeoutMs: args.stepTimeoutMs ?? config.execution?.stepTimeoutMs,
-        scenarioTimeoutMs: args.scenarioTimeoutMs ?? config.execution?.scenarioTimeoutMs,
+    const resolvedConfiguration = resolveRunConfiguration(
+      {
+        schemaVersion: config.schemaVersion,
+        executionTargetProfile: config.executionTargetProfile ?? {
+          id: web ? 'web' : 'custom',
+        },
+        concurrency: args.concurrency ?? config.concurrency,
+        execution: {
+          infrastructureRetries:
+            args.retries ?? config.execution?.infrastructureRetries,
+          stepTimeoutMs: args.stepTimeoutMs ?? config.execution?.stepTimeoutMs,
+          scenarioTimeoutMs:
+            args.scenarioTimeoutMs ?? config.execution?.scenarioTimeoutMs,
+        },
       },
-    }, {
-      adapter: configuredAdapter(extensions, web),
-    })
+      {
+        adapter: configuredAdapter(extensions, web),
+      },
+    )
     server = await startServer({
       ...config.server,
       ...(args.reuseServer ? { reuseExisting: true } : {}),
@@ -199,10 +251,17 @@ async function run(argv: string[]): Promise<number> {
     })
 
     for (const scenarioRun of runs) {
-      console.log(JSON.stringify({ kind: 'test-result', result: scenarioRun.result }))
+      console.log(
+        JSON.stringify({ kind: 'test-result', result: scenarioRun.result }),
+      )
     }
     if (runs.some(({ result }) => result.state === 'cancelled')) return 130
-    if (runs.some(({ result }) => result.state === 'failed' || result.state === 'infrastructure-error')) {
+    if (
+      runs.some(
+        ({ result }) =>
+          result.state === 'failed' || result.state === 'infrastructure-error',
+      )
+    ) {
       return 1
     }
     return 0
@@ -212,18 +271,25 @@ async function run(argv: string[]): Promise<number> {
   }
 }
 
-function projectOptions(argv: string[]): { configPath?: string; extensionsPath?: string } {
+function projectOptions(argv: string[]): {
+  configPath?: string
+  extensionsPath?: string
+} {
   const options: { configPath?: string; extensionsPath?: string } = {}
   for (let index = 1; index < argv.length; index++) {
     const flag = argv[index]!
     if (flag === '--config') options.configPath = valueAfter(argv, index++)
-    else if (flag === '--extensions') options.extensionsPath = valueAfter(argv, index++)
+    else if (flag === '--extensions')
+      options.extensionsPath = valueAfter(argv, index++)
     else throw new Error(`Unknown option: ${flag}`)
   }
   return options
 }
 
-function migrateOptions(argv: string[]): { configPath?: string; yes?: boolean } {
+function migrateOptions(argv: string[]): {
+  configPath?: string
+  yes?: boolean
+} {
   const options: { configPath?: string; yes?: boolean } = {}
   for (let index = 1; index < argv.length; index++) {
     const flag = argv[index]!

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -1,11 +1,17 @@
+import { resolve } from 'node:path'
 import {
-  validateRunConfiguration,
   type ExecutionTargetProfile,
   type RunConfiguration,
+  validateRunConfiguration,
 } from '@pickle-spec/runner'
-import { validateSelectionOptions, type SelectionOptions } from '@pickle-spec/spec'
-import { validateWebAdapterOptions, type WebAdapterOptions } from '@pickle-spec/web'
-import { resolve } from 'node:path'
+import {
+  type SelectionOptions,
+  validateSelectionOptions,
+} from '@pickle-spec/spec'
+import {
+  validateWebAdapterOptions,
+  type WebAdapterOptions,
+} from '@pickle-spec/web'
 
 export interface ServerConfig {
   command?: string
@@ -36,7 +42,9 @@ export interface PickleConfig {
 export function runConfigurationFrom(config: PickleConfig): RunConfiguration {
   return {
     schemaVersion: config.schemaVersion,
-    executionTargetProfile: config.executionTargetProfile ?? { id: config.web ? 'web' : 'custom' },
+    executionTargetProfile: config.executionTargetProfile ?? {
+      id: config.web ? 'web' : 'custom',
+    },
     concurrency: config.concurrency,
     execution: config.execution,
   }
@@ -49,9 +57,14 @@ function record(value: unknown, field: string): Record<string, unknown> {
   return value as Record<string, unknown>
 }
 
-function knownFields(value: Record<string, unknown>, fields: readonly string[], parent: string): void {
+function knownFields(
+  value: Record<string, unknown>,
+  fields: readonly string[],
+  parent: string,
+): void {
   for (const field of Object.keys(value)) {
-    if (!fields.includes(field)) throw new Error(`${parent}.${field} is not supported`)
+    if (!fields.includes(field))
+      throw new Error(`${parent}.${field} is not supported`)
   }
 }
 
@@ -62,27 +75,54 @@ function optionalString(value: unknown, field: string): void {
 }
 
 function optionalPositiveInteger(value: unknown, field: string): void {
-  if (value !== undefined && (!Number.isInteger(value) || (value as number) < 1)) {
+  if (
+    value !== undefined &&
+    (!Number.isInteger(value) || (value as number) < 1)
+  ) {
     throw new Error(`${field} must be an integer greater than or equal to 1`)
   }
 }
 
 function validateConfig(value: unknown): PickleConfig {
   const config = record(value, 'configuration')
-  knownFields(config, [
-    'schemaVersion', 'language', 'specifications', 'executionTargetProfile', 'web',
-    'selection', 'execution', 'concurrency', 'server',
-  ], 'configuration')
+  knownFields(
+    config,
+    [
+      'schemaVersion',
+      'language',
+      'specifications',
+      'executionTargetProfile',
+      'web',
+      'selection',
+      'execution',
+      'concurrency',
+      'server',
+    ],
+    'configuration',
+  )
   optionalString(config.language, 'language')
-  if (typeof config.specifications === 'string' && !config.specifications.trim()) {
+  if (
+    typeof config.specifications === 'string' &&
+    !config.specifications.trim()
+  ) {
     throw new Error('specifications paths must not be empty')
   }
-  if (Array.isArray(config.specifications) && config.specifications.length === 0) {
+  if (
+    Array.isArray(config.specifications) &&
+    config.specifications.length === 0
+  ) {
     throw new Error('specifications must contain at least one path')
   }
-  if (config.specifications !== undefined && typeof config.specifications !== 'string'
-    && !(Array.isArray(config.specifications)
-      && config.specifications.every(item => typeof item === 'string' && item.trim()))) {
+  if (
+    config.specifications !== undefined &&
+    typeof config.specifications !== 'string' &&
+    !(
+      Array.isArray(config.specifications) &&
+      config.specifications.every(
+        (item) => typeof item === 'string' && item.trim(),
+      )
+    )
+  ) {
     throw new Error('specifications must be a string or an array of strings')
   }
   if (config.web !== undefined) {
@@ -90,17 +130,29 @@ function validateConfig(value: unknown): PickleConfig {
   }
   if (config.server !== undefined) {
     const server = record(config.server, 'server')
-    knownFields(server, [
-      'command', 'url', 'port', 'startupTimeoutMs', 'pollIntervalMs', 'readinessPath',
-      'reuseExisting',
-    ], 'server')
+    knownFields(
+      server,
+      [
+        'command',
+        'url',
+        'port',
+        'startupTimeoutMs',
+        'pollIntervalMs',
+        'readinessPath',
+        'reuseExisting',
+      ],
+      'server',
+    )
     optionalString(server.command, 'server.command')
     optionalString(server.url, 'server.url')
     optionalString(server.readinessPath, 'server.readinessPath')
     optionalPositiveInteger(server.port, 'server.port')
     optionalPositiveInteger(server.startupTimeoutMs, 'server.startupTimeoutMs')
     optionalPositiveInteger(server.pollIntervalMs, 'server.pollIntervalMs')
-    if (server.reuseExisting !== undefined && typeof server.reuseExisting !== 'boolean') {
+    if (
+      server.reuseExisting !== undefined &&
+      typeof server.reuseExisting !== 'boolean'
+    ) {
       throw new Error('server.reuseExisting must be a boolean')
     }
     if (server.command && !server.url && !server.port) {
@@ -150,7 +202,11 @@ function removeJsonComments(source: string): string {
     }
     if (character === '/' && next === '*') {
       index += 2
-      while (index < source.length && !(source[index] === '*' && source[index + 1] === '/')) index++
+      while (
+        index < source.length &&
+        !(source[index] === '*' && source[index + 1] === '/')
+      )
+        index++
       index++
       continue
     }
@@ -161,11 +217,13 @@ function removeJsonComments(source: string): string {
 }
 
 async function defaultConfigPath(): Promise<string | undefined> {
-  return await Bun.file('pickle.config.jsonc').exists() ? 'pickle.config.jsonc' : undefined
+  return (await Bun.file('pickle.config.jsonc').exists())
+    ? 'pickle.config.jsonc'
+    : undefined
 }
 
 export async function loadConfig(configPath?: string): Promise<PickleConfig> {
-  const selectedPath = configPath ?? await defaultConfigPath()
+  const selectedPath = configPath ?? (await defaultConfigPath())
   if (!selectedPath) return { schemaVersion: 1 }
   if (!selectedPath.endsWith('.jsonc') && !selectedPath.endsWith('.json')) {
     throw new Error('Configuration must use pickle.config.jsonc')
@@ -176,9 +234,13 @@ export async function loadConfig(configPath?: string): Promise<PickleConfig> {
   }
 
   try {
-    return validateConfig(JSON.parse(removeJsonComments(await Bun.file(absolutePath).text())))
+    return validateConfig(
+      JSON.parse(removeJsonComments(await Bun.file(absolutePath).text())),
+    )
   } catch (error) {
     const reason = error instanceof Error ? error.message : String(error)
-    throw new Error(`Invalid configuration ${selectedPath}: ${reason}. Correct the value and run pickle check again.`)
+    throw new Error(
+      `Invalid configuration ${selectedPath}: ${reason}. Correct the value and run pickle check again.`,
+    )
   }
 }

--- a/packages/cli/src/extension-validation.ts
+++ b/packages/cli/src/extension-validation.ts
@@ -1,5 +1,5 @@
-import type { RunExtensionManifest } from '@pickle-spec/runner'
 import { dirname, relative, resolve } from 'node:path'
+import type { RunExtensionManifest } from '@pickle-spec/runner'
 import ts from 'typescript'
 
 function extensionModuleSpecifier(from: string, to: string): string {
@@ -21,12 +21,16 @@ function isRelevantSemanticDiagnostic(
   validationPath: string,
 ): boolean {
   if (diagnostic.category !== ts.DiagnosticCategory.Error) return false
-  if (diagnostic.code === 2307 && /^Cannot find module '(?:node|bun):/.test(
-    diagnosticMessage(diagnostic),
-  )) return false
+  if (
+    diagnostic.code === 2307 &&
+    /^Cannot find module '(?:node|bun):/.test(diagnosticMessage(diagnostic))
+  )
+    return false
   if (!diagnostic.file) return false
-  return resolve(diagnostic.file.fileName) === validationPath
-    || !program.isSourceFileFromExternalLibrary(diagnostic.file)
+  return (
+    resolve(diagnostic.file.fileName) === validationPath ||
+    !program.isSourceFileFromExternalLibrary(diagnostic.file)
+  )
 }
 
 function extensionProvidesAdapter(
@@ -34,20 +38,36 @@ function extensionProvidesAdapter(
   defaultExport: ts.Symbol,
   sourceFile: ts.SourceFile,
 ): boolean {
-  const exportedSymbol = defaultExport.flags & ts.SymbolFlags.Alias
-    ? typeChecker.getAliasedSymbol(defaultExport)
-    : defaultExport
-  const declaration = exportedSymbol.valueDeclaration ?? exportedSymbol.declarations?.[0] ?? sourceFile
-  const extensionType = typeChecker.getTypeOfSymbolAtLocation(exportedSymbol, declaration)
+  const exportedSymbol =
+    defaultExport.flags & ts.SymbolFlags.Alias
+      ? typeChecker.getAliasedSymbol(defaultExport)
+      : defaultExport
+  const declaration =
+    exportedSymbol.valueDeclaration ??
+    exportedSymbol.declarations?.[0] ??
+    sourceFile
+  const extensionType = typeChecker.getTypeOfSymbolAtLocation(
+    exportedSymbol,
+    declaration,
+  )
   const adapter = extensionType.getProperty('adapter')
-  const adapterDeclaration = adapter?.valueDeclaration ?? adapter?.declarations?.[0] ?? sourceFile
-  const adapterType = adapter && typeChecker.getTypeOfSymbolAtLocation(adapter, adapterDeclaration)
+  const adapterDeclaration =
+    adapter?.valueDeclaration ?? adapter?.declarations?.[0] ?? sourceFile
+  const adapterType =
+    adapter &&
+    typeChecker.getTypeOfSymbolAtLocation(adapter, adapterDeclaration)
 
-  return Boolean(adapter && !(adapter.flags & ts.SymbolFlags.Optional)
-    && adapterType && !(adapterType.flags & ts.TypeFlags.Undefined))
+  return Boolean(
+    adapter &&
+      !(adapter.flags & ts.SymbolFlags.Optional) &&
+      adapterType &&
+      !(adapterType.flags & ts.TypeFlags.Undefined),
+  )
 }
 
-export function validateExtensions(path: string): Pick<RunExtensionManifest, 'adapterAvailable'> {
+export function validateExtensions(
+  path: string,
+): Pick<RunExtensionManifest, 'adapterAvailable'> {
   const validationPath = resolve(import.meta.dir, '__extension_validation__.ts')
   const validationSource = `
 import extensions from ${JSON.stringify(extensionModuleSpecifier(validationPath, path))}
@@ -74,54 +94,84 @@ validate(extensions)
   }
   const host = ts.createCompilerHost(compilerOptions)
   const getSourceFile = host.getSourceFile.bind(host)
-  host.fileExists = fileName => resolve(fileName) === validationPath || ts.sys.fileExists(fileName)
-  host.readFile = fileName => resolve(fileName) === validationPath
-    ? validationSource
-    : ts.sys.readFile(fileName)
-  host.getSourceFile = (fileName, languageVersion, onError, shouldCreateNewSourceFile) => {
+  host.fileExists = (fileName) =>
+    resolve(fileName) === validationPath || ts.sys.fileExists(fileName)
+  host.readFile = (fileName) =>
+    resolve(fileName) === validationPath
+      ? validationSource
+      : ts.sys.readFile(fileName)
+  host.getSourceFile = (
+    fileName,
+    languageVersion,
+    onError,
+    shouldCreateNewSourceFile,
+  ) => {
     if (resolve(fileName) === validationPath) {
-      return ts.createSourceFile(fileName, validationSource, languageVersion, true, ts.ScriptKind.TS)
+      return ts.createSourceFile(
+        fileName,
+        validationSource,
+        languageVersion,
+        true,
+        ts.ScriptKind.TS,
+      )
     }
-    return getSourceFile(fileName, languageVersion, onError, shouldCreateNewSourceFile)
+    return getSourceFile(
+      fileName,
+      languageVersion,
+      onError,
+      shouldCreateNewSourceFile,
+    )
   }
 
   const program = ts.createProgram([validationPath], compilerOptions, host)
-  const syntaxDiagnostics = program.getSyntacticDiagnostics()
-    .filter(diagnostic => diagnostic.category === ts.DiagnosticCategory.Error)
+  const syntaxDiagnostics = program
+    .getSyntacticDiagnostics()
+    .filter((diagnostic) => diagnostic.category === ts.DiagnosticCategory.Error)
   if (syntaxDiagnostics.length > 0) {
     throw new Error(
-      `Cannot validate ${relative(process.cwd(), path)}: ${diagnosticReason(syntaxDiagnostics)}. `
-      + 'Fix its imports or syntax and run pickle check again.',
+      `Cannot validate ${relative(process.cwd(), path)}: ${diagnosticReason(syntaxDiagnostics)}. ` +
+        'Fix its imports or syntax and run pickle check again.',
     )
   }
 
   const typeChecker = program.getTypeChecker()
   const sourceFile = program.getSourceFile(path)
   const moduleSymbol = sourceFile && typeChecker.getSymbolAtLocation(sourceFile)
-  const defaultExport = moduleSymbol && typeChecker
-    .getExportsOfModule(moduleSymbol)
-    .find(symbol => symbol.name === 'default')
+  const defaultExport =
+    moduleSymbol &&
+    typeChecker
+      .getExportsOfModule(moduleSymbol)
+      .find((symbol) => symbol.name === 'default')
   if (!defaultExport) {
     throw new Error(
-      `${relative(process.cwd(), path)} must provide a default export. `
-      + 'Export the extension object as default and run pickle check again.',
+      `${relative(process.cwd(), path)} must provide a default export. ` +
+        'Export the extension object as default and run pickle check again.',
     )
   }
 
-  const semanticDiagnostics = program.getSemanticDiagnostics()
-    .filter(diagnostic => isRelevantSemanticDiagnostic(program, diagnostic, validationPath))
+  const semanticDiagnostics = program
+    .getSemanticDiagnostics()
+    .filter((diagnostic) =>
+      isRelevantSemanticDiagnostic(program, diagnostic, validationPath),
+    )
   if (semanticDiagnostics.length > 0) {
-    const correction = semanticDiagnostics.some(diagnostic =>
-      resolve(diagnostic.file?.fileName ?? '') !== validationPath)
+    const correction = semanticDiagnostics.some(
+      (diagnostic) =>
+        resolve(diagnostic.file?.fileName ?? '') !== validationPath,
+    )
       ? 'Fix its imports or syntax and run pickle check again.'
       : 'Correct the extension default export and run pickle check again.'
     throw new Error(
-      `Cannot validate ${relative(process.cwd(), path)}: `
-      + `${diagnosticReason(semanticDiagnostics)}. ${correction}`,
+      `Cannot validate ${relative(process.cwd(), path)}: ` +
+        `${diagnosticReason(semanticDiagnostics)}. ${correction}`,
     )
   }
 
   return {
-    adapterAvailable: extensionProvidesAdapter(typeChecker, defaultExport, sourceFile),
+    adapterAvailable: extensionProvidesAdapter(
+      typeChecker,
+      defaultExport,
+      sourceFile,
+    ),
   }
 }

--- a/packages/cli/src/project.ts
+++ b/packages/cli/src/project.ts
@@ -1,17 +1,17 @@
+import { relative, resolve } from 'node:path'
 import { validateProjectRunConfiguration } from '@pickle-spec/runner'
 import {
   formatMigrationPreview,
   parseSpecification,
   planSpecificationMigration,
-  validateSpecificationMetadata,
   type SpecificationSourceFile,
+  validateSpecificationMetadata,
 } from '@pickle-spec/spec'
-import { relative, resolve } from 'node:path'
-import { loadConfig, runConfigurationFrom, type PickleConfig } from './config'
+import { loadConfig, type PickleConfig, runConfigurationFrom } from './config'
 import { validateExtensions } from './extension-validation'
 
-const CONFIG_PATH = 'pickle.config.jsonc'
-const EXTENSIONS_PATH = 'pickle.extensions.ts'
+const defaultConfigPath = 'pickle.config.jsonc'
+const defaultExtensionsPath = 'pickle.extensions.ts'
 
 const initialConfig = `{
   // Pickle Spec project configuration.
@@ -39,10 +39,15 @@ interface ProjectCommandOptions {
   report?: (message: string) => void
 }
 
-export async function initializeProject(options: ProjectCommandOptions = {}): Promise<void> {
+export async function initializeProject(
+  options: ProjectCommandOptions = {},
+): Promise<void> {
   const cwd = resolve(options.cwd ?? process.cwd())
   const report = options.report ?? console.log
-  for (const [path, contents] of [[CONFIG_PATH, initialConfig], [EXTENSIONS_PATH, initialExtensions]] as const) {
+  for (const [path, contents] of [
+    [defaultConfigPath, initialConfig],
+    [defaultExtensionsPath, initialExtensions],
+  ] as const) {
     const absolutePath = resolve(cwd, path)
     if (await Bun.file(absolutePath).exists()) {
       report(`Skipped ${path}: file already exists`)
@@ -53,23 +58,34 @@ export async function initializeProject(options: ProjectCommandOptions = {}): Pr
   }
 }
 
-async function discoverSpecificationPaths(config: PickleConfig, cwd: string): Promise<string[]> {
+async function discoverSpecificationPaths(
+  config: PickleConfig,
+  cwd: string,
+): Promise<string[]> {
   const patterns = config.specifications ?? 'features/**/*.feature'
   const specificationPaths = new Set<string>()
   for (const pattern of Array.isArray(patterns) ? patterns : [patterns]) {
     let found = false
-    for await (const path of new Bun.Glob(pattern).scan({ cwd, onlyFiles: true })) {
+    for await (const path of new Bun.Glob(pattern).scan({
+      cwd,
+      onlyFiles: true,
+    })) {
       found = true
       specificationPaths.add(resolve(cwd, path))
     }
     if (!found) {
-      throw new Error(`Specification path ${JSON.stringify(pattern)} matches no files. Add a Specification or correct specifications in the configuration.`)
+      throw new Error(
+        `Specification path ${JSON.stringify(pattern)} matches no files. Add a Specification or correct specifications in the configuration.`,
+      )
     }
   }
   return [...specificationPaths].sort()
 }
 
-async function readSpecificationFiles(config: PickleConfig, cwd: string): Promise<SpecificationSourceFile[]> {
+async function readSpecificationFiles(
+  config: PickleConfig,
+  cwd: string,
+): Promise<SpecificationSourceFile[]> {
   const files: SpecificationSourceFile[] = []
   for (const path of await discoverSpecificationPaths(config, cwd)) {
     const uri = relative(cwd, path)
@@ -79,8 +95,8 @@ async function readSpecificationFiles(config: PickleConfig, cwd: string): Promis
     } catch (error) {
       const reason = error instanceof Error ? error.message : String(error)
       throw new Error(
-        `Invalid Specification ${uri}: ${reason}. `
-        + 'Correct the Specification and run pickle check again.',
+        `Invalid Specification ${uri}: ${reason}. ` +
+          'Correct the Specification and run pickle check again.',
       )
     }
     files.push({ uri, source })
@@ -88,12 +104,16 @@ async function readSpecificationFiles(config: PickleConfig, cwd: string): Promis
   return files
 }
 
-export async function migrateProject(options: ProjectCommandOptions = {}): Promise<void> {
+export async function migrateProject(
+  options: ProjectCommandOptions = {},
+): Promise<void> {
   const cwd = resolve(options.cwd ?? process.cwd())
-  const configPath = resolve(cwd, options.configPath ?? CONFIG_PATH)
+  const configPath = resolve(cwd, options.configPath ?? defaultConfigPath)
   const report = options.report ?? console.log
   if (!(await Bun.file(configPath).exists())) {
-    throw new Error(`Configuration file not found: ${relative(cwd, configPath)}. Run pickle init or pass --config <path>.`)
+    throw new Error(
+      `Configuration file not found: ${relative(cwd, configPath)}. Run pickle init or pass --config <path>.`,
+    )
   }
 
   const previousCwd = process.cwd()
@@ -106,7 +126,9 @@ export async function migrateProject(options: ProjectCommandOptions = {}): Promi
     if (plan.changes.length === 0) return
     if (!options.yes) {
       if (!process.stdin.isTTY) {
-        report('No files were changed. Re-run pickle migrate --yes after reviewing the preview.')
+        report(
+          'No files were changed. Re-run pickle migrate --yes after reviewing the preview.',
+        )
         return
       }
       if (!/^[yY]/.test((prompt('Apply these changes? [y/N]') ?? '').trim())) {
@@ -126,15 +148,24 @@ export async function migrateProject(options: ProjectCommandOptions = {}): Promi
   }
 }
 
-export async function checkProject(options: ProjectCommandOptions = {}): Promise<void> {
+export async function checkProject(
+  options: ProjectCommandOptions = {},
+): Promise<void> {
   const cwd = resolve(options.cwd ?? process.cwd())
-  const configPath = resolve(cwd, options.configPath ?? CONFIG_PATH)
-  const extensionsPath = resolve(cwd, options.extensionsPath ?? EXTENSIONS_PATH)
+  const configPath = resolve(cwd, options.configPath ?? defaultConfigPath)
+  const extensionsPath = resolve(
+    cwd,
+    options.extensionsPath ?? defaultExtensionsPath,
+  )
   if (!(await Bun.file(configPath).exists())) {
-    throw new Error(`Configuration file not found: ${relative(cwd, configPath)}. Run pickle init or pass --config <path>.`)
+    throw new Error(
+      `Configuration file not found: ${relative(cwd, configPath)}. Run pickle init or pass --config <path>.`,
+    )
   }
   if (!(await Bun.file(extensionsPath).exists())) {
-    throw new Error(`Extensions file not found: ${relative(cwd, extensionsPath)}. Run pickle init or pass --extensions <path>.`)
+    throw new Error(
+      `Extensions file not found: ${relative(cwd, extensionsPath)}. Run pickle init or pass --extensions <path>.`,
+    )
   }
 
   const previousCwd = process.cwd()
@@ -146,8 +177,13 @@ export async function checkProject(options: ProjectCommandOptions = {}): Promise
       ...extensions,
       fallbackAdapterAvailable: Boolean(config.web),
     })
-    validateSpecificationMetadata(await readSpecificationFiles(config, cwd), config.language)
-    options.report?.(`Project is valid (${relative(cwd, configPath)}, ${relative(cwd, extensionsPath)})`)
+    validateSpecificationMetadata(
+      await readSpecificationFiles(config, cwd),
+      config.language,
+    )
+    options.report?.(
+      `Project is valid (${relative(cwd, configPath)}, ${relative(cwd, extensionsPath)})`,
+    )
   } finally {
     process.chdir(previousCwd)
   }

--- a/packages/cli/src/project.ts
+++ b/packages/cli/src/project.ts
@@ -1,5 +1,11 @@
 import { validateProjectRunConfiguration } from '@pickle-spec/runner'
-import { parseSpecificationFile } from '@pickle-spec/spec'
+import {
+  formatMigrationPreview,
+  parseSpecification,
+  planSpecificationMigration,
+  validateSpecificationMetadata,
+  type SpecificationSourceFile,
+} from '@pickle-spec/spec'
 import { relative, resolve } from 'node:path'
 import { loadConfig, runConfigurationFrom, type PickleConfig } from './config'
 import { validateExtensions } from './extension-validation'
@@ -29,6 +35,7 @@ interface ProjectCommandOptions {
   cwd?: string
   configPath?: string
   extensionsPath?: string
+  yes?: boolean
   report?: (message: string) => void
 }
 
@@ -46,7 +53,7 @@ export async function initializeProject(options: ProjectCommandOptions = {}): Pr
   }
 }
 
-async function validateSpecificationPaths(config: PickleConfig, cwd: string): Promise<void> {
+async function discoverSpecificationPaths(config: PickleConfig, cwd: string): Promise<string[]> {
   const patterns = config.specifications ?? 'features/**/*.feature'
   const specificationPaths = new Set<string>()
   for (const pattern of Array.isArray(patterns) ? patterns : [patterns]) {
@@ -59,16 +66,63 @@ async function validateSpecificationPaths(config: PickleConfig, cwd: string): Pr
       throw new Error(`Specification path ${JSON.stringify(pattern)} matches no files. Add a Specification or correct specifications in the configuration.`)
     }
   }
-  for (const path of [...specificationPaths].sort()) {
+  return [...specificationPaths].sort()
+}
+
+async function readSpecificationFiles(config: PickleConfig, cwd: string): Promise<SpecificationSourceFile[]> {
+  const files: SpecificationSourceFile[] = []
+  for (const path of await discoverSpecificationPaths(config, cwd)) {
+    const uri = relative(cwd, path)
+    const source = await Bun.file(path).text()
     try {
-      await parseSpecificationFile(path, config.language)
+      parseSpecification({ source, uri, language: config.language })
     } catch (error) {
       const reason = error instanceof Error ? error.message : String(error)
       throw new Error(
-        `Invalid Specification ${relative(cwd, path)}: ${reason}. `
+        `Invalid Specification ${uri}: ${reason}. `
         + 'Correct the Specification and run pickle check again.',
       )
     }
+    files.push({ uri, source })
+  }
+  return files
+}
+
+export async function migrateProject(options: ProjectCommandOptions = {}): Promise<void> {
+  const cwd = resolve(options.cwd ?? process.cwd())
+  const configPath = resolve(cwd, options.configPath ?? CONFIG_PATH)
+  const report = options.report ?? console.log
+  if (!(await Bun.file(configPath).exists())) {
+    throw new Error(`Configuration file not found: ${relative(cwd, configPath)}. Run pickle init or pass --config <path>.`)
+  }
+
+  const previousCwd = process.cwd()
+  try {
+    process.chdir(cwd)
+    const config = await loadConfig(configPath)
+    const files = await readSpecificationFiles(config, cwd)
+    const plan = planSpecificationMigration(files, config.language)
+    report(formatMigrationPreview(plan))
+    if (plan.changes.length === 0) return
+    if (!options.yes) {
+      if (!process.stdin.isTTY) {
+        report('No files were changed. Re-run pickle migrate --yes after reviewing the preview.')
+        return
+      }
+      if (!/^[yY]/.test((prompt('Apply these changes? [y/N]') ?? '').trim())) {
+        report('No files were changed')
+        return
+      }
+    }
+    let updated = 0
+    for (const file of plan.files) {
+      if (file.source === file.nextSource) continue
+      await Bun.write(resolve(cwd, file.uri), file.nextSource)
+      updated++
+    }
+    report(`Updated ${updated} Specification file(s)`)
+  } finally {
+    process.chdir(previousCwd)
   }
 }
 
@@ -92,7 +146,7 @@ export async function checkProject(options: ProjectCommandOptions = {}): Promise
       ...extensions,
       fallbackAdapterAvailable: Boolean(config.web),
     })
-    await validateSpecificationPaths(config, cwd)
+    validateSpecificationMetadata(await readSpecificationFiles(config, cwd), config.language)
     options.report?.(`Project is valid (${relative(cwd, configPath)}, ${relative(cwd, extensionsPath)})`)
   } finally {
     process.chdir(previousCwd)

--- a/packages/cli/src/server.ts
+++ b/packages/cli/src/server.ts
@@ -1,5 +1,5 @@
-import type { ServerConfig } from './config'
 import type { Subprocess } from 'bun'
+import type { ServerConfig } from './config'
 
 export interface ManagedServer {
   mode: 'spawned' | 'reused'
@@ -22,7 +22,8 @@ function commandForShell(command: string): string[] {
 }
 
 function serverUrl(config: ServerConfig): string {
-  const url = config.url ?? (config.port ? `http://localhost:${config.port}` : undefined)
+  const url =
+    config.url ?? (config.port ? `http://localhost:${config.port}` : undefined)
   if (!url) throw new Error('server.command requires server.url or server.port')
   return url
 }
@@ -61,18 +62,28 @@ export async function startServer(
   const timeoutMs = config.startupTimeoutMs ?? 30_000
   const deadline = Date.now() + timeoutMs
 
-  if (config.reuseExisting && await isHealthy(config, url, deadline, serverRuntime)) {
+  if (
+    config.reuseExisting &&
+    (await isHealthy(config, url, deadline, serverRuntime))
+  ) {
     return { mode: 'reused', url, stop() {} }
   }
 
-  const child: Subprocess = serverRuntime.spawn(commandForShell(config.command), {
-    cwd: process.cwd(), stdout: 'ignore', stderr: 'pipe',
-  })
+  const child: Subprocess = serverRuntime.spawn(
+    commandForShell(config.command),
+    {
+      cwd: process.cwd(),
+      stdout: 'ignore',
+      stderr: 'pipe',
+    },
+  )
   while (Date.now() < deadline) {
     if (await isHealthy(config, url, deadline, serverRuntime)) {
       return { mode: 'spawned', url, stop: () => child.kill() }
     }
-    await serverRuntime.sleep(Math.min(config.pollIntervalMs ?? 500, deadline - Date.now()))
+    await serverRuntime.sleep(
+      Math.min(config.pollIntervalMs ?? 500, deadline - Date.now()),
+    )
   }
 
   child.kill()

--- a/packages/cli/src/workspace.test.ts
+++ b/packages/cli/src/workspace.test.ts
@@ -27,7 +27,10 @@ Feature: Example
     Then validation succeeds`,
   }
 
-  async function createCheckProject(name: string, fixture: CheckProjectFixture): Promise<string> {
+  async function createCheckProject(
+    name: string,
+    fixture: CheckProjectFixture,
+  ): Promise<string> {
     const project = join(workspace, name)
     await mkdir(project, { recursive: true })
     if (fixture.specification) {
@@ -35,7 +38,10 @@ Feature: Example
       await mkdir(dirname(path), { recursive: true })
       await Bun.write(path, fixture.specification.source)
     }
-    await Bun.write(join(project, 'pickle.config.jsonc'), JSON.stringify(fixture.config))
+    await Bun.write(
+      join(project, 'pickle.config.jsonc'),
+      JSON.stringify(fixture.config),
+    )
     await Bun.write(
       join(project, 'pickle.extensions.ts'),
       fixture.extensions ?? 'export default {}',
@@ -44,29 +50,46 @@ Feature: Example
   }
 
   function runCheck(project: string) {
-    return Bun.spawnSync({ cmd: [pickleCommand, 'check'], cwd: project, env: { ...Bun.env } })
+    return Bun.spawnSync({
+      cmd: [pickleCommand, 'check'],
+      cwd: project,
+      env: { ...Bun.env },
+    })
   }
 
   beforeAll(async () => {
     workspace = await mkdtemp(join(tmpdir(), 'pickle-spec-workspace-'))
     const packageDirectory = resolve(import.meta.dir, '..')
-    const packageManifest = await Bun.file(join(packageDirectory, 'package.json')).json() as {
+    const packageManifest = (await Bun.file(
+      join(packageDirectory, 'package.json'),
+    ).json()) as {
       bin: { pickle: string }
     }
     pickleCommand = join(workspace, 'node_modules', '.bin', 'pickle')
     await mkdir(join(workspace, 'node_modules', '.bin'), { recursive: true })
-    await symlink(resolve(packageDirectory, packageManifest.bin.pickle), pickleCommand)
-    await Bun.write(join(workspace, 'purchase.feature'), `@pickle:id:specpurchaseaaaaaa @pickle:state:active
+    await symlink(
+      resolve(packageDirectory, packageManifest.bin.pickle),
+      pickleCommand,
+    )
+    await Bun.write(
+      join(workspace, 'purchase.feature'),
+      `@pickle:id:specpurchaseaaaaaa @pickle:state:active
 Feature: Purchase
   @pickle:id:scnpurchasebbbbbb
   Scenario: Complete a purchase
     Given a product is in the basket
-    Then the purchase succeeds`)
-    await Bun.write(join(workspace, 'deterministic.config.jsonc'), JSON.stringify({
-      schemaVersion: 1,
-      executionTargetProfile: { id: 'deterministic' },
-    }))
-    await Bun.write(join(workspace, 'pickle.extensions.ts'), `
+    Then the purchase succeeds`,
+    )
+    await Bun.write(
+      join(workspace, 'deterministic.config.jsonc'),
+      JSON.stringify({
+        schemaVersion: 1,
+        executionTargetProfile: { id: 'deterministic' },
+      }),
+    )
+    await Bun.write(
+      join(workspace, 'pickle.extensions.ts'),
+      `
 const state = process.env.PICKLE_TEST_OUTCOME ?? 'passed'
 
 export default {
@@ -100,7 +123,8 @@ export default {
     },
   },
 }
-`)
+`,
+    )
   })
 
   afterAll(async () => {
@@ -132,8 +156,15 @@ export default {
 
     expect(stderr).toBe('')
     expect(exitCode).toBe(0)
-    const records = stdout.trim().split('\n').map(line => JSON.parse(line))
-    expect(records.filter(record => record.kind === 'run-event').map(record => record.event.type)).toEqual([
+    const records = stdout
+      .trim()
+      .split('\n')
+      .map((line) => JSON.parse(line))
+    expect(
+      records
+        .filter((record) => record.kind === 'run-event')
+        .map((record) => record.event.type),
+    ).toEqual([
       'scenario-started',
       'step-started',
       'step-finished',
@@ -158,25 +189,48 @@ export default {
   test('initializes a project without overwriting files and checks it without opening a session', async () => {
     const project = join(workspace, 'initialized-project')
     await mkdir(join(project, 'features'), { recursive: true })
-    await Bun.write(join(project, 'features', 'example.feature'), `@pickle:id:specaaaaaaaaaaaa @pickle:state:active
+    await Bun.write(
+      join(project, 'features', 'example.feature'),
+      `@pickle:id:specaaaaaaaaaaaa @pickle:state:active
 Feature: Example
   @pickle:id:scnbbbbbbbbbbbb
   Scenario: Safe check
-    Then validation is offline`)
+    Then validation is offline`,
+    )
 
-    const first = Bun.spawnSync({ cmd: [pickleCommand, 'init'], cwd: project, env: { ...Bun.env } })
+    const first = Bun.spawnSync({
+      cmd: [pickleCommand, 'init'],
+      cwd: project,
+      env: { ...Bun.env },
+    })
     expect(first.exitCode).toBe(0)
     expect(first.stdout.toString()).toContain('Created pickle.config.jsonc')
     expect(first.stdout.toString()).toContain('Created pickle.extensions.ts')
 
-    const originalExtensions = await Bun.file(join(project, 'pickle.extensions.ts')).text()
-    const second = Bun.spawnSync({ cmd: [pickleCommand, 'init'], cwd: project, env: { ...Bun.env } })
+    const originalExtensions = await Bun.file(
+      join(project, 'pickle.extensions.ts'),
+    ).text()
+    const second = Bun.spawnSync({
+      cmd: [pickleCommand, 'init'],
+      cwd: project,
+      env: { ...Bun.env },
+    })
     expect(second.exitCode).toBe(0)
-    expect(second.stdout.toString()).toContain('Skipped pickle.config.jsonc: file already exists')
-    expect(second.stdout.toString()).toContain('Skipped pickle.extensions.ts: file already exists')
-    expect(await Bun.file(join(project, 'pickle.extensions.ts')).text()).toBe(originalExtensions)
+    expect(second.stdout.toString()).toContain(
+      'Skipped pickle.config.jsonc: file already exists',
+    )
+    expect(second.stdout.toString()).toContain(
+      'Skipped pickle.extensions.ts: file already exists',
+    )
+    expect(await Bun.file(join(project, 'pickle.extensions.ts')).text()).toBe(
+      originalExtensions,
+    )
 
-    const checked = Bun.spawnSync({ cmd: [pickleCommand, 'check'], cwd: project, env: { ...Bun.env } })
+    const checked = Bun.spawnSync({
+      cmd: [pickleCommand, 'check'],
+      cwd: project,
+      env: { ...Bun.env },
+    })
     expect(checked.exitCode).toBe(0)
     expect(checked.stdout.toString()).toContain('Project is valid')
     expect(checked.stderr.toString()).toBe('')
@@ -199,9 +253,13 @@ export default {}
     const checked = runCheck(project)
 
     expect(checked.exitCode).toBe(2)
-    expect(checked.stderr.toString()).toContain('Cannot validate pickle.extensions.ts')
+    expect(checked.stderr.toString()).toContain(
+      'Cannot validate pickle.extensions.ts',
+    )
     expect(checked.stderr.toString()).toContain('missing-adapter.ts')
-    expect(checked.stderr.toString()).toContain('Fix its imports or syntax and run pickle check again')
+    expect(checked.stderr.toString()).toContain(
+      'Fix its imports or syntax and run pickle check again',
+    )
     expect(await Bun.file(marker).exists()).toBe(false)
   })
 
@@ -223,8 +281,12 @@ export default { adapter: missingAdapter }
     const checked = runCheck(project)
 
     expect(checked.exitCode).toBe(2)
-    expect(checked.stderr.toString()).toContain("has no exported member 'missingAdapter'")
-    expect(checked.stderr.toString()).toContain('Fix its imports or syntax and run pickle check again')
+    expect(checked.stderr.toString()).toContain(
+      "has no exported member 'missingAdapter'",
+    )
+    expect(checked.stderr.toString()).toContain(
+      'Fix its imports or syntax and run pickle check again',
+    )
     expect(await Bun.file(marker).exists()).toBe(false)
   })
 
@@ -240,8 +302,9 @@ export default { adapter: missingAdapter }
     const checked = runCheck(project)
 
     expect(checked.exitCode).toBe(2)
-    expect(checked.stderr.toString())
-      .toContain('Configure web.baseUrl or export an adapter from pickle.extensions.ts')
+    expect(checked.stderr.toString()).toContain(
+      'Configure web.baseUrl or export an adapter from pickle.extensions.ts',
+    )
   })
 
   test('check requires an extension default export without evaluating it', async () => {
@@ -254,8 +317,12 @@ export default { adapter: missingAdapter }
     const checked = runCheck(project)
 
     expect(checked.exitCode).toBe(2)
-    expect(checked.stderr.toString()).toContain('pickle.extensions.ts must provide a default export')
-    expect(checked.stderr.toString()).toContain('Export the extension object as default and run pickle check again')
+    expect(checked.stderr.toString()).toContain(
+      'pickle.extensions.ts must provide a default export',
+    )
+    expect(checked.stderr.toString()).toContain(
+      'Export the extension object as default and run pickle check again',
+    )
   })
 
   test('check rejects an invalid extension adapter without evaluating it', async () => {
@@ -271,9 +338,13 @@ export default { adapter: missingAdapter }
     const checked = runCheck(project)
 
     expect(checked.exitCode).toBe(2)
-    expect(checked.stderr.toString()).toContain("Property 'openSession' is missing")
+    expect(checked.stderr.toString()).toContain(
+      "Property 'openSession' is missing",
+    )
     expect(checked.stderr.toString()).toContain('executionTargetProfile')
-    expect(checked.stderr.toString()).toContain('Correct the extension default export and run pickle check again')
+    expect(checked.stderr.toString()).toContain(
+      'Correct the extension default export and run pickle check again',
+    )
   })
 
   test('check rejects invalid selection policies', async () => {
@@ -288,8 +359,12 @@ export default { adapter: missingAdapter }
     const checked = runCheck(project)
 
     expect(checked.exitCode).toBe(2)
-    expect(checked.stderr.toString()).toContain('selection.shard.index must be less than or equal to selection.shard.total')
-    expect(checked.stderr.toString()).toContain('Correct the value and run pickle check again')
+    expect(checked.stderr.toString()).toContain(
+      'selection.shard.index must be less than or equal to selection.shard.total',
+    )
+    expect(checked.stderr.toString()).toContain(
+      'Correct the value and run pickle check again',
+    )
   })
 
   test('check rejects invalid web adapter policies', async () => {
@@ -307,8 +382,12 @@ export default { adapter: missingAdapter }
     const checked = runCheck(project)
 
     expect(checked.exitCode).toBe(2)
-    expect(checked.stderr.toString()).toContain('web.browser.environment must be local or browserbase')
-    expect(checked.stderr.toString()).toContain('Correct the value and run pickle check again')
+    expect(checked.stderr.toString()).toContain(
+      'web.browser.environment must be local or browserbase',
+    )
+    expect(checked.stderr.toString()).toContain(
+      'Correct the value and run pickle check again',
+    )
   })
 
   test('check rejects invalid Specifications before execution resources start', async () => {
@@ -323,8 +402,12 @@ export default { adapter: missingAdapter }
     const checked = runCheck(project)
 
     expect(checked.exitCode).toBe(2)
-    expect(checked.stderr.toString()).toContain('Invalid Specification features/invalid.feature')
-    expect(checked.stderr.toString()).toContain('Correct the Specification and run pickle check again')
+    expect(checked.stderr.toString()).toContain(
+      'Invalid Specification features/invalid.feature',
+    )
+    expect(checked.stderr.toString()).toContain(
+      'Correct the Specification and run pickle check again',
+    )
   })
 
   test('run validates Specifications before starting the configured application server', async () => {
@@ -352,7 +435,11 @@ export default {}
 `,
     })
 
-    const run = Bun.spawnSync({ cmd: [pickleCommand, 'run'], cwd: project, env: { ...Bun.env } })
+    const run = Bun.spawnSync({
+      cmd: [pickleCommand, 'run'],
+      cwd: project,
+      env: { ...Bun.env },
+    })
 
     expect(run.exitCode).toBe(2)
     expect(run.stderr.toString()).toContain('Parser errors')
@@ -368,8 +455,12 @@ export default {}
     const checked = runCheck(project)
 
     expect(checked.exitCode).toBe(2)
-    expect(checked.stderr.toString()).toContain('specifications must contain at least one path')
-    expect(checked.stderr.toString()).toContain('Correct the value and run pickle check again')
+    expect(checked.stderr.toString()).toContain(
+      'specifications must contain at least one path',
+    )
+    expect(checked.stderr.toString()).toContain(
+      'Correct the value and run pickle check again',
+    )
   })
 
   test('check reports the reason and corrective action for validation failures', async () => {
@@ -379,8 +470,12 @@ export default {}
 
     const checked = runCheck(project)
     expect(checked.exitCode).toBe(2)
-    expect(checked.stderr.toString()).toContain('Unsupported configuration schemaVersion: 99')
-    expect(checked.stderr.toString()).toContain('Correct the value and run pickle check again')
+    expect(checked.stderr.toString()).toContain(
+      'Unsupported configuration schemaVersion: 99',
+    )
+    expect(checked.stderr.toString()).toContain(
+      'Correct the value and run pickle check again',
+    )
   })
 
   test('migrate previews namespaced identifiers and writes only after confirmation', async () => {
@@ -397,22 +492,40 @@ Feature: Checkout
     })
     const featurePath = join(project, 'features', 'checkout.feature')
 
-    const preview = Bun.spawnSync({ cmd: [pickleCommand, 'migrate'], cwd: project, env: { ...Bun.env } })
+    const preview = Bun.spawnSync({
+      cmd: [pickleCommand, 'migrate'],
+      cwd: project,
+      env: { ...Bun.env },
+    })
     expect(preview.exitCode).toBe(0)
-    expect(preview.stdout.toString()).toMatch(/Feature "Checkout": add @pickle:id:[0-9a-f]{16} @pickle:state:active/)
-    expect(preview.stdout.toString()).toMatch(/Scenario "Complete a purchase": add @pickle:id:[0-9a-f]{16}/)
-    expect(preview.stdout.toString()).toContain('Re-run pickle migrate --yes after reviewing the preview')
+    expect(preview.stdout.toString()).toMatch(
+      /Feature "Checkout": add @pickle:id:[0-9a-f]{16} @pickle:state:active/,
+    )
+    expect(preview.stdout.toString()).toMatch(
+      /Scenario "Complete a purchase": add @pickle:id:[0-9a-f]{16}/,
+    )
+    expect(preview.stdout.toString()).toContain(
+      'Re-run pickle migrate --yes after reviewing the preview',
+    )
     expect(await Bun.file(featurePath).text()).toBe(source)
 
-    const applied = Bun.spawnSync({ cmd: [pickleCommand, 'migrate', '--yes'], cwd: project, env: { ...Bun.env } })
+    const applied = Bun.spawnSync({
+      cmd: [pickleCommand, 'migrate', '--yes'],
+      cwd: project,
+      env: { ...Bun.env },
+    })
     expect(applied.exitCode).toBe(0)
-    expect(applied.stdout.toString()).toContain('Updated 1 Specification file(s)')
+    expect(applied.stdout.toString()).toContain(
+      'Updated 1 Specification file(s)',
+    )
     const migrated = await Bun.file(featurePath).text()
     expect(migrated).toContain('# keep this comment')
     expect(migrated).toContain('\n@smoke\n@pickle:id:')
     expect(migrated).toContain('@pickle:state:active')
     expect(migrated).toContain('Then the purchase succeeds')
-    for (const id of applied.stdout.toString().match(/@pickle:id:[0-9a-f]{16}/g) ?? []) {
+    for (const id of applied.stdout
+      .toString()
+      .match(/@pickle:id:[0-9a-f]{16}/g) ?? []) {
       expect(migrated).toContain(id)
     }
 
@@ -420,9 +533,15 @@ Feature: Checkout
     expect(checked.exitCode).toBe(0)
     expect(checked.stdout.toString()).toContain('Project is valid')
 
-    const again = Bun.spawnSync({ cmd: [pickleCommand, 'migrate', '--yes'], cwd: project, env: { ...Bun.env } })
+    const again = Bun.spawnSync({
+      cmd: [pickleCommand, 'migrate', '--yes'],
+      cwd: project,
+      env: { ...Bun.env },
+    })
     expect(again.exitCode).toBe(0)
-    expect(again.stdout.toString()).toContain('No Specification metadata changes needed')
+    expect(again.stdout.toString()).toContain(
+      'No Specification metadata changes needed',
+    )
     expect(await Bun.file(featurePath).text()).toBe(migrated)
   })
 
@@ -431,7 +550,8 @@ Feature: Checkout
       config: defaultCheckConfig,
       specification: {
         path: 'features/missing.feature',
-        source: 'Feature: Missing\n  Scenario: Needs identity\n    Then validation fails',
+        source:
+          'Feature: Missing\n  Scenario: Needs identity\n    Then validation fails',
       },
     })
 
@@ -439,11 +559,14 @@ Feature: Checkout
 
     expect(checked.exitCode).toBe(2)
     expect(checked.stderr.toString()).toContain('missing a durable identifier')
-    expect(checked.stderr.toString()).toContain('Run pickle migrate to add missing metadata')
+    expect(checked.stderr.toString()).toContain(
+      'Run pickle migrate to add missing metadata',
+    )
   })
 
   test('check and run never modify Specification source', async () => {
-    const source = 'Feature: Unchanged\n  Scenario: Stay put\n    Then nothing writes'
+    const source =
+      'Feature: Unchanged\n  Scenario: Stay put\n    Then nothing writes'
     const project = await createCheckProject('no-write', {
       config: defaultCheckConfig,
       specification: { path: 'features/unchanged.feature', source },
@@ -484,7 +607,9 @@ Feature: Checkout
         specifications: 'features/**/*.feature',
       },
       specification: { path: 'features/unreported.feature', source },
-      extensions: await Bun.file(join(workspace, 'pickle.extensions.ts')).text(),
+      extensions: await Bun.file(
+        join(workspace, 'pickle.extensions.ts'),
+      ).text(),
     })
     const featurePath = join(project, 'features', 'unreported.feature')
 
@@ -496,7 +621,9 @@ Feature: Checkout
 
     expect(run.exitCode).toBe(0)
     expect(run.stderr.toString()).toContain('missing a durable identifier')
-    expect(run.stderr.toString()).toContain('Run pickle migrate to add missing metadata')
+    expect(run.stderr.toString()).toContain(
+      'Run pickle migrate to add missing metadata',
+    )
     expect(await Bun.file(featurePath).text()).toBe(source)
   })
 
@@ -530,7 +657,10 @@ Feature: Checkout
         new Response(process.stdout).text(),
         new Response(process.stderr).text(),
       ])
-      const records = stdout.trim().split('\n').map(line => JSON.parse(line))
+      const records = stdout
+        .trim()
+        .split('\n')
+        .map((line) => JSON.parse(line))
 
       expect(stderr).toBe('')
       expect(exitCode).toBe(expected.exitCode)
@@ -569,7 +699,11 @@ Feature: Checkout
       stderr: 'pipe',
     })
 
-    for (let attempt = 0; attempt < 200 && !(await Bun.file(stepMarker).exists()); attempt++) {
+    for (
+      let attempt = 0;
+      attempt < 200 && !(await Bun.file(stepMarker).exists());
+      attempt++
+    ) {
       await Bun.sleep(5)
     }
     expect(await Bun.file(stepMarker).exists()).toBe(true)
@@ -580,7 +714,10 @@ Feature: Checkout
       new Response(child.stdout).text(),
       new Response(child.stderr).text(),
     ])
-    const records = stdout.trim().split('\n').map(line => JSON.parse(line))
+    const records = stdout
+      .trim()
+      .split('\n')
+      .map((line) => JSON.parse(line))
 
     expect(stderr).toBe('')
     expect(exitCode).toBe(130)
@@ -593,15 +730,21 @@ Feature: Checkout
 
   test('runs a real web Scenario through the public web adapter composition', async () => {
     const artifactDirectory = join(workspace, 'web-artifacts')
-    const applicationUrl = 'data:text/html,<button id="search">Search</button><div id="results"></div>'
-    await Bun.write(join(workspace, 'web.feature'), `@pickle:id:specwebaaaaaaaaaa @pickle:state:active
+    const applicationUrl =
+      'data:text/html,<button id="search">Search</button><div id="results"></div>'
+    await Bun.write(
+      join(workspace, 'web.feature'),
+      `@pickle:id:specwebaaaaaaaaaa @pickle:state:active
 Feature: Web search
   @pickle:id:scnwebbbbbbbbbbb
   Scenario: Search from the application
     Given I navigate to the main page
     When I search for pickles
-    Then pickle results are visible`)
-    await Bun.write(join(workspace, 'pickle.config.jsonc'), `{
+    Then pickle results are visible`,
+    )
+    await Bun.write(
+      join(workspace, 'pickle.config.jsonc'),
+      `{
   // The CLI owns this declarative target configuration.
   "schemaVersion": 1,
   "executionTargetProfile": { "id": "web" },
@@ -617,8 +760,11 @@ Feature: Web search
       "outputDir": ${JSON.stringify(artifactDirectory)}
     }
   }
-}`)
-    await Bun.write(join(workspace, 'web.extensions.ts'), `
+}`,
+    )
+    await Bun.write(
+      join(workspace, 'web.extensions.ts'),
+      `
 export default {
   webAutomationFactory: {
     async open() {
@@ -644,7 +790,8 @@ export default {
     },
   },
 }
-`)
+`,
+    )
 
     const process = Bun.spawn({
       cmd: [
@@ -669,7 +816,10 @@ export default {
 
     expect(stderr).toBe('')
     expect(exitCode).toBe(0)
-    const records = stdout.trim().split('\n').map(line => JSON.parse(line))
+    const records = stdout
+      .trim()
+      .split('\n')
+      .map((line) => JSON.parse(line))
     expect(records.at(-1)).toMatchObject({
       kind: 'test-result',
       result: {
@@ -685,7 +835,9 @@ export default {
         ],
       },
     })
-    const screenshots = new Bun.Glob('**/*.png').scanSync({ cwd: artifactDirectory })
+    const screenshots = new Bun.Glob('**/*.png').scanSync({
+      cwd: artifactDirectory,
+    })
     expect([...screenshots]).toHaveLength(3)
     expect(stdout).not.toContain('Stagehand')
     expect(stdout).not.toContain('gherkinDocument')

--- a/packages/cli/src/workspace.test.ts
+++ b/packages/cli/src/workspace.test.ts
@@ -20,7 +20,11 @@ describe('public CLI workspace seam', () => {
   }
   const validSpecification = {
     path: 'features/example.feature',
-    source: 'Feature: Example\n  Scenario: Validate project\n    Then validation succeeds',
+    source: `@pickle:id:specaaaaaaaaaaaa @pickle:state:active
+Feature: Example
+  @pickle:id:scnbbbbbbbbbbbb
+  Scenario: Validate project
+    Then validation succeeds`,
   }
 
   async function createCheckProject(name: string, fixture: CheckProjectFixture): Promise<string> {
@@ -52,7 +56,9 @@ describe('public CLI workspace seam', () => {
     pickleCommand = join(workspace, 'node_modules', '.bin', 'pickle')
     await mkdir(join(workspace, 'node_modules', '.bin'), { recursive: true })
     await symlink(resolve(packageDirectory, packageManifest.bin.pickle), pickleCommand)
-    await Bun.write(join(workspace, 'purchase.feature'), `Feature: Purchase
+    await Bun.write(join(workspace, 'purchase.feature'), `@pickle:id:specpurchaseaaaaaa @pickle:state:active
+Feature: Purchase
+  @pickle:id:scnpurchasebbbbbb
   Scenario: Complete a purchase
     Given a product is in the basket
     Then the purchase succeeds`)
@@ -152,7 +158,11 @@ export default {
   test('initializes a project without overwriting files and checks it without opening a session', async () => {
     const project = join(workspace, 'initialized-project')
     await mkdir(join(project, 'features'), { recursive: true })
-    await Bun.write(join(project, 'features', 'example.feature'), `Feature: Example\n  Scenario: Safe check\n    Then validation is offline`)
+    await Bun.write(join(project, 'features', 'example.feature'), `@pickle:id:specaaaaaaaaaaaa @pickle:state:active
+Feature: Example
+  @pickle:id:scnbbbbbbbbbbbb
+  Scenario: Safe check
+    Then validation is offline`)
 
     const first = Bun.spawnSync({ cmd: [pickleCommand, 'init'], cwd: project, env: { ...Bun.env } })
     expect(first.exitCode).toBe(0)
@@ -373,6 +383,123 @@ export default {}
     expect(checked.stderr.toString()).toContain('Correct the value and run pickle check again')
   })
 
+  test('migrate previews namespaced identifiers and writes only after confirmation', async () => {
+    const source = `# keep this comment
+
+@smoke
+Feature: Checkout
+  Scenario: Complete a purchase
+    Then the purchase succeeds
+`
+    const project = await createCheckProject('migrate-preview', {
+      config: defaultCheckConfig,
+      specification: { path: 'features/checkout.feature', source },
+    })
+    const featurePath = join(project, 'features', 'checkout.feature')
+
+    const preview = Bun.spawnSync({ cmd: [pickleCommand, 'migrate'], cwd: project, env: { ...Bun.env } })
+    expect(preview.exitCode).toBe(0)
+    expect(preview.stdout.toString()).toMatch(/Feature "Checkout": add @pickle:id:[0-9a-f]{16} @pickle:state:active/)
+    expect(preview.stdout.toString()).toMatch(/Scenario "Complete a purchase": add @pickle:id:[0-9a-f]{16}/)
+    expect(preview.stdout.toString()).toContain('Re-run pickle migrate --yes after reviewing the preview')
+    expect(await Bun.file(featurePath).text()).toBe(source)
+
+    const applied = Bun.spawnSync({ cmd: [pickleCommand, 'migrate', '--yes'], cwd: project, env: { ...Bun.env } })
+    expect(applied.exitCode).toBe(0)
+    expect(applied.stdout.toString()).toContain('Updated 1 Specification file(s)')
+    const migrated = await Bun.file(featurePath).text()
+    expect(migrated).toContain('# keep this comment')
+    expect(migrated).toContain('\n@smoke\n@pickle:id:')
+    expect(migrated).toContain('@pickle:state:active')
+    expect(migrated).toContain('Then the purchase succeeds')
+    for (const id of applied.stdout.toString().match(/@pickle:id:[0-9a-f]{16}/g) ?? []) {
+      expect(migrated).toContain(id)
+    }
+
+    const checked = runCheck(project)
+    expect(checked.exitCode).toBe(0)
+    expect(checked.stdout.toString()).toContain('Project is valid')
+
+    const again = Bun.spawnSync({ cmd: [pickleCommand, 'migrate', '--yes'], cwd: project, env: { ...Bun.env } })
+    expect(again.exitCode).toBe(0)
+    expect(again.stdout.toString()).toContain('No Specification metadata changes needed')
+    expect(await Bun.file(featurePath).text()).toBe(migrated)
+  })
+
+  test('check rejects missing Specification metadata without starting execution resources', async () => {
+    const project = await createCheckProject('missing-metadata', {
+      config: defaultCheckConfig,
+      specification: {
+        path: 'features/missing.feature',
+        source: 'Feature: Missing\n  Scenario: Needs identity\n    Then validation fails',
+      },
+    })
+
+    const checked = runCheck(project)
+
+    expect(checked.exitCode).toBe(2)
+    expect(checked.stderr.toString()).toContain('missing a durable identifier')
+    expect(checked.stderr.toString()).toContain('Run pickle migrate to add missing metadata')
+  })
+
+  test('check and run never modify Specification source', async () => {
+    const source = 'Feature: Unchanged\n  Scenario: Stay put\n    Then nothing writes'
+    const project = await createCheckProject('no-write', {
+      config: defaultCheckConfig,
+      specification: { path: 'features/unchanged.feature', source },
+    })
+    const featurePath = join(project, 'features', 'unchanged.feature')
+
+    const checked = runCheck(project)
+    expect(checked.exitCode).toBe(2)
+    expect(await Bun.file(featurePath).text()).toBe(source)
+
+    const purchasePath = join(workspace, 'purchase.feature')
+    const purchaseSource = await Bun.file(purchasePath).text()
+    const run = Bun.spawnSync({
+      cmd: [
+        pickleCommand,
+        'run',
+        'purchase.feature',
+        '--config',
+        'deterministic.config.jsonc',
+        '--extensions',
+        'pickle.extensions.ts',
+      ],
+      cwd: workspace,
+      env: { ...Bun.env, PICKLE_TEST_OUTCOME: 'passed' },
+    })
+    expect(run.exitCode).toBe(0)
+    expect(await Bun.file(purchasePath).text()).toBe(purchaseSource)
+  })
+
+  test('run reports missing Specification metadata without modifying source', async () => {
+    const source = `Feature: Unreported
+  Scenario: Still runs
+    Then the purchase succeeds`
+    const project = await createCheckProject('run-reports-metadata', {
+      config: {
+        schemaVersion: 1,
+        executionTargetProfile: { id: 'deterministic' },
+        specifications: 'features/**/*.feature',
+      },
+      specification: { path: 'features/unreported.feature', source },
+      extensions: await Bun.file(join(workspace, 'pickle.extensions.ts')).text(),
+    })
+    const featurePath = join(project, 'features', 'unreported.feature')
+
+    const run = Bun.spawnSync({
+      cmd: [pickleCommand, 'run'],
+      cwd: project,
+      env: { ...Bun.env, PICKLE_TEST_OUTCOME: 'passed' },
+    })
+
+    expect(run.exitCode).toBe(0)
+    expect(run.stderr.toString()).toContain('missing a durable identifier')
+    expect(run.stderr.toString()).toContain('Run pickle migrate to add missing metadata')
+    expect(await Bun.file(featurePath).text()).toBe(source)
+  })
+
   test('the deterministic adapter models every kernel outcome', async () => {
     const cases = [
       { outcome: 'passed', exitCode: 0 },
@@ -467,7 +594,9 @@ export default {}
   test('runs a real web Scenario through the public web adapter composition', async () => {
     const artifactDirectory = join(workspace, 'web-artifacts')
     const applicationUrl = 'data:text/html,<button id="search">Search</button><div id="results"></div>'
-    await Bun.write(join(workspace, 'web.feature'), `Feature: Web search
+    await Bun.write(join(workspace, 'web.feature'), `@pickle:id:specwebaaaaaaaaaa @pickle:state:active
+Feature: Web search
+  @pickle:id:scnwebbbbbbbbbbb
   Scenario: Search from the application
     Given I navigate to the main page
     When I search for pickles

--- a/packages/runner/index.ts
+++ b/packages/runner/index.ts
@@ -1,14 +1,18 @@
-export { runScenario } from './src/run-scenario'
-export { runScenarios } from './src/run-scenarios'
+export type {
+  ResolvedRunConfiguration,
+  RunConfiguration,
+  RunExtensionManifest,
+  RunExtensions,
+} from './src/configuration'
 export {
   resolveRunConfiguration,
   validateProjectRunConfiguration,
   validateRunConfiguration,
 } from './src/configuration'
 export type {
+  ExecutionPolicy,
   ExecutionTargetAdapter,
   ExecutionTargetProfile,
-  ExecutionPolicy,
   ExecutionTimeouts,
   OpenSessionInput,
   ResolvedAction,
@@ -21,10 +25,6 @@ export type {
   TestResult,
   TestResultState,
 } from './src/run-scenario'
+export { runScenario } from './src/run-scenario'
 export type { RunScenariosInput } from './src/run-scenarios'
-export type {
-  ResolvedRunConfiguration,
-  RunConfiguration,
-  RunExtensionManifest,
-  RunExtensions,
-} from './src/configuration'
+export { runScenarios } from './src/run-scenarios'

--- a/packages/runner/src/configuration.test.ts
+++ b/packages/runner/src/configuration.test.ts
@@ -1,33 +1,38 @@
 import { expect, test } from 'bun:test'
 import {
+  type ExecutionTargetAdapter,
   resolveRunConfiguration,
   validateProjectRunConfiguration,
   validateRunConfiguration,
-  type ExecutionTargetAdapter,
 } from '../index'
 
 const adapter: ExecutionTargetAdapter = {
   async openSession() {
     return {
-      async executeStep() { return { state: 'passed', resolvedActions: [] } },
+      async executeStep() {
+        return { state: 'passed', resolvedActions: [] }
+      },
       async close() {},
     }
   },
 }
 
 test('combines versioned configuration and extensions into validated runner input', () => {
-  const resolved = resolveRunConfiguration({
-    schemaVersion: 1,
-    executionTargetProfile: { id: 'configured-web' },
-    concurrency: 3,
-    execution: {
-      infrastructureRetries: 2,
-      scenarioTimeoutMs: 30_000,
-      stepTimeoutMs: 5_000,
+  const resolved = resolveRunConfiguration(
+    {
+      schemaVersion: 1,
+      executionTargetProfile: { id: 'configured-web' },
+      concurrency: 3,
+      execution: {
+        infrastructureRetries: 2,
+        scenarioTimeoutMs: 30_000,
+        stepTimeoutMs: 5_000,
+      },
     },
-  }, {
-    adapter,
-  })
+    {
+      adapter,
+    },
+  )
 
   expect(resolved).toEqual({
     adapter,
@@ -39,18 +44,27 @@ test('combines versioned configuration and extensions into validated runner inpu
 })
 
 test('rejects an unsupported configuration schema before execution', () => {
-  expect(() => resolveRunConfiguration({
-    schemaVersion: 2 as 1,
-    executionTargetProfile: { id: 'web' },
-  }, { adapter })).toThrow('Unsupported configuration schemaVersion: 2')
+  expect(() =>
+    resolveRunConfiguration(
+      {
+        schemaVersion: 2 as 1,
+        executionTargetProfile: { id: 'web' },
+      },
+      { adapter },
+    ),
+  ).toThrow('Unsupported configuration schemaVersion: 2')
 })
 
 test('validates run policies without requiring an execution adapter', () => {
-  expect(() => validateRunConfiguration({
-    schemaVersion: 1,
-    executionTargetProfile: { id: 'web' },
-    execution: { scenarioTimeoutMs: 0 },
-  })).toThrow('execution.scenarioTimeoutMs must be an integer greater than or equal to 1')
+  expect(() =>
+    validateRunConfiguration({
+      schemaVersion: 1,
+      executionTargetProfile: { id: 'web' },
+      execution: { scenarioTimeoutMs: 0 },
+    }),
+  ).toThrow(
+    'execution.scenarioTimeoutMs must be an integer greater than or equal to 1',
+  )
 })
 
 test('combines project configuration with the extension manifest before execution', () => {
@@ -59,18 +73,24 @@ test('combines project configuration with the extension manifest before executio
     executionTargetProfile: { id: 'custom' },
   }
 
-  expect(validateProjectRunConfiguration(configuration, {
-    adapterAvailable: true,
-    fallbackAdapterAvailable: false,
-  }))
-    .toEqual(configuration)
-  expect(validateProjectRunConfiguration(configuration, {
-    adapterAvailable: false,
-    fallbackAdapterAvailable: true,
-  }))
-    .toEqual(configuration)
-  expect(() => validateProjectRunConfiguration(configuration, {
-    adapterAvailable: false,
-    fallbackAdapterAvailable: false,
-  })).toThrow('Configure web.baseUrl or export an adapter from pickle.extensions.ts')
+  expect(
+    validateProjectRunConfiguration(configuration, {
+      adapterAvailable: true,
+      fallbackAdapterAvailable: false,
+    }),
+  ).toEqual(configuration)
+  expect(
+    validateProjectRunConfiguration(configuration, {
+      adapterAvailable: false,
+      fallbackAdapterAvailable: true,
+    }),
+  ).toEqual(configuration)
+  expect(() =>
+    validateProjectRunConfiguration(configuration, {
+      adapterAvailable: false,
+      fallbackAdapterAvailable: false,
+    }),
+  ).toThrow(
+    'Configure web.baseUrl or export an adapter from pickle.extensions.ts',
+  )
 })

--- a/packages/runner/src/configuration.ts
+++ b/packages/runner/src/configuration.ts
@@ -37,14 +37,22 @@ function record(value: unknown, field: string): Record<string, unknown> {
   return value as Record<string, unknown>
 }
 
-function knownFields(value: Record<string, unknown>, fields: readonly string[], parent: string): void {
+function knownFields(
+  value: Record<string, unknown>,
+  fields: readonly string[],
+  parent: string,
+): void {
   for (const field of Object.keys(value)) {
-    if (!fields.includes(field)) throw new Error(`${parent}.${field} is not supported`)
+    if (!fields.includes(field))
+      throw new Error(`${parent}.${field} is not supported`)
   }
 }
 
 function positiveInteger(value: unknown, field: string): void {
-  if (value !== undefined && (!Number.isInteger(value) || (value as number) < 1)) {
+  if (
+    value !== undefined &&
+    (!Number.isInteger(value) || (value as number) < 1)
+  ) {
     throw new Error(`${field} must be an integer greater than or equal to 1`)
   }
 }
@@ -59,24 +67,35 @@ function validateExecutionTargetProfile(value: unknown): void {
 
 export function validateRunConfiguration(value: unknown): RunConfiguration {
   const configuration = record(value, 'run configuration')
-  knownFields(configuration, [
-    'schemaVersion', 'executionTargetProfile', 'concurrency', 'execution',
-  ], 'run configuration')
+  knownFields(
+    configuration,
+    ['schemaVersion', 'executionTargetProfile', 'concurrency', 'execution'],
+    'run configuration',
+  )
   if (configuration.schemaVersion !== 1) {
-    throw new Error(`Unsupported configuration schemaVersion: ${String(configuration.schemaVersion)}`)
+    throw new Error(
+      `Unsupported configuration schemaVersion: ${String(configuration.schemaVersion)}`,
+    )
   }
   validateExecutionTargetProfile(configuration.executionTargetProfile)
   positiveInteger(configuration.concurrency, 'concurrency')
   if (configuration.execution !== undefined) {
     const execution = record(configuration.execution, 'execution')
-    knownFields(execution, [
-      'infrastructureRetries', 'scenarioTimeoutMs', 'stepTimeoutMs',
-    ], 'execution')
+    knownFields(
+      execution,
+      ['infrastructureRetries', 'scenarioTimeoutMs', 'stepTimeoutMs'],
+      'execution',
+    )
     positiveInteger(execution.scenarioTimeoutMs, 'execution.scenarioTimeoutMs')
     positiveInteger(execution.stepTimeoutMs, 'execution.stepTimeoutMs')
     const retries = execution.infrastructureRetries
-    if (retries !== undefined && (!Number.isInteger(retries) || (retries as number) < 0)) {
-      throw new Error('execution.infrastructureRetries must be a non-negative integer')
+    if (
+      retries !== undefined &&
+      (!Number.isInteger(retries) || (retries as number) < 0)
+    ) {
+      throw new Error(
+        'execution.infrastructureRetries must be a non-negative integer',
+      )
     }
   }
   return configuration as unknown as RunConfiguration
@@ -89,8 +108,8 @@ export function validateProjectRunConfiguration(
   const validatedConfiguration = validateRunConfiguration(configuration)
   if (!extensions.adapterAvailable && !extensions.fallbackAdapterAvailable) {
     throw new Error(
-      'No execution target is configured. '
-      + 'Configure web.baseUrl or export an adapter from pickle.extensions.ts.',
+      'No execution target is configured. ' +
+        'Configure web.baseUrl or export an adapter from pickle.extensions.ts.',
     )
   }
   return validatedConfiguration
@@ -101,8 +120,11 @@ export function resolveRunConfiguration(
   extensions: RunExtensions,
 ): ResolvedRunConfiguration {
   const validatedConfiguration = validateRunConfiguration(configuration)
-  if (typeof extensions.adapter !== 'object' || extensions.adapter === null
-    || typeof extensions.adapter.openSession !== 'function') {
+  if (
+    typeof extensions.adapter !== 'object' ||
+    extensions.adapter === null ||
+    typeof extensions.adapter.openSession !== 'function'
+  ) {
     throw new Error('extensions.adapter must provide openSession')
   }
   const retries = validatedConfiguration.execution?.infrastructureRetries

--- a/packages/runner/src/run-scenario.test.ts
+++ b/packages/runner/src/run-scenario.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, mock, test } from 'bun:test'
 import type { Scenario, Specification } from '@pickle-spec/spec'
-import { runScenario, type ExecutionTargetAdapter } from '../index'
+import { type ExecutionTargetAdapter, runScenario } from '../index'
 
 const scenario: Scenario = {
   name: 'Complete a purchase',
@@ -42,7 +42,13 @@ describe('runScenario', () => {
       adapter,
     })
 
-    expect(run.events.map(event => [event.schemaVersion, event.sequence, event.type])).toEqual([
+    expect(
+      run.events.map((event) => [
+        event.schemaVersion,
+        event.sequence,
+        event.type,
+      ]),
+    ).toEqual([
       [1, 1, 'scenario-started'],
       [1, 2, 'step-started'],
       [1, 3, 'step-finished'],
@@ -61,14 +67,26 @@ describe('runScenario', () => {
       state: 'passed',
       steps: [
         {
-          step: { keyword: 'Given', text: 'a product is in the basket', type: 'context' },
+          step: {
+            keyword: 'Given',
+            text: 'a product is in the basket',
+            type: 'context',
+          },
           state: 'passed',
-          resolvedActions: [{ description: 'Performed: a product is in the basket' }],
+          resolvedActions: [
+            { description: 'Performed: a product is in the basket' },
+          ],
         },
         {
-          step: { keyword: 'Then', text: 'the purchase succeeds', type: 'outcome' },
+          step: {
+            keyword: 'Then',
+            text: 'the purchase succeeds',
+            type: 'outcome',
+          },
           state: 'passed',
-          resolvedActions: [{ description: 'Performed: the purchase succeeds' }],
+          resolvedActions: [
+            { description: 'Performed: the purchase succeeds' },
+          ],
         },
       ],
     })
@@ -126,7 +144,7 @@ describe('runScenario', () => {
       steps: [],
       message: 'Scenario cancelled before the logical session started',
     })
-    expect(run.events.map(event => event.type)).toEqual([
+    expect(run.events.map((event) => event.type)).toEqual([
       'scenario-started',
       'scenario-finished',
     ])
@@ -148,7 +166,9 @@ describe('runScenario', () => {
               controller.abort()
               return {
                 state: 'passed',
-                resolvedActions: [{ description: 'Completed after cancellation' }],
+                resolvedActions: [
+                  { description: 'Completed after cancellation' },
+                ],
               }
             },
             close,
@@ -163,7 +183,7 @@ describe('runScenario', () => {
       message: 'Scenario cancelled during step execution',
       steps: [{ state: 'cancelled' }],
     })
-    expect(run.events.map(event => event.type)).toEqual([
+    expect(run.events.map((event) => event.type)).toEqual([
       'scenario-started',
       'step-started',
       'step-finished',
@@ -191,7 +211,7 @@ describe('runScenario', () => {
       steps: [],
       message: 'Execution target is unavailable',
     })
-    expect(run.events.map(event => event.type)).toEqual([
+    expect(run.events.map((event) => event.type)).toEqual([
       'scenario-started',
       'scenario-finished',
     ])
@@ -209,8 +229,13 @@ describe('runScenario', () => {
             async executeStep() {
               step += 1
               return {
-                state: step === 1 ? 'passed-with-adaptation' as const : 'passed' as const,
-                resolvedActions: [{ description: 'Completed deterministic action' }],
+                state:
+                  step === 1
+                    ? ('passed-with-adaptation' as const)
+                    : ('passed' as const),
+                resolvedActions: [
+                  { description: 'Completed deterministic action' },
+                ],
               }
             },
             async close() {},
@@ -244,9 +269,14 @@ describe('runScenario', () => {
     expect(run.result).toMatchObject({
       state: 'infrastructure-error',
       message: 'Target connection was lost',
-      steps: [{ state: 'infrastructure-error', message: 'Target connection was lost' }],
+      steps: [
+        {
+          state: 'infrastructure-error',
+          message: 'Target connection was lost',
+        },
+      ],
     })
-    expect(run.events.map(event => event.type)).toEqual([
+    expect(run.events.map((event) => event.type)).toEqual([
       'scenario-started',
       'step-started',
       'step-finished',
@@ -325,10 +355,14 @@ describe('runScenario', () => {
         async openSession() {
           return {
             async executeStep(_step, signal) {
-              await new Promise((resolve, reject) => {
-                signal?.addEventListener('abort', () => reject(new DOMException('Aborted', 'AbortError')), {
-                  once: true,
-                })
+              await new Promise((_resolve, reject) => {
+                signal?.addEventListener(
+                  'abort',
+                  () => reject(new DOMException('Aborted', 'AbortError')),
+                  {
+                    once: true,
+                  },
+                )
               })
               return { state: 'passed', resolvedActions: [] }
             },

--- a/packages/runner/src/run-scenario.ts
+++ b/packages/runner/src/run-scenario.ts
@@ -124,7 +124,10 @@ function errorMessage(error: unknown): string {
 }
 
 function isCancellation(error: unknown, signal?: AbortSignal): boolean {
-  return Boolean(signal?.aborted) || (error instanceof Error && error.name === 'AbortError')
+  return (
+    Boolean(signal?.aborted) ||
+    (error instanceof Error && error.name === 'AbortError')
+  )
 }
 
 function executeWithDeadline<T>(
@@ -146,10 +149,12 @@ function executeWithDeadline<T>(
       controller.abort()
       reject(new ExecutionDeadlineError(timeoutMessage))
     }, timeoutMs)
-    operation(controller.signal).then(resolve, reject).finally(() => {
-      clearTimeout(timer)
-      signal?.removeEventListener('abort', onAbort)
-    })
+    operation(controller.signal)
+      .then(resolve, reject)
+      .finally(() => {
+        clearTimeout(timer)
+        signal?.removeEventListener('abort', onAbort)
+      })
   })
 }
 
@@ -173,7 +178,9 @@ function createTestResult(
   }
 }
 
-async function runScenarioAttempt(input: RunScenarioInput): Promise<ScenarioRun> {
+async function runScenarioAttempt(
+  input: RunScenarioInput,
+): Promise<ScenarioRun> {
   const scenarioStartedAt = Date.now()
   const events: RunEvent[] = []
   let sequence = 0
@@ -193,7 +200,12 @@ async function runScenarioAttempt(input: RunScenarioInput): Promise<ScenarioRun>
   })
 
   if (input.scenario.tags.includes('@ignore')) {
-    const result = createTestResult(input, 'skipped', [], 'Scenario is tagged @ignore')
+    const result = createTestResult(
+      input,
+      'skipped',
+      [],
+      'Scenario is tagged @ignore',
+    )
     await emit({ type: 'scenario-finished', result })
     return { events, result }
   }
@@ -220,7 +232,9 @@ async function runScenarioAttempt(input: RunScenarioInput): Promise<ScenarioRun>
   } catch (error) {
     const result = createTestResult(
       input,
-      isCancellation(error, input.signal) ? 'cancelled' : 'infrastructure-error',
+      isCancellation(error, input.signal)
+        ? 'cancelled'
+        : 'infrastructure-error',
       [],
       errorMessage(error),
     )
@@ -244,23 +258,30 @@ async function runScenarioAttempt(input: RunScenarioInput): Promise<ScenarioRun>
       await emit({ type: 'step-started', step })
       let execution: StepExecution
       try {
-        const scenarioRemaining = input.timeout?.scenarioMs === undefined
-          ? undefined
-          : input.timeout.scenarioMs - (Date.now() - scenarioStartedAt)
-        const usesScenarioDeadline = scenarioRemaining !== undefined
-          && (input.timeout?.stepMs === undefined || scenarioRemaining <= input.timeout.stepMs)
-        const timeoutMs = usesScenarioDeadline ? Math.max(0, scenarioRemaining) : input.timeout?.stepMs
+        const scenarioRemaining =
+          input.timeout?.scenarioMs === undefined
+            ? undefined
+            : input.timeout.scenarioMs - (Date.now() - scenarioStartedAt)
+        const usesScenarioDeadline =
+          scenarioRemaining !== undefined &&
+          (input.timeout?.stepMs === undefined ||
+            scenarioRemaining <= input.timeout.stepMs)
+        const timeoutMs = usesScenarioDeadline
+          ? Math.max(0, scenarioRemaining)
+          : input.timeout?.stepMs
         const timeoutMessage = usesScenarioDeadline
           ? `Scenario exceeded its ${input.timeout?.scenarioMs}ms deadline`
           : `Step exceeded its ${input.timeout?.stepMs}ms deadline`
         execution = await executeWithDeadline(
-          operationSignal => session.executeStep(step, operationSignal),
+          (operationSignal) => session.executeStep(step, operationSignal),
           input.signal,
           timeoutMs,
           timeoutMessage,
         )
       } catch (error) {
-        state = isCancellation(error, input.signal) ? 'cancelled' : 'infrastructure-error'
+        state = isCancellation(error, input.signal)
+          ? 'cancelled'
+          : 'infrastructure-error'
         message = errorMessage(error)
         const result: TestStepResult = {
           step,
@@ -292,7 +313,9 @@ async function runScenarioAttempt(input: RunScenarioInput): Promise<ScenarioRun>
         state: execution.state,
         resolvedActions: execution.resolvedActions,
         ...(execution.message ? { message: execution.message } : {}),
-        ...(execution.artifacts?.length ? { artifacts: execution.artifacts } : {}),
+        ...(execution.artifacts?.length
+          ? { artifacts: execution.artifacts }
+          : {}),
       }
       steps.push(result)
       await emit({ type: 'step-finished', result })
@@ -324,29 +347,41 @@ async function runScenarioAttempt(input: RunScenarioInput): Promise<ScenarioRun>
   return { events, result }
 }
 
-export async function runScenario(input: RunScenarioInput): Promise<ScenarioRun> {
+export async function runScenario(
+  input: RunScenarioInput,
+): Promise<ScenarioRun> {
   const events: RunEvent[] = []
   const maximumAttempts = (input.retry?.infrastructureErrors ?? 0) + 1
 
   for (let attempt = 1; attempt <= maximumAttempts; attempt++) {
-    const run = await runScenarioAttempt({ ...input, onEvent: undefined, retry: undefined })
-    const shouldRetry = run.result.state === 'infrastructure-error'
-      && attempt < maximumAttempts
-      && !input.signal?.aborted
+    const run = await runScenarioAttempt({
+      ...input,
+      onEvent: undefined,
+      retry: undefined,
+    })
+    const shouldRetry =
+      run.result.state === 'infrastructure-error' &&
+      attempt < maximumAttempts &&
+      !input.signal?.aborted
 
-    const result: TestResult = attempt === 1
-      ? run.result
-      : {
-          ...run.result,
-          attempts: attempt,
-          flaky: run.result.state === 'passed' || run.result.state === 'passed-with-adaptation',
-        }
+    const result: TestResult =
+      attempt === 1
+        ? run.result
+        : {
+            ...run.result,
+            attempts: attempt,
+            flaky:
+              run.result.state === 'passed' ||
+              run.result.state === 'passed-with-adaptation',
+          }
 
     for (const event of run.events) {
       const versionedEvent = {
         ...event,
         sequence: events.length + 1,
-        ...(event.type === 'scenario-finished' && !shouldRetry ? { result } : {}),
+        ...(event.type === 'scenario-finished' && !shouldRetry
+          ? { result }
+          : {}),
       } as RunEvent
       events.push(versionedEvent)
       await input.onEvent?.(versionedEvent)

--- a/packages/runner/src/run-scenarios.test.ts
+++ b/packages/runner/src/run-scenarios.test.ts
@@ -1,23 +1,31 @@
 import { expect, mock, test } from 'bun:test'
 import type { ScenarioSelection } from '@pickle-spec/spec'
-import { runScenarios, type ExecutionTargetAdapter } from '../index'
+import { type ExecutionTargetAdapter, runScenarios } from '../index'
 
-const selections: ScenarioSelection[] = ['First', 'Ignored', 'Third'].map((name, index) => {
-  const scenario = {
-    name,
-    tags: index === 1 ? ['@ignore'] : [],
-    steps: [{ keyword: 'Then', text: `${name} completes`, type: 'outcome' as const }],
-  }
-  return {
-    specification: {
-      name: 'Scheduling',
-      source: { uri: 'features/scheduling.feature', language: 'en' },
-      tags: [],
-      scenarios: [scenario],
-    },
-    scenario,
-  }
-})
+const selections: ScenarioSelection[] = ['First', 'Ignored', 'Third'].map(
+  (name, index) => {
+    const scenario = {
+      name,
+      tags: index === 1 ? ['@ignore'] : [],
+      steps: [
+        {
+          keyword: 'Then',
+          text: `${name} completes`,
+          type: 'outcome' as const,
+        },
+      ],
+    }
+    return {
+      specification: {
+        name: 'Scheduling',
+        source: { uri: 'features/scheduling.feature', language: 'en' },
+        tags: [],
+        scenarios: [scenario],
+      },
+      scenario,
+    }
+  },
+)
 
 test('runs selected Scenarios concurrently while preserving stable test-result order', async () => {
   let active = 0
@@ -30,7 +38,9 @@ test('runs selected Scenarios concurrently while preserving stable test-result o
         await Bun.sleep(step.text.startsWith('First') ? 20 : 1)
         return { state: 'passed' as const, resolvedActions: [] }
       },
-      async close() { active-- },
+      async close() {
+        active--
+      },
     }
   })
   const adapter: ExecutionTargetAdapter = { openSession }
@@ -42,7 +52,9 @@ test('runs selected Scenarios concurrently while preserving stable test-result o
     concurrency: 2,
   })
 
-  expect(runs.map(run => [run.result.scenario.name, run.result.state])).toEqual([
+  expect(
+    runs.map((run) => [run.result.scenario.name, run.result.state]),
+  ).toEqual([
     ['First', 'passed'],
     ['Ignored', 'skipped'],
     ['Third', 'passed'],
@@ -57,14 +69,21 @@ test('rejects a target that lacks a Scenario capability requirement before openi
   })
   const selection = selections[0]!
 
-  await expect(runScenarios({
-    selections: [{
-      ...selection,
-      scenario: { ...selection.scenario, capabilityRequirements: ['geolocation'] },
-    }],
-    executionTargetProfile: { id: 'web' },
-    adapter: { capabilities: ['screenshots'], openSession },
-  })).rejects.toThrow(
+  await expect(
+    runScenarios({
+      selections: [
+        {
+          ...selection,
+          scenario: {
+            ...selection.scenario,
+            capabilityRequirements: ['geolocation'],
+          },
+        },
+      ],
+      executionTargetProfile: { id: 'web' },
+      adapter: { capabilities: ['screenshots'], openSession },
+    }),
+  ).rejects.toThrow(
     'Execution target profile "web" lacks required capabilities for Scenario "First": geolocation',
   )
   expect(openSession).not.toHaveBeenCalled()

--- a/packages/runner/src/run-scenarios.ts
+++ b/packages/runner/src/run-scenarios.ts
@@ -1,10 +1,10 @@
 import type { ScenarioSelection } from '@pickle-spec/spec'
 import {
-  runScenario,
+  type ExecutionPolicy,
   type ExecutionTargetAdapter,
   type ExecutionTargetProfile,
-  type ExecutionPolicy,
   type RunEvent,
+  runScenario,
   type ScenarioRun,
 } from './run-scenario'
 
@@ -20,7 +20,9 @@ export interface RunScenariosInput extends ExecutionPolicy {
   ) => void | Promise<void>
 }
 
-export async function runScenarios(input: RunScenariosInput): Promise<ScenarioRun[]> {
+export async function runScenarios(
+  input: RunScenariosInput,
+): Promise<ScenarioRun[]> {
   const concurrency = input.concurrency ?? 1
   if (!Number.isInteger(concurrency) || concurrency < 1) {
     throw new Error('concurrency must be an integer greater than or equal to 1')
@@ -28,8 +30,9 @@ export async function runScenarios(input: RunScenariosInput): Promise<ScenarioRu
 
   const capabilities = new Set(input.adapter.capabilities ?? [])
   for (const { scenario } of input.selections) {
-    const missing = (scenario.capabilityRequirements ?? [])
-      .filter(requirement => !capabilities.has(requirement))
+    const missing = (scenario.capabilityRequirements ?? []).filter(
+      (requirement) => !capabilities.has(requirement),
+    )
     if (missing.length > 0) {
       throw new Error(
         `Execution target profile "${input.executionTargetProfile.id}" lacks required capabilities ` +
@@ -55,7 +58,7 @@ export async function runScenarios(input: RunScenariosInput): Promise<ScenarioRu
         retry: input.retry,
         timeout: input.timeout,
         onEvent: input.onEvent
-          ? event => input.onEvent!(event, selection)
+          ? (event) => input.onEvent!(event, selection)
           : undefined,
       })
     }

--- a/packages/spec/index.ts
+++ b/packages/spec/index.ts
@@ -1,5 +1,10 @@
 export { parseSpecification, parseSpecificationFile } from './src/specification'
 export { selectScenarios, validateSelectionOptions } from './src/selection'
+export {
+  formatMigrationPreview,
+  planSpecificationMigration,
+  validateSpecificationMetadata,
+} from './src/identity'
 export type {
   ParseSpecificationInput,
   Scenario,
@@ -7,6 +12,13 @@ export type {
   Specification,
   SpecificationSource,
 } from './src/specification'
+export type {
+  SpecificationMigrationChange,
+  SpecificationMigrationFile,
+  SpecificationMigrationPlan,
+  SpecificationSourceFile,
+  SpecificationState,
+} from './src/identity'
 export type {
   ScenarioSelection,
   SelectionOptions,

--- a/packages/spec/index.ts
+++ b/packages/spec/index.ts
@@ -1,17 +1,3 @@
-export { parseSpecification, parseSpecificationFile } from './src/specification'
-export { selectScenarios, validateSelectionOptions } from './src/selection'
-export {
-  formatMigrationPreview,
-  planSpecificationMigration,
-  validateSpecificationMetadata,
-} from './src/identity'
-export type {
-  ParseSpecificationInput,
-  Scenario,
-  ScenarioStep,
-  Specification,
-  SpecificationSource,
-} from './src/specification'
 export type {
   SpecificationMigrationChange,
   SpecificationMigrationFile,
@@ -19,8 +5,22 @@ export type {
   SpecificationSourceFile,
   SpecificationState,
 } from './src/identity'
+export {
+  formatMigrationPreview,
+  planSpecificationMigration,
+  validateSpecificationMetadata,
+} from './src/identity'
 export type {
   ScenarioSelection,
   SelectionOptions,
   Shard,
 } from './src/selection'
+export { selectScenarios, validateSelectionOptions } from './src/selection'
+export type {
+  ParseSpecificationInput,
+  Scenario,
+  ScenarioStep,
+  Specification,
+  SpecificationSource,
+} from './src/specification'
+export { parseSpecification, parseSpecificationFile } from './src/specification'

--- a/packages/spec/src/identity.test.ts
+++ b/packages/spec/src/identity.test.ts
@@ -1,0 +1,140 @@
+import { describe, expect, test } from 'bun:test'
+import {
+  formatMigrationPreview,
+  planSpecificationMigration,
+  validateSpecificationMetadata,
+} from '../index'
+
+const checkoutSource = `# keep this comment
+
+@smoke
+Feature: Checkout
+
+  # scenario comment
+  Scenario: Complete a purchase
+    Given a product is in the basket
+    Then the purchase succeeds
+
+  Scenario Outline: Pay
+    When the customer pays with <method>
+    Then the payment succeeds
+
+    Examples: Payment methods
+      | method |
+      | card   |
+      | cash   |
+`
+
+describe('planSpecificationMigration', () => {
+  test('previews namespaced identifiers and lifecycle tags without rewriting unrelated source', () => {
+    const plan = planSpecificationMigration([
+      { uri: 'features/checkout.feature', source: checkoutSource },
+    ])
+    const preview = formatMigrationPreview(plan)
+
+    expect(preview).toContain('features/checkout.feature')
+    expect(preview).toMatch(/Feature "Checkout": add @pickle:id:[0-9a-f]{16} @pickle:state:active/)
+    expect(preview).toMatch(/Scenario "Complete a purchase": add @pickle:id:[0-9a-f]{16}/)
+    expect(preview).toMatch(/Scenario "Pay": add @pickle:id:[0-9a-f]{16}/)
+    expect(preview).toMatch(/Examples "Payment methods": add @pickle:id:[0-9a-f]{16}/)
+    expect(preview).toMatch(/Examples row 1: add pickle_id [0-9a-f]{16}/)
+    expect(preview).toMatch(/Examples row 2: add pickle_id [0-9a-f]{16}/)
+
+    const nextSource = plan.files[0]?.nextSource ?? ''
+    expect(nextSource).toContain('# keep this comment')
+    expect(nextSource).toContain('  # scenario comment')
+    expect(nextSource).toContain('\n@smoke\n@pickle:id:')
+    expect(nextSource).toContain('@pickle:state:active')
+    expect(nextSource).toContain('| pickle_id | method |')
+    expect(nextSource).toContain('| card   |')
+    expect(nextSource).toContain('| cash   |')
+    expect(plan.files[0]?.source).toBe(checkoutSource)
+  })
+
+  test('keeps existing identifiers and only fills missing metadata', () => {
+    const source = `@pickle:id:specaaaaaaaaaaaa @pickle:state:draft
+Feature: Checkout
+  @pickle:id:scnbbbbbbbbbbbb
+  Scenario: Complete a purchase
+    Then the purchase succeeds
+`
+
+    const plan = planSpecificationMigration([{ uri: 'features/checkout.feature', source }])
+
+    expect(plan.changes).toEqual([])
+    expect(plan.files[0]?.nextSource).toBe(source)
+  })
+})
+
+describe('validateSpecificationMetadata', () => {
+  test('accepts complete unique metadata', () => {
+    expect(() => validateSpecificationMetadata([
+      {
+        uri: 'features/checkout.feature',
+        source: `@pickle:id:specaaaaaaaaaaaa @pickle:state:active
+Feature: Checkout
+  @pickle:id:scnbbbbbbbbbbbb
+  Scenario: Complete a purchase
+    Then the purchase succeeds
+`,
+      },
+    ])).not.toThrow()
+  })
+
+  test('rejects missing, duplicate, malformed, and conflicting metadata', () => {
+    expect(() => validateSpecificationMetadata([
+      {
+        uri: 'features/missing.feature',
+        source: `Feature: Missing
+  Scenario: Needs identity
+    Then validation fails
+`,
+      },
+    ])).toThrow(/missing a durable identifier/)
+
+    expect(() => validateSpecificationMetadata([
+      {
+        uri: 'features/a.feature',
+        source: `@pickle:id:duplicateduplicate @pickle:state:active
+Feature: First
+  @pickle:id:scncccccccccccccccc
+  Scenario: One
+    Then it works
+`,
+      },
+      {
+        uri: 'features/b.feature',
+        source: `@pickle:id:duplicateduplicate @pickle:state:draft
+Feature: Second
+  @pickle:id:scnddddddddddddddd
+  Scenario: Two
+    Then it works
+`,
+      },
+    ])).toThrow(/Duplicate identifier "duplicateduplicate"/)
+
+    expect(() => validateSpecificationMetadata([
+      {
+        uri: 'features/malformed.feature',
+        source: `@pickle:id:bad.value @pickle:state:active
+Feature: Malformed
+  @pickle:id:scneeeeeeeeeeeeeee
+  Scenario: One
+    Then it works
+`,
+      },
+    ])).toThrow(/malformed durable identifier/)
+
+    expect(() => validateSpecificationMetadata([
+      {
+        uri: 'features/conflict.feature',
+        source: `@pickle:id:specffffffffffffffff @pickle:state:draft @pickle:state:active
+Feature: Conflict
+  @pickle:id:scnffffffffffffffff
+  Scenario: One
+    Then it works
+`,
+      },
+    ])).toThrow(/conflicting Specification states/)
+  })
+})

--- a/packages/spec/src/identity.test.ts
+++ b/packages/spec/src/identity.test.ts
@@ -33,10 +33,16 @@ describe('planSpecificationMigration', () => {
     const preview = formatMigrationPreview(plan)
 
     expect(preview).toContain('features/checkout.feature')
-    expect(preview).toMatch(/Feature "Checkout": add @pickle:id:[0-9a-f]{16} @pickle:state:active/)
-    expect(preview).toMatch(/Scenario "Complete a purchase": add @pickle:id:[0-9a-f]{16}/)
+    expect(preview).toMatch(
+      /Feature "Checkout": add @pickle:id:[0-9a-f]{16} @pickle:state:active/,
+    )
+    expect(preview).toMatch(
+      /Scenario "Complete a purchase": add @pickle:id:[0-9a-f]{16}/,
+    )
     expect(preview).toMatch(/Scenario "Pay": add @pickle:id:[0-9a-f]{16}/)
-    expect(preview).toMatch(/Examples "Payment methods": add @pickle:id:[0-9a-f]{16}/)
+    expect(preview).toMatch(
+      /Examples "Payment methods": add @pickle:id:[0-9a-f]{16}/,
+    )
     expect(preview).toMatch(/Examples row 1: add pickle_id [0-9a-f]{16}/)
     expect(preview).toMatch(/Examples row 2: add pickle_id [0-9a-f]{16}/)
 
@@ -59,7 +65,9 @@ Feature: Checkout
     Then the purchase succeeds
 `
 
-    const plan = planSpecificationMigration([{ uri: 'features/checkout.feature', source }])
+    const plan = planSpecificationMigration([
+      { uri: 'features/checkout.feature', source },
+    ])
 
     expect(plan.changes).toEqual([])
     expect(plan.files[0]?.nextSource).toBe(source)
@@ -68,73 +76,83 @@ Feature: Checkout
 
 describe('validateSpecificationMetadata', () => {
   test('accepts complete unique metadata', () => {
-    expect(() => validateSpecificationMetadata([
-      {
-        uri: 'features/checkout.feature',
-        source: `@pickle:id:specaaaaaaaaaaaa @pickle:state:active
+    expect(() =>
+      validateSpecificationMetadata([
+        {
+          uri: 'features/checkout.feature',
+          source: `@pickle:id:specaaaaaaaaaaaa @pickle:state:active
 Feature: Checkout
   @pickle:id:scnbbbbbbbbbbbb
   Scenario: Complete a purchase
     Then the purchase succeeds
 `,
-      },
-    ])).not.toThrow()
+        },
+      ]),
+    ).not.toThrow()
   })
 
   test('rejects missing, duplicate, malformed, and conflicting metadata', () => {
-    expect(() => validateSpecificationMetadata([
-      {
-        uri: 'features/missing.feature',
-        source: `Feature: Missing
+    expect(() =>
+      validateSpecificationMetadata([
+        {
+          uri: 'features/missing.feature',
+          source: `Feature: Missing
   Scenario: Needs identity
     Then validation fails
 `,
-      },
-    ])).toThrow(/missing a durable identifier/)
+        },
+      ]),
+    ).toThrow(/missing a durable identifier/)
 
-    expect(() => validateSpecificationMetadata([
-      {
-        uri: 'features/a.feature',
-        source: `@pickle:id:duplicateduplicate @pickle:state:active
+    expect(() =>
+      validateSpecificationMetadata([
+        {
+          uri: 'features/a.feature',
+          source: `@pickle:id:duplicateduplicate @pickle:state:active
 Feature: First
   @pickle:id:scncccccccccccccccc
   Scenario: One
     Then it works
 `,
-      },
-      {
-        uri: 'features/b.feature',
-        source: `@pickle:id:duplicateduplicate @pickle:state:draft
+        },
+        {
+          uri: 'features/b.feature',
+          source: `@pickle:id:duplicateduplicate @pickle:state:draft
 Feature: Second
   @pickle:id:scnddddddddddddddd
   Scenario: Two
     Then it works
 `,
-      },
-    ])).toThrow(/Duplicate identifier "duplicateduplicate"/)
+        },
+      ]),
+    ).toThrow(/Duplicate identifier "duplicateduplicate"/)
 
-    expect(() => validateSpecificationMetadata([
-      {
-        uri: 'features/malformed.feature',
-        source: `@pickle:id:bad.value @pickle:state:active
+    expect(() =>
+      validateSpecificationMetadata([
+        {
+          uri: 'features/malformed.feature',
+          source: `@pickle:id:bad.value @pickle:state:active
 Feature: Malformed
   @pickle:id:scneeeeeeeeeeeeeee
   Scenario: One
     Then it works
 `,
-      },
-    ])).toThrow(/malformed durable identifier/)
+        },
+      ]),
+    ).toThrow(/malformed durable identifier/)
 
-    expect(() => validateSpecificationMetadata([
-      {
-        uri: 'features/conflict.feature',
-        source: `@pickle:id:specffffffffffffffff @pickle:state:draft @pickle:state:active
+    expect(() =>
+      validateSpecificationMetadata([
+        {
+          uri: 'features/conflict.feature',
+          source: `@pickle:id:specffffffffffffffff @pickle:state:draft @pickle:state:active
 Feature: Conflict
   @pickle:id:scnffffffffffffffff
   Scenario: One
     Then it works
 `,
-      },
-    ])).toThrow(/conflicting Specification states/)
+        },
+      ]),
+    ).toThrow(/conflicting Specification states/)
   })
 })

--- a/packages/spec/src/identity.ts
+++ b/packages/spec/src/identity.ts
@@ -1,0 +1,413 @@
+import { AstBuilder, GherkinClassicTokenMatcher, Parser } from '@cucumber/gherkin'
+import { IdGenerator } from '@cucumber/messages'
+import type {
+  Examples,
+  Feature,
+  FeatureChild,
+  RuleChild,
+  Scenario,
+  TableRow,
+} from '@cucumber/messages'
+
+export type SpecificationState = 'draft' | 'active' | 'deprecated'
+
+export interface SpecificationSourceFile {
+  uri: string
+  source: string
+}
+
+export interface SpecificationMigrationChange {
+  uri: string
+  description: string
+}
+
+export interface SpecificationMigrationFile {
+  uri: string
+  source: string
+  nextSource: string
+}
+
+export interface SpecificationMigrationPlan {
+  changes: SpecificationMigrationChange[]
+  files: SpecificationMigrationFile[]
+}
+
+const ID_TAG_PREFIX = '@pickle:id:'
+const STATE_TAG_PREFIX = '@pickle:state:'
+const ROW_ID_COLUMN = 'pickle_id'
+const VALID_STATES = ['draft', 'active', 'deprecated'] as const
+const ID_PATTERN = /^[A-Za-z0-9_-]+$/
+
+interface IdentityNode {
+  kind: 'feature' | 'scenario' | 'examples' | 'examples-row'
+  name?: string
+  line: number
+  column: number
+  tags: string[]
+  rowIndex?: number
+  pickleIdValue?: string
+  pickleIdColumnIndex?: number
+  headerLine?: number
+}
+
+type SourceEdit =
+  | { type: 'insert-line'; beforeLine: number; text: string }
+  | { type: 'insert-column'; line: number; value: string }
+  | { type: 'fill-cell'; line: number; columnIndex: number; value: string }
+
+function parseDocument(source: string, language = 'en') {
+  return new Parser(
+    new AstBuilder(IdGenerator.incrementing()),
+    new GherkinClassicTokenMatcher(language),
+  ).parse(source)
+}
+
+function idValues(tags: readonly string[]): string[] {
+  return tags.filter(tag => tag.startsWith(ID_TAG_PREFIX)).map(tag => tag.slice(ID_TAG_PREFIX.length))
+}
+
+function stateValues(tags: readonly string[]): string[] {
+  return tags.filter(tag => tag.startsWith(STATE_TAG_PREFIX)).map(tag => tag.slice(STATE_TAG_PREFIX.length))
+}
+
+function specificationState(value: string | undefined): SpecificationState | undefined {
+  return VALID_STATES.find(state => state === value)
+}
+
+export function identityFromTags(tags: readonly string[]): { id?: string; state?: SpecificationState } {
+  const id = idValues(tags)[0]
+  const state = specificationState(stateValues(tags)[0])
+  return {
+    ...(id ? { id } : {}),
+    ...(state ? { state } : {}),
+  }
+}
+
+export function examplesRowId(header: readonly string[], cells: readonly string[]): string | undefined {
+  const index = header.indexOf(ROW_ID_COLUMN)
+  const value = index >= 0 ? cells[index]?.trim() : undefined
+  return value || undefined
+}
+
+function nodeLabel(node: IdentityNode): string {
+  switch (node.kind) {
+    case 'feature': return node.name ? `Feature "${node.name}"` : 'Feature'
+    case 'scenario': return `Scenario "${node.name}"`
+    case 'examples': return node.name ? `Examples "${node.name}"` : 'Examples'
+    case 'examples-row': return `Examples row ${node.rowIndex}`
+  }
+}
+
+function sourcePosition(location: { line?: number; column?: number } | undefined): { line: number; column: number } {
+  return { line: location?.line ?? 1, column: location?.column ?? 1 }
+}
+
+function visitScenario(scenario: Scenario, nodes: IdentityNode[]): void {
+  nodes.push({
+    kind: 'scenario',
+    name: scenario.name,
+    ...sourcePosition(scenario.location),
+    tags: scenario.tags.map(tag => tag.name),
+  })
+  for (const examples of scenario.examples) collectExamples(examples, nodes)
+}
+
+function collectExamples(examples: Examples, nodes: IdentityNode[]): void {
+  const header = examples.tableHeader?.cells.map(cell => cell.value) ?? []
+  const pickleIdColumnIndex = header.indexOf(ROW_ID_COLUMN)
+  nodes.push({
+    kind: 'examples',
+    name: examples.name,
+    ...sourcePosition(examples.location),
+    tags: examples.tags.map(tag => tag.name),
+    headerLine: examples.tableHeader?.location.line,
+    pickleIdColumnIndex: pickleIdColumnIndex >= 0 ? pickleIdColumnIndex : undefined,
+  })
+  examples.tableBody.forEach((row, index) => collectExamplesRow(row, index, pickleIdColumnIndex, nodes))
+}
+
+function collectExamplesRow(
+  row: TableRow,
+  index: number,
+  pickleIdColumnIndex: number,
+  nodes: IdentityNode[],
+): void {
+  const value = pickleIdColumnIndex >= 0 ? row.cells[pickleIdColumnIndex]?.value ?? '' : ''
+  nodes.push({
+    kind: 'examples-row',
+    ...sourcePosition(row.location),
+    tags: [],
+    rowIndex: index + 1,
+    pickleIdValue: value,
+    pickleIdColumnIndex: pickleIdColumnIndex >= 0 ? pickleIdColumnIndex : undefined,
+  })
+}
+
+function visitChild(child: FeatureChild | RuleChild, nodes: IdentityNode[]): void {
+  if (child.scenario) visitScenario(child.scenario, nodes)
+  if ('rule' in child && child.rule) {
+    for (const ruleChild of child.rule.children) visitChild(ruleChild, nodes)
+  }
+}
+
+function identityNodes(feature: Feature): IdentityNode[] {
+  const nodes: IdentityNode[] = [{
+    kind: 'feature',
+    name: feature.name,
+    ...sourcePosition(feature.location),
+    tags: feature.tags.map(tag => tag.name),
+  }]
+  for (const child of feature.children) visitChild(child, nodes)
+  return nodes
+}
+
+function recordIdentifier(
+  seen: Map<string, string>,
+  id: string,
+  uri: string,
+  errors: string[],
+): void {
+  const existing = seen.get(id)
+  if (existing) {
+    errors.push(
+      `Invalid Specification ${uri}: Duplicate identifier "${id}" also used in ${existing}. `
+      + 'Give each Feature, Scenario, Examples block, and Examples row a unique identifier and run pickle check again.',
+    )
+    return
+  }
+  seen.set(id, uri)
+}
+
+function validateNode(node: IdentityNode, uri: string, seen: Map<string, string>, errors: string[]): void {
+  if (node.kind === 'examples-row') {
+    const id = node.pickleIdValue?.trim() ?? ''
+    if (!id) {
+      errors.push(
+        `Invalid Specification ${uri}: Examples row ${node.rowIndex} is missing a pickle_id. `
+        + 'Run pickle migrate to add missing metadata.',
+      )
+      return
+    }
+    if (!ID_PATTERN.test(id)) {
+      errors.push(
+        `Invalid Specification ${uri}: Examples row ${node.rowIndex} has a malformed durable identifier "${id}". `
+        + 'Use letters, numbers, underscores, or hyphens and run pickle check again.',
+      )
+      return
+    }
+    recordIdentifier(seen, id, uri, errors)
+    return
+  }
+
+  const ids = idValues(node.tags)
+  const states = stateValues(node.tags)
+  if (node.kind === 'feature') {
+    if (states.length > 1) {
+      errors.push(
+        `Invalid Specification ${uri}: Feature has conflicting Specification states `
+        + `${states.map(state => `${STATE_TAG_PREFIX}${state}`).join(' and ')}. `
+        + 'Keep one of draft, active, or deprecated and run pickle check again.',
+      )
+    } else if (states.length === 1 && !specificationState(states[0])) {
+      errors.push(
+        `Invalid Specification ${uri}: Feature has a malformed Specification state "${states[0]}". `
+        + 'Use draft, active, or deprecated and run pickle check again.',
+      )
+    } else if (states.length === 0) {
+      errors.push(
+        `Invalid Specification ${uri}: Feature is missing a Specification state. `
+        + 'Run pickle migrate to add missing metadata.',
+      )
+    }
+  } else if (states.length > 0) {
+    errors.push(
+      `Invalid Specification ${uri}: ${nodeLabel(node)} has a Specification state tag. `
+      + 'Declare draft, active, or deprecated on the Feature and run pickle check again.',
+    )
+  }
+
+  if (ids.length > 1) {
+    errors.push(
+      `Invalid Specification ${uri}: ${nodeLabel(node)} has conflicting durable identifiers. `
+      + 'Keep one @pickle:id tag and run pickle check again.',
+    )
+    return
+  }
+  if (ids.length === 0) {
+    errors.push(
+      `Invalid Specification ${uri}: ${nodeLabel(node)} is missing a durable identifier. `
+      + 'Run pickle migrate to add missing metadata.',
+    )
+    return
+  }
+  if (!ids[0] || !ID_PATTERN.test(ids[0])) {
+    errors.push(
+      `Invalid Specification ${uri}: ${nodeLabel(node)} has a malformed durable identifier`
+      + `${ids[0] ? ` "${ids[0]}"` : ''}. `
+      + 'Use letters, numbers, underscores, or hyphens and run pickle check again.',
+    )
+    return
+  }
+  recordIdentifier(seen, ids[0], uri, errors)
+}
+
+export function validateSpecificationMetadata(
+  files: readonly SpecificationSourceFile[],
+  language = 'en',
+): void {
+  const seen = new Map<string, string>()
+  const errors: string[] = []
+  for (const file of files) {
+    const feature = parseDocument(file.source, language).feature
+    if (!feature) {
+      errors.push(
+        `Invalid Specification ${file.uri}: Feature is missing. `
+        + 'Correct the Specification and run pickle check again.',
+      )
+      continue
+    }
+    for (const node of identityNodes(feature)) validateNode(node, file.uri, seen, errors)
+  }
+  if (errors.length > 0) throw new Error(errors.join('\n'))
+}
+
+function createDurableId(existing: Set<string>): string {
+  for (;;) {
+    const id = Buffer.from(crypto.getRandomValues(new Uint8Array(8))).toString('hex')
+    if (!existing.has(id)) {
+      existing.add(id)
+      return id
+    }
+  }
+}
+
+function collectExistingIds(features: readonly (Feature | undefined)[]): Set<string> {
+  const existing = new Set<string>()
+  for (const feature of features) {
+    if (!feature) continue
+    for (const node of identityNodes(feature)) {
+      for (const id of idValues(node.tags)) {
+        if (id) existing.add(id)
+      }
+      const rowId = node.pickleIdValue?.trim()
+      if (rowId) existing.add(rowId)
+    }
+  }
+  return existing
+}
+
+function splitSource(source: string): { lines: string[]; newline: string } {
+  const newline = source.includes('\r\n') ? '\r\n' : '\n'
+  return { lines: source.split(newline), newline }
+}
+
+function insertTableColumn(line: string, value: string): string {
+  const parts = line.split('|')
+  parts.splice(1, 0, ` ${value} `)
+  return parts.join('|')
+}
+
+function fillTableCell(line: string, columnIndex: number, value: string): string {
+  const parts = line.split('|')
+  parts[columnIndex + 1] = ` ${value} `
+  return parts.join('|')
+}
+
+function applyEdits(source: string, edits: readonly SourceEdit[]): string {
+  const { lines, newline } = splitSource(source)
+  const lineEdits = edits
+    .filter(edit => edit.type === 'insert-line')
+    .sort((left, right) => right.beforeLine - left.beforeLine)
+
+  for (const edit of edits) {
+    if (edit.type === 'insert-line') continue
+    const line = lines[edit.line - 1]
+    if (line === undefined) continue
+    if (edit.type === 'insert-column') lines[edit.line - 1] = insertTableColumn(line, edit.value)
+    else lines[edit.line - 1] = fillTableCell(line, edit.columnIndex, edit.value)
+  }
+  for (const edit of lineEdits) {
+    lines.splice(edit.beforeLine - 1, 0, edit.text)
+  }
+  return lines.join(newline)
+}
+
+function tagLine(column: number, tags: readonly string[]): string {
+  return `${' '.repeat(Math.max(column - 1, 0))}${tags.join(' ')}`
+}
+
+function migrateFile(
+  file: SpecificationSourceFile,
+  feature: Feature | undefined,
+  existing: Set<string>,
+): { nextSource: string; changes: SpecificationMigrationChange[] } {
+  if (!feature) return { nextSource: file.source, changes: [] }
+
+  const edits: SourceEdit[] = []
+  const changes: SpecificationMigrationChange[] = []
+  const nodes = identityNodes(feature)
+
+  for (const node of nodes) {
+    if (node.kind === 'examples-row') {
+      const current = node.pickleIdValue?.trim() ?? ''
+      if (current) continue
+      const id = createDurableId(existing)
+      if (node.pickleIdColumnIndex === undefined) {
+        edits.push({ type: 'insert-column', line: node.line, value: id })
+      } else {
+        edits.push({ type: 'fill-cell', line: node.line, columnIndex: node.pickleIdColumnIndex, value: id })
+      }
+      changes.push({ uri: file.uri, description: `Examples row ${node.rowIndex}: add pickle_id ${id}` })
+      continue
+    }
+
+    if (node.kind === 'examples' && node.pickleIdColumnIndex === undefined && node.headerLine) {
+      edits.push({ type: 'insert-column', line: node.headerLine, value: ROW_ID_COLUMN })
+    }
+
+    const tagsToAdd: string[] = []
+    const ids = idValues(node.tags)
+    const states = stateValues(node.tags)
+    if (ids.length === 0) {
+      const id = createDurableId(existing)
+      tagsToAdd.push(`${ID_TAG_PREFIX}${id}`)
+    }
+    if (node.kind === 'feature' && states.length === 0) {
+      tagsToAdd.push(`${STATE_TAG_PREFIX}active`)
+    }
+    if (tagsToAdd.length === 0) continue
+    edits.push({ type: 'insert-line', beforeLine: node.line, text: tagLine(node.column, tagsToAdd) })
+    changes.push({
+      uri: file.uri,
+      description: `${nodeLabel(node)}: add ${tagsToAdd.join(' ')}`,
+    })
+  }
+
+  return { nextSource: applyEdits(file.source, edits), changes }
+}
+
+export function planSpecificationMigration(
+  files: readonly SpecificationSourceFile[],
+  language = 'en',
+): SpecificationMigrationPlan {
+  const parsed = files.map(file => ({ file, feature: parseDocument(file.source, language).feature }))
+  const existing = collectExistingIds(parsed.map(({ feature }) => feature))
+  const changes: SpecificationMigrationChange[] = []
+  const nextFiles: SpecificationMigrationFile[] = []
+  for (const { file, feature } of parsed) {
+    const migrated = migrateFile(file, feature, existing)
+    changes.push(...migrated.changes)
+    nextFiles.push({ uri: file.uri, source: file.source, nextSource: migrated.nextSource })
+  }
+  return { changes, files: nextFiles }
+}
+
+export function formatMigrationPreview(plan: SpecificationMigrationPlan): string {
+  if (plan.changes.length === 0) return 'No Specification metadata changes needed'
+  const uris = [...new Set(plan.changes.map(change => change.uri))]
+  const sections = uris.map(uri => {
+    const lines = plan.changes.filter(change => change.uri === uri).map(change => `  ${change.description}`)
+    return `${uri}\n${lines.join('\n')}`
+  })
+  return `Migration preview\n\n${sections.join('\n\n')}\n`
+}

--- a/packages/spec/src/identity.ts
+++ b/packages/spec/src/identity.ts
@@ -1,5 +1,8 @@
-import { AstBuilder, GherkinClassicTokenMatcher, Parser } from '@cucumber/gherkin'
-import { IdGenerator } from '@cucumber/messages'
+import {
+  AstBuilder,
+  GherkinClassicTokenMatcher,
+  Parser,
+} from '@cucumber/gherkin'
 import type {
   Examples,
   Feature,
@@ -8,6 +11,7 @@ import type {
   Scenario,
   TableRow,
 } from '@cucumber/messages'
+import { IdGenerator } from '@cucumber/messages'
 
 export type SpecificationState = 'draft' | 'active' | 'deprecated'
 
@@ -32,11 +36,11 @@ export interface SpecificationMigrationPlan {
   files: SpecificationMigrationFile[]
 }
 
-const ID_TAG_PREFIX = '@pickle:id:'
-const STATE_TAG_PREFIX = '@pickle:state:'
-const ROW_ID_COLUMN = 'pickle_id'
-const VALID_STATES = ['draft', 'active', 'deprecated'] as const
-const ID_PATTERN = /^[A-Za-z0-9_-]+$/
+const idTagPrefix = '@pickle:id:'
+const stateTagPrefix = '@pickle:state:'
+const rowIdColumn = 'pickle_id'
+const validStates = ['draft', 'active', 'deprecated'] as const
+const idPattern = /^[A-Za-z0-9_-]+$/
 
 interface IdentityNode {
   kind: 'feature' | 'scenario' | 'examples' | 'examples-row'
@@ -63,18 +67,27 @@ function parseDocument(source: string, language = 'en') {
 }
 
 function idValues(tags: readonly string[]): string[] {
-  return tags.filter(tag => tag.startsWith(ID_TAG_PREFIX)).map(tag => tag.slice(ID_TAG_PREFIX.length))
+  return tags
+    .filter((tag) => tag.startsWith(idTagPrefix))
+    .map((tag) => tag.slice(idTagPrefix.length))
 }
 
 function stateValues(tags: readonly string[]): string[] {
-  return tags.filter(tag => tag.startsWith(STATE_TAG_PREFIX)).map(tag => tag.slice(STATE_TAG_PREFIX.length))
+  return tags
+    .filter((tag) => tag.startsWith(stateTagPrefix))
+    .map((tag) => tag.slice(stateTagPrefix.length))
 }
 
-function specificationState(value: string | undefined): SpecificationState | undefined {
-  return VALID_STATES.find(state => state === value)
+function specificationState(
+  value: string | undefined,
+): SpecificationState | undefined {
+  return validStates.find((state) => state === value)
 }
 
-export function identityFromTags(tags: readonly string[]): { id?: string; state?: SpecificationState } {
+export function identityFromTags(tags: readonly string[]): {
+  id?: string
+  state?: SpecificationState
+} {
   const id = idValues(tags)[0]
   const state = specificationState(stateValues(tags)[0])
   return {
@@ -83,22 +96,31 @@ export function identityFromTags(tags: readonly string[]): { id?: string; state?
   }
 }
 
-export function examplesRowId(header: readonly string[], cells: readonly string[]): string | undefined {
-  const index = header.indexOf(ROW_ID_COLUMN)
+export function examplesRowId(
+  header: readonly string[],
+  cells: readonly string[],
+): string | undefined {
+  const index = header.indexOf(rowIdColumn)
   const value = index >= 0 ? cells[index]?.trim() : undefined
   return value || undefined
 }
 
 function nodeLabel(node: IdentityNode): string {
   switch (node.kind) {
-    case 'feature': return node.name ? `Feature "${node.name}"` : 'Feature'
-    case 'scenario': return `Scenario "${node.name}"`
-    case 'examples': return node.name ? `Examples "${node.name}"` : 'Examples'
-    case 'examples-row': return `Examples row ${node.rowIndex}`
+    case 'feature':
+      return node.name ? `Feature "${node.name}"` : 'Feature'
+    case 'scenario':
+      return `Scenario "${node.name}"`
+    case 'examples':
+      return node.name ? `Examples "${node.name}"` : 'Examples'
+    case 'examples-row':
+      return `Examples row ${node.rowIndex}`
   }
 }
 
-function sourcePosition(location: { line?: number; column?: number } | undefined): { line: number; column: number } {
+function sourcePosition(
+  location: { line?: number; column?: number } | undefined,
+): { line: number; column: number } {
   return { line: location?.line ?? 1, column: location?.column ?? 1 }
 }
 
@@ -107,23 +129,26 @@ function visitScenario(scenario: Scenario, nodes: IdentityNode[]): void {
     kind: 'scenario',
     name: scenario.name,
     ...sourcePosition(scenario.location),
-    tags: scenario.tags.map(tag => tag.name),
+    tags: scenario.tags.map((tag) => tag.name),
   })
   for (const examples of scenario.examples) collectExamples(examples, nodes)
 }
 
 function collectExamples(examples: Examples, nodes: IdentityNode[]): void {
-  const header = examples.tableHeader?.cells.map(cell => cell.value) ?? []
-  const pickleIdColumnIndex = header.indexOf(ROW_ID_COLUMN)
+  const header = examples.tableHeader?.cells.map((cell) => cell.value) ?? []
+  const pickleIdColumnIndex = header.indexOf(rowIdColumn)
   nodes.push({
     kind: 'examples',
     name: examples.name,
     ...sourcePosition(examples.location),
-    tags: examples.tags.map(tag => tag.name),
+    tags: examples.tags.map((tag) => tag.name),
     headerLine: examples.tableHeader?.location.line,
-    pickleIdColumnIndex: pickleIdColumnIndex >= 0 ? pickleIdColumnIndex : undefined,
+    pickleIdColumnIndex:
+      pickleIdColumnIndex >= 0 ? pickleIdColumnIndex : undefined,
   })
-  examples.tableBody.forEach((row, index) => collectExamplesRow(row, index, pickleIdColumnIndex, nodes))
+  for (const [index, row] of examples.tableBody.entries()) {
+    collectExamplesRow(row, index, pickleIdColumnIndex, nodes)
+  }
 }
 
 function collectExamplesRow(
@@ -132,18 +157,25 @@ function collectExamplesRow(
   pickleIdColumnIndex: number,
   nodes: IdentityNode[],
 ): void {
-  const value = pickleIdColumnIndex >= 0 ? row.cells[pickleIdColumnIndex]?.value ?? '' : ''
+  const value =
+    pickleIdColumnIndex >= 0
+      ? (row.cells[pickleIdColumnIndex]?.value ?? '')
+      : ''
   nodes.push({
     kind: 'examples-row',
     ...sourcePosition(row.location),
     tags: [],
     rowIndex: index + 1,
     pickleIdValue: value,
-    pickleIdColumnIndex: pickleIdColumnIndex >= 0 ? pickleIdColumnIndex : undefined,
+    pickleIdColumnIndex:
+      pickleIdColumnIndex >= 0 ? pickleIdColumnIndex : undefined,
   })
 }
 
-function visitChild(child: FeatureChild | RuleChild, nodes: IdentityNode[]): void {
+function visitChild(
+  child: FeatureChild | RuleChild,
+  nodes: IdentityNode[],
+): void {
   if (child.scenario) visitScenario(child.scenario, nodes)
   if ('rule' in child && child.rule) {
     for (const ruleChild of child.rule.children) visitChild(ruleChild, nodes)
@@ -151,12 +183,14 @@ function visitChild(child: FeatureChild | RuleChild, nodes: IdentityNode[]): voi
 }
 
 function identityNodes(feature: Feature): IdentityNode[] {
-  const nodes: IdentityNode[] = [{
-    kind: 'feature',
-    name: feature.name,
-    ...sourcePosition(feature.location),
-    tags: feature.tags.map(tag => tag.name),
-  }]
+  const nodes: IdentityNode[] = [
+    {
+      kind: 'feature',
+      name: feature.name,
+      ...sourcePosition(feature.location),
+      tags: feature.tags.map((tag) => tag.name),
+    },
+  ]
   for (const child of feature.children) visitChild(child, nodes)
   return nodes
 }
@@ -170,28 +204,33 @@ function recordIdentifier(
   const existing = seen.get(id)
   if (existing) {
     errors.push(
-      `Invalid Specification ${uri}: Duplicate identifier "${id}" also used in ${existing}. `
-      + 'Give each Feature, Scenario, Examples block, and Examples row a unique identifier and run pickle check again.',
+      `Invalid Specification ${uri}: Duplicate identifier "${id}" also used in ${existing}. ` +
+        'Give each Feature, Scenario, Examples block, and Examples row a unique identifier and run pickle check again.',
     )
     return
   }
   seen.set(id, uri)
 }
 
-function validateNode(node: IdentityNode, uri: string, seen: Map<string, string>, errors: string[]): void {
+function validateNode(
+  node: IdentityNode,
+  uri: string,
+  seen: Map<string, string>,
+  errors: string[],
+): void {
   if (node.kind === 'examples-row') {
     const id = node.pickleIdValue?.trim() ?? ''
     if (!id) {
       errors.push(
-        `Invalid Specification ${uri}: Examples row ${node.rowIndex} is missing a pickle_id. `
-        + 'Run pickle migrate to add missing metadata.',
+        `Invalid Specification ${uri}: Examples row ${node.rowIndex} is missing a pickle_id. ` +
+          'Run pickle migrate to add missing metadata.',
       )
       return
     }
-    if (!ID_PATTERN.test(id)) {
+    if (!idPattern.test(id)) {
       errors.push(
-        `Invalid Specification ${uri}: Examples row ${node.rowIndex} has a malformed durable identifier "${id}". `
-        + 'Use letters, numbers, underscores, or hyphens and run pickle check again.',
+        `Invalid Specification ${uri}: Examples row ${node.rowIndex} has a malformed durable identifier "${id}". ` +
+          'Use letters, numbers, underscores, or hyphens and run pickle check again.',
       )
       return
     }
@@ -204,47 +243,47 @@ function validateNode(node: IdentityNode, uri: string, seen: Map<string, string>
   if (node.kind === 'feature') {
     if (states.length > 1) {
       errors.push(
-        `Invalid Specification ${uri}: Feature has conflicting Specification states `
-        + `${states.map(state => `${STATE_TAG_PREFIX}${state}`).join(' and ')}. `
-        + 'Keep one of draft, active, or deprecated and run pickle check again.',
+        `Invalid Specification ${uri}: Feature has conflicting Specification states ` +
+          `${states.map((state) => `${stateTagPrefix}${state}`).join(' and ')}. ` +
+          'Keep one of draft, active, or deprecated and run pickle check again.',
       )
     } else if (states.length === 1 && !specificationState(states[0])) {
       errors.push(
-        `Invalid Specification ${uri}: Feature has a malformed Specification state "${states[0]}". `
-        + 'Use draft, active, or deprecated and run pickle check again.',
+        `Invalid Specification ${uri}: Feature has a malformed Specification state "${states[0]}". ` +
+          'Use draft, active, or deprecated and run pickle check again.',
       )
     } else if (states.length === 0) {
       errors.push(
-        `Invalid Specification ${uri}: Feature is missing a Specification state. `
-        + 'Run pickle migrate to add missing metadata.',
+        `Invalid Specification ${uri}: Feature is missing a Specification state. ` +
+          'Run pickle migrate to add missing metadata.',
       )
     }
   } else if (states.length > 0) {
     errors.push(
-      `Invalid Specification ${uri}: ${nodeLabel(node)} has a Specification state tag. `
-      + 'Declare draft, active, or deprecated on the Feature and run pickle check again.',
+      `Invalid Specification ${uri}: ${nodeLabel(node)} has a Specification state tag. ` +
+        'Declare draft, active, or deprecated on the Feature and run pickle check again.',
     )
   }
 
   if (ids.length > 1) {
     errors.push(
-      `Invalid Specification ${uri}: ${nodeLabel(node)} has conflicting durable identifiers. `
-      + 'Keep one @pickle:id tag and run pickle check again.',
+      `Invalid Specification ${uri}: ${nodeLabel(node)} has conflicting durable identifiers. ` +
+        'Keep one @pickle:id tag and run pickle check again.',
     )
     return
   }
   if (ids.length === 0) {
     errors.push(
-      `Invalid Specification ${uri}: ${nodeLabel(node)} is missing a durable identifier. `
-      + 'Run pickle migrate to add missing metadata.',
+      `Invalid Specification ${uri}: ${nodeLabel(node)} is missing a durable identifier. ` +
+        'Run pickle migrate to add missing metadata.',
     )
     return
   }
-  if (!ids[0] || !ID_PATTERN.test(ids[0])) {
+  if (!ids[0] || !idPattern.test(ids[0])) {
     errors.push(
-      `Invalid Specification ${uri}: ${nodeLabel(node)} has a malformed durable identifier`
-      + `${ids[0] ? ` "${ids[0]}"` : ''}. `
-      + 'Use letters, numbers, underscores, or hyphens and run pickle check again.',
+      `Invalid Specification ${uri}: ${nodeLabel(node)} has a malformed durable identifier` +
+        `${ids[0] ? ` "${ids[0]}"` : ''}. ` +
+        'Use letters, numbers, underscores, or hyphens and run pickle check again.',
     )
     return
   }
@@ -261,19 +300,22 @@ export function validateSpecificationMetadata(
     const feature = parseDocument(file.source, language).feature
     if (!feature) {
       errors.push(
-        `Invalid Specification ${file.uri}: Feature is missing. `
-        + 'Correct the Specification and run pickle check again.',
+        `Invalid Specification ${file.uri}: Feature is missing. ` +
+          'Correct the Specification and run pickle check again.',
       )
       continue
     }
-    for (const node of identityNodes(feature)) validateNode(node, file.uri, seen, errors)
+    for (const node of identityNodes(feature))
+      validateNode(node, file.uri, seen, errors)
   }
   if (errors.length > 0) throw new Error(errors.join('\n'))
 }
 
 function createDurableId(existing: Set<string>): string {
   for (;;) {
-    const id = Buffer.from(crypto.getRandomValues(new Uint8Array(8))).toString('hex')
+    const id = Buffer.from(crypto.getRandomValues(new Uint8Array(8))).toString(
+      'hex',
+    )
     if (!existing.has(id)) {
       existing.add(id)
       return id
@@ -281,7 +323,9 @@ function createDurableId(existing: Set<string>): string {
   }
 }
 
-function collectExistingIds(features: readonly (Feature | undefined)[]): Set<string> {
+function collectExistingIds(
+  features: readonly (Feature | undefined)[],
+): Set<string> {
   const existing = new Set<string>()
   for (const feature of features) {
     if (!feature) continue
@@ -307,7 +351,11 @@ function insertTableColumn(line: string, value: string): string {
   return parts.join('|')
 }
 
-function fillTableCell(line: string, columnIndex: number, value: string): string {
+function fillTableCell(
+  line: string,
+  columnIndex: number,
+  value: string,
+): string {
   const parts = line.split('|')
   parts[columnIndex + 1] = ` ${value} `
   return parts.join('|')
@@ -316,15 +364,17 @@ function fillTableCell(line: string, columnIndex: number, value: string): string
 function applyEdits(source: string, edits: readonly SourceEdit[]): string {
   const { lines, newline } = splitSource(source)
   const lineEdits = edits
-    .filter(edit => edit.type === 'insert-line')
+    .filter((edit) => edit.type === 'insert-line')
     .sort((left, right) => right.beforeLine - left.beforeLine)
 
   for (const edit of edits) {
     if (edit.type === 'insert-line') continue
     const line = lines[edit.line - 1]
     if (line === undefined) continue
-    if (edit.type === 'insert-column') lines[edit.line - 1] = insertTableColumn(line, edit.value)
-    else lines[edit.line - 1] = fillTableCell(line, edit.columnIndex, edit.value)
+    if (edit.type === 'insert-column')
+      lines[edit.line - 1] = insertTableColumn(line, edit.value)
+    else
+      lines[edit.line - 1] = fillTableCell(line, edit.columnIndex, edit.value)
   }
   for (const edit of lineEdits) {
     lines.splice(edit.beforeLine - 1, 0, edit.text)
@@ -355,14 +405,30 @@ function migrateFile(
       if (node.pickleIdColumnIndex === undefined) {
         edits.push({ type: 'insert-column', line: node.line, value: id })
       } else {
-        edits.push({ type: 'fill-cell', line: node.line, columnIndex: node.pickleIdColumnIndex, value: id })
+        edits.push({
+          type: 'fill-cell',
+          line: node.line,
+          columnIndex: node.pickleIdColumnIndex,
+          value: id,
+        })
       }
-      changes.push({ uri: file.uri, description: `Examples row ${node.rowIndex}: add pickle_id ${id}` })
+      changes.push({
+        uri: file.uri,
+        description: `Examples row ${node.rowIndex}: add pickle_id ${id}`,
+      })
       continue
     }
 
-    if (node.kind === 'examples' && node.pickleIdColumnIndex === undefined && node.headerLine) {
-      edits.push({ type: 'insert-column', line: node.headerLine, value: ROW_ID_COLUMN })
+    if (
+      node.kind === 'examples' &&
+      node.pickleIdColumnIndex === undefined &&
+      node.headerLine
+    ) {
+      edits.push({
+        type: 'insert-column',
+        line: node.headerLine,
+        value: rowIdColumn,
+      })
     }
 
     const tagsToAdd: string[] = []
@@ -370,13 +436,17 @@ function migrateFile(
     const states = stateValues(node.tags)
     if (ids.length === 0) {
       const id = createDurableId(existing)
-      tagsToAdd.push(`${ID_TAG_PREFIX}${id}`)
+      tagsToAdd.push(`${idTagPrefix}${id}`)
     }
     if (node.kind === 'feature' && states.length === 0) {
-      tagsToAdd.push(`${STATE_TAG_PREFIX}active`)
+      tagsToAdd.push(`${stateTagPrefix}active`)
     }
     if (tagsToAdd.length === 0) continue
-    edits.push({ type: 'insert-line', beforeLine: node.line, text: tagLine(node.column, tagsToAdd) })
+    edits.push({
+      type: 'insert-line',
+      beforeLine: node.line,
+      text: tagLine(node.column, tagsToAdd),
+    })
     changes.push({
       uri: file.uri,
       description: `${nodeLabel(node)}: add ${tagsToAdd.join(' ')}`,
@@ -390,23 +460,35 @@ export function planSpecificationMigration(
   files: readonly SpecificationSourceFile[],
   language = 'en',
 ): SpecificationMigrationPlan {
-  const parsed = files.map(file => ({ file, feature: parseDocument(file.source, language).feature }))
+  const parsed = files.map((file) => ({
+    file,
+    feature: parseDocument(file.source, language).feature,
+  }))
   const existing = collectExistingIds(parsed.map(({ feature }) => feature))
   const changes: SpecificationMigrationChange[] = []
   const nextFiles: SpecificationMigrationFile[] = []
   for (const { file, feature } of parsed) {
     const migrated = migrateFile(file, feature, existing)
     changes.push(...migrated.changes)
-    nextFiles.push({ uri: file.uri, source: file.source, nextSource: migrated.nextSource })
+    nextFiles.push({
+      uri: file.uri,
+      source: file.source,
+      nextSource: migrated.nextSource,
+    })
   }
   return { changes, files: nextFiles }
 }
 
-export function formatMigrationPreview(plan: SpecificationMigrationPlan): string {
-  if (plan.changes.length === 0) return 'No Specification metadata changes needed'
-  const uris = [...new Set(plan.changes.map(change => change.uri))]
-  const sections = uris.map(uri => {
-    const lines = plan.changes.filter(change => change.uri === uri).map(change => `  ${change.description}`)
+export function formatMigrationPreview(
+  plan: SpecificationMigrationPlan,
+): string {
+  if (plan.changes.length === 0)
+    return 'No Specification metadata changes needed'
+  const uris = [...new Set(plan.changes.map((change) => change.uri))]
+  const sections = uris.map((uri) => {
+    const lines = plan.changes
+      .filter((change) => change.uri === uri)
+      .map((change) => `  ${change.description}`)
     return `${uri}\n${lines.join('\n')}`
   })
   return `Migration preview\n\n${sections.join('\n\n')}\n`

--- a/packages/spec/src/selection.test.ts
+++ b/packages/spec/src/selection.test.ts
@@ -1,9 +1,9 @@
 import { describe, expect, test } from 'bun:test'
 import {
-  selectScenarios,
-  validateSelectionOptions,
   type Scenario,
   type Specification,
+  selectScenarios,
+  validateSelectionOptions,
 } from '../index'
 
 function scenario(name: string, tags: string[] = []): Scenario {
@@ -38,35 +38,45 @@ describe('selectScenarios', () => {
       shard: { index: 1, total: 2 },
     })
 
-    expect(selected.map(({ specification, scenario }) => [
-      specification.source.uri,
-      scenario.name,
-    ])).toEqual([
-      ['features/a.feature', 'Checkout with a voucher'],
-    ])
+    expect(
+      selected.map(({ specification, scenario }) => [
+        specification.source.uri,
+        scenario.name,
+      ]),
+    ).toEqual([['features/a.feature', 'Checkout with a voucher']])
   })
 
   test('rejects invalid shard coordinates', () => {
-    expect(() => selectScenarios([], { shard: { index: 2, total: 1 } }))
-      .toThrow('selection.shard.index must be less than or equal to selection.shard.total')
+    expect(() =>
+      selectScenarios([], { shard: { index: 2, total: 1 } }),
+    ).toThrow(
+      'selection.shard.index must be less than or equal to selection.shard.total',
+    )
   })
 
   test('rejects unsupported characters in tag expressions', () => {
-    expect(() => validateSelectionOptions({ tagExpression: '@smoke !' }))
-      .toThrow('Unexpected character "!" in tag expression')
-    expect(() => validateSelectionOptions({ tagExpression: '@smoke,' }))
-      .toThrow('Unexpected character "," in tag expression')
+    expect(() =>
+      validateSelectionOptions({ tagExpression: '@smoke !' }),
+    ).toThrow('Unexpected character "!" in tag expression')
+    expect(() =>
+      validateSelectionOptions({ tagExpression: '@smoke,' }),
+    ).toThrow('Unexpected character "," in tag expression')
   })
 
   test('does not assign ignored Scenarios to a shard or count them as shard positions', () => {
-    const selected = selectScenarios([
-      specification('features/search.feature', [
-        scenario('Ignored', ['@ignore']),
-        scenario('First runnable'),
-        scenario('Second runnable'),
-      ]),
-    ], { shard: { index: 1, total: 2 } })
+    const selected = selectScenarios(
+      [
+        specification('features/search.feature', [
+          scenario('Ignored', ['@ignore']),
+          scenario('First runnable'),
+          scenario('Second runnable'),
+        ]),
+      ],
+      { shard: { index: 1, total: 2 } },
+    )
 
-    expect(selected.map(({ scenario }) => scenario.name)).toEqual(['First runnable'])
+    expect(selected.map(({ scenario }) => scenario.name)).toEqual([
+      'First runnable',
+    ])
   })
 })

--- a/packages/spec/src/selection.ts
+++ b/packages/spec/src/selection.ts
@@ -34,7 +34,10 @@ function tagExpressionTokens(expression: string): string[] {
     if (index === expression.length) break
     tokenPattern.lastIndex = index
     const match = tokenPattern.exec(expression)
-    if (!match) throw new Error(`Unexpected character "${expression[index]}" in tag expression`)
+    if (!match)
+      throw new Error(
+        `Unexpected character "${expression[index]}" in tag expression`,
+      )
     tokens.push(match[0])
     index = tokenPattern.lastIndex
   }
@@ -90,14 +93,25 @@ function parseTagExpression(expression: string): TagExpressionNode {
   return result
 }
 
-function matchesTagExpression(node: TagExpressionNode, tags: readonly string[]): boolean {
+function matchesTagExpression(
+  node: TagExpressionNode,
+  tags: readonly string[],
+): boolean {
   switch (node.type) {
-    case 'tag': return tags.includes(node.value)
-    case 'not': return !matchesTagExpression(node.child, tags)
+    case 'tag':
+      return tags.includes(node.value)
+    case 'not':
+      return !matchesTagExpression(node.child, tags)
     case 'and':
-      return matchesTagExpression(node.left, tags) && matchesTagExpression(node.right, tags)
+      return (
+        matchesTagExpression(node.left, tags) &&
+        matchesTagExpression(node.right, tags)
+      )
     case 'or':
-      return matchesTagExpression(node.left, tags) || matchesTagExpression(node.right, tags)
+      return (
+        matchesTagExpression(node.left, tags) ||
+        matchesTagExpression(node.right, tags)
+      )
   }
 }
 
@@ -108,9 +122,14 @@ function record(value: unknown, field: string): Record<string, unknown> {
   return value as Record<string, unknown>
 }
 
-function knownFields(value: Record<string, unknown>, fields: readonly string[], parent: string): void {
+function knownFields(
+  value: Record<string, unknown>,
+  fields: readonly string[],
+  parent: string,
+): void {
   for (const field of Object.keys(value)) {
-    if (!fields.includes(field)) throw new Error(`${parent}.${field} is not supported`)
+    if (!fields.includes(field))
+      throw new Error(`${parent}.${field} is not supported`)
   }
 }
 
@@ -124,13 +143,19 @@ function validateShard(value: unknown): void {
   const shard = record(value, 'selection.shard')
   knownFields(shard, ['index', 'total'], 'selection.shard')
   if (!Number.isInteger(shard.index) || (shard.index as number) < 1) {
-    throw new Error('selection.shard.index must be an integer greater than or equal to 1')
+    throw new Error(
+      'selection.shard.index must be an integer greater than or equal to 1',
+    )
   }
   if (!Number.isInteger(shard.total) || (shard.total as number) < 1) {
-    throw new Error('selection.shard.total must be an integer greater than or equal to 1')
+    throw new Error(
+      'selection.shard.total must be an integer greater than or equal to 1',
+    )
   }
   if ((shard.index as number) > (shard.total as number)) {
-    throw new Error('selection.shard.index must be less than or equal to selection.shard.total')
+    throw new Error(
+      'selection.shard.index must be less than or equal to selection.shard.total',
+    )
   }
 }
 
@@ -156,13 +181,24 @@ export function selectScenarios(
 
   const selected = [...specifications]
     .sort((left, right) => left.source.uri.localeCompare(right.source.uri))
-    .flatMap(specification => specification.scenarios.map(scenario => ({ specification, scenario })))
-    .filter(({ scenario }) => !name || scenario.name.toLowerCase().includes(name))
-    .filter(({ scenario }) => !tagExpression || matchesTagExpression(tagExpression, scenario.tags))
+    .flatMap((specification) =>
+      specification.scenarios.map((scenario) => ({ specification, scenario })),
+    )
+    .filter(
+      ({ scenario }) => !name || scenario.name.toLowerCase().includes(name),
+    )
+    .filter(
+      ({ scenario }) =>
+        !tagExpression || matchesTagExpression(tagExpression, scenario.tags),
+    )
 
   if (!validatedOptions.shard) return selected
 
   return selected
     .filter(({ scenario }) => !scenario.tags.includes('@ignore'))
-    .filter((_, index) => index % validatedOptions.shard!.total === validatedOptions.shard!.index - 1)
+    .filter(
+      (_, index) =>
+        index % validatedOptions.shard!.total ===
+        validatedOptions.shard!.index - 1,
+    )
 }

--- a/packages/spec/src/specification.test.ts
+++ b/packages/spec/src/specification.test.ts
@@ -37,6 +37,52 @@ Feature: Checkout
     expect(JSON.stringify(specification)).not.toContain('pickle')
   })
 
+  test('maps namespaced identity tags and Examples row identifiers onto the Specification', () => {
+    const specification = parseSpecification({
+      uri: 'features/search.feature',
+      source: `@pickle:id:specaaaaaaaaaaaa @pickle:state:draft
+Feature: Search
+  @pickle:id:scnbbbbbbbbbbbb
+  Scenario Outline: Find a product
+    When the customer searches for <product>
+    Then the product page shows <product>
+
+    @pickle:id:exscccccccccccccccc
+    Examples:
+      | pickle_id | product |
+      | rowdddddddddddddd | Pickles |
+      | roweeeeeeeeeeeeee | Olives  |
+`,
+    })
+
+    expect(specification.id).toBe('specaaaaaaaaaaaa')
+    expect(specification.state).toBe('draft')
+    expect(specification.scenarios).toEqual([
+      {
+        name: 'Find a product',
+        id: 'scnbbbbbbbbbbbb',
+        examplesId: 'exscccccccccccccccc',
+        examplesRowId: 'rowdddddddddddddd',
+        tags: ['@pickle:id:specaaaaaaaaaaaa', '@pickle:state:draft', '@pickle:id:scnbbbbbbbbbbbb', '@pickle:id:exscccccccccccccccc'],
+        steps: [
+          { keyword: 'When', text: 'the customer searches for Pickles', type: 'action' },
+          { keyword: 'Then', text: 'the product page shows Pickles', type: 'outcome' },
+        ],
+      },
+      {
+        name: 'Find a product',
+        id: 'scnbbbbbbbbbbbb',
+        examplesId: 'exscccccccccccccccc',
+        examplesRowId: 'roweeeeeeeeeeeeee',
+        tags: ['@pickle:id:specaaaaaaaaaaaa', '@pickle:state:draft', '@pickle:id:scnbbbbbbbbbbbb', '@pickle:id:exscccccccccccccccc'],
+        steps: [
+          { keyword: 'When', text: 'the customer searches for Olives', type: 'action' },
+          { keyword: 'Then', text: 'the product page shows Olives', type: 'outcome' },
+        ],
+      },
+    ])
+  })
+
   test('includes feature and rule backgrounds in nested scenarios', () => {
     const specification = parseSpecification({
       uri: 'features/account.feature',

--- a/packages/spec/src/specification.test.ts
+++ b/packages/spec/src/specification.test.ts
@@ -25,8 +25,16 @@ Feature: Checkout
           name: 'Complete a purchase',
           tags: ['@smoke'],
           steps: [
-            { keyword: 'Given', text: 'a product is in the basket', type: 'context' },
-            { keyword: 'When', text: 'the customer confirms the order', type: 'action' },
+            {
+              keyword: 'Given',
+              text: 'a product is in the basket',
+              type: 'context',
+            },
+            {
+              keyword: 'When',
+              text: 'the customer confirms the order',
+              type: 'action',
+            },
             { keyword: 'Then', text: 'the purchase succeeds', type: 'outcome' },
           ],
         },
@@ -63,10 +71,23 @@ Feature: Search
         id: 'scnbbbbbbbbbbbb',
         examplesId: 'exscccccccccccccccc',
         examplesRowId: 'rowdddddddddddddd',
-        tags: ['@pickle:id:specaaaaaaaaaaaa', '@pickle:state:draft', '@pickle:id:scnbbbbbbbbbbbb', '@pickle:id:exscccccccccccccccc'],
+        tags: [
+          '@pickle:id:specaaaaaaaaaaaa',
+          '@pickle:state:draft',
+          '@pickle:id:scnbbbbbbbbbbbb',
+          '@pickle:id:exscccccccccccccccc',
+        ],
         steps: [
-          { keyword: 'When', text: 'the customer searches for Pickles', type: 'action' },
-          { keyword: 'Then', text: 'the product page shows Pickles', type: 'outcome' },
+          {
+            keyword: 'When',
+            text: 'the customer searches for Pickles',
+            type: 'action',
+          },
+          {
+            keyword: 'Then',
+            text: 'the product page shows Pickles',
+            type: 'outcome',
+          },
         ],
       },
       {
@@ -74,10 +95,23 @@ Feature: Search
         id: 'scnbbbbbbbbbbbb',
         examplesId: 'exscccccccccccccccc',
         examplesRowId: 'roweeeeeeeeeeeeee',
-        tags: ['@pickle:id:specaaaaaaaaaaaa', '@pickle:state:draft', '@pickle:id:scnbbbbbbbbbbbb', '@pickle:id:exscccccccccccccccc'],
+        tags: [
+          '@pickle:id:specaaaaaaaaaaaa',
+          '@pickle:state:draft',
+          '@pickle:id:scnbbbbbbbbbbbb',
+          '@pickle:id:exscccccccccccccccc',
+        ],
         steps: [
-          { keyword: 'When', text: 'the customer searches for Olives', type: 'action' },
-          { keyword: 'Then', text: 'the product page shows Olives', type: 'outcome' },
+          {
+            keyword: 'When',
+            text: 'the customer searches for Olives',
+            type: 'action',
+          },
+          {
+            keyword: 'Then',
+            text: 'the product page shows Olives',
+            type: 'outcome',
+          },
         ],
       },
     ])
@@ -111,7 +145,11 @@ Feature: Search
         tags: [],
         steps: [
           { keyword: 'Given', text: 'an account exists', type: 'context' },
-          { keyword: 'When', text: 'the customer opens the account', type: 'action' },
+          {
+            keyword: 'When',
+            text: 'the customer opens the account',
+            type: 'action',
+          },
           { keyword: 'Then', text: 'the balance is visible', type: 'outcome' },
         ],
       },
@@ -121,7 +159,11 @@ Feature: Search
         steps: [
           { keyword: 'Given', text: 'an account exists', type: 'context' },
           { keyword: 'Given', text: 'the account is locked', type: 'context' },
-          { keyword: 'When', text: 'the customer opens the account', type: 'action' },
+          {
+            keyword: 'When',
+            text: 'the customer opens the account',
+            type: 'action',
+          },
           { keyword: 'Then', text: 'access is denied', type: 'outcome' },
         ],
       },
@@ -152,20 +194,44 @@ Feature: Search
         name: 'Find a product',
         tags: ['@web'],
         steps: [
-          { keyword: 'Given', text: 'the search page is open', type: 'context' },
-          { keyword: 'When', text: 'the customer searches for Pickles', type: 'action' },
+          {
+            keyword: 'Given',
+            text: 'the search page is open',
+            type: 'context',
+          },
+          {
+            keyword: 'When',
+            text: 'the customer searches for Pickles',
+            type: 'action',
+          },
           { keyword: 'And', text: 'opens the first result', type: 'action' },
-          { keyword: 'Then', text: 'the product page shows Pickles', type: 'outcome' },
+          {
+            keyword: 'Then',
+            text: 'the product page shows Pickles',
+            type: 'outcome',
+          },
         ],
       },
       {
         name: 'Find a product',
         tags: ['@web'],
         steps: [
-          { keyword: 'Given', text: 'the search page is open', type: 'context' },
-          { keyword: 'When', text: 'the customer searches for Olives', type: 'action' },
+          {
+            keyword: 'Given',
+            text: 'the search page is open',
+            type: 'context',
+          },
+          {
+            keyword: 'When',
+            text: 'the customer searches for Olives',
+            type: 'action',
+          },
           { keyword: 'And', text: 'opens the first result', type: 'action' },
-          { keyword: 'Then', text: 'the product page shows Olives', type: 'outcome' },
+          {
+            keyword: 'Then',
+            text: 'the product page shows Olives',
+            type: 'outcome',
+          },
         ],
       },
     ])

--- a/packages/spec/src/specification.ts
+++ b/packages/spec/src/specification.ts
@@ -1,10 +1,14 @@
 import { AstBuilder, compile, GherkinClassicTokenMatcher, Parser } from '@cucumber/gherkin'
 import { IdGenerator, StepKeywordType } from '@cucumber/messages'
 import type {
+  Examples,
+  FeatureChild,
   GherkinDocument,
   PickleStep,
+  RuleChild,
   Step,
 } from '@cucumber/messages'
+import { examplesRowId, identityFromTags, type SpecificationState } from './identity'
 
 export interface SpecificationSource {
   uri: string
@@ -25,6 +29,9 @@ export interface Scenario {
   name: string
   tags: string[]
   steps: ScenarioStep[]
+  id?: string
+  examplesId?: string
+  examplesRowId?: string
   capabilityRequirements?: string[]
 }
 
@@ -33,6 +40,8 @@ export interface Specification {
   source: SpecificationSource
   tags: string[]
   scenarios: Scenario[]
+  id?: string
+  state?: SpecificationState
 }
 
 export interface ParseSpecificationInput {
@@ -122,11 +131,24 @@ export function parseSpecification(input: ParseSpecificationInput): Specificatio
   }
 
   const infoByAstNodeId = collectStepInfo(document)
-  const scenarios: Scenario[] = compile(document, input.uri, newId).map(pickle => ({
-    name: pickle.name,
-    tags: pickle.tags.map(({ name }) => name),
-    steps: pickle.steps.map(step => mapStep(step, infoByAstNodeId)),
-  }))
+  const scenariosById = new Map<string, { tags: string[] }>()
+  const rowsById = new Map<string, { header: string[]; cells: string[]; examplesTags: string[] }>()
+  collectIdentityNodes(document, scenariosById, rowsById)
+  const featureIdentity = identityFromTags(feature.tags.map(tag => tag.name))
+  const scenarios: Scenario[] = compile(document, input.uri, newId).map(pickle => {
+    const scenarioIdentity = identityFromTags(scenariosById.get(pickle.astNodeIds[0] ?? '')?.tags ?? [])
+    const row = rowsById.get(pickle.astNodeIds[1] ?? '')
+    const examplesIdentity = identityFromTags(row?.examplesTags ?? [])
+    const rowId = row ? examplesRowId(row.header, row.cells) : undefined
+    return {
+      name: pickle.name,
+      tags: pickle.tags.map(({ name }) => name),
+      steps: pickle.steps.map(step => mapStep(step, infoByAstNodeId)),
+      ...(scenarioIdentity.id ? { id: scenarioIdentity.id } : {}),
+      ...(examplesIdentity.id ? { examplesId: examplesIdentity.id } : {}),
+      ...(rowId ? { examplesRowId: rowId } : {}),
+    }
+  })
 
   return {
     name: feature.name,
@@ -136,7 +158,39 @@ export function parseSpecification(input: ParseSpecificationInput): Specificatio
     },
     tags: feature.tags.map(({ name }) => name),
     scenarios,
+    ...(featureIdentity.id ? { id: featureIdentity.id } : {}),
+    ...(featureIdentity.state ? { state: featureIdentity.state } : {}),
   }
+}
+
+function collectIdentityNodes(
+  document: GherkinDocument,
+  scenariosById: Map<string, { tags: string[] }>,
+  rowsById: Map<string, { header: string[]; cells: string[]; examplesTags: string[] }>,
+): void {
+  function visitExamples(examples: Examples): void {
+    const header = examples.tableHeader?.cells.map(cell => cell.value) ?? []
+    const examplesTags = examples.tags.map(tag => tag.name)
+    for (const row of examples.tableBody) {
+      rowsById.set(row.id, {
+        header,
+        cells: row.cells.map(cell => cell.value),
+        examplesTags,
+      })
+    }
+  }
+
+  function visitChild(child: FeatureChild | RuleChild): void {
+    if (child.scenario) {
+      scenariosById.set(child.scenario.id, { tags: child.scenario.tags.map(tag => tag.name) })
+      for (const examples of child.scenario.examples) visitExamples(examples)
+    }
+    if ('rule' in child && child.rule) {
+      for (const ruleChild of child.rule.children) visitChild(ruleChild)
+    }
+  }
+
+  for (const child of document.feature?.children ?? []) visitChild(child)
 }
 
 export async function parseSpecificationFile(filePath: string, language?: string): Promise<Specification> {

--- a/packages/spec/src/specification.ts
+++ b/packages/spec/src/specification.ts
@@ -1,5 +1,9 @@
-import { AstBuilder, compile, GherkinClassicTokenMatcher, Parser } from '@cucumber/gherkin'
-import { IdGenerator, StepKeywordType } from '@cucumber/messages'
+import {
+  AstBuilder,
+  compile,
+  GherkinClassicTokenMatcher,
+  Parser,
+} from '@cucumber/gherkin'
 import type {
   Examples,
   FeatureChild,
@@ -8,7 +12,12 @@ import type {
   RuleChild,
   Step,
 } from '@cucumber/messages'
-import { examplesRowId, identityFromTags, type SpecificationState } from './identity'
+import { IdGenerator, StepKeywordType } from '@cucumber/messages'
+import {
+  examplesRowId,
+  identityFromTags,
+  type SpecificationState,
+} from './identity'
 
 export interface SpecificationSource {
   uri: string
@@ -52,7 +61,10 @@ export interface ParseSpecificationInput {
 
 type ScenarioStepType = ScenarioStep['type']
 
-function stepType(keywordType: StepKeywordType | undefined, previous: ScenarioStepType): ScenarioStepType {
+function stepType(
+  keywordType: StepKeywordType | undefined,
+  previous: ScenarioStepType,
+): ScenarioStepType {
   switch (keywordType) {
     case StepKeywordType.CONTEXT:
       return 'context'
@@ -60,14 +72,14 @@ function stepType(keywordType: StepKeywordType | undefined, previous: ScenarioSt
       return 'action'
     case StepKeywordType.OUTCOME:
       return 'outcome'
-    case StepKeywordType.CONJUNCTION:
-    case StepKeywordType.UNKNOWN:
     default:
       return previous
   }
 }
 
-function collectStepInfo(document: GherkinDocument): Map<string, Pick<ScenarioStep, 'keyword' | 'type'>> {
+function collectStepInfo(
+  document: GherkinDocument,
+): Map<string, Pick<ScenarioStep, 'keyword' | 'type'>> {
   const result = new Map<string, Pick<ScenarioStep, 'keyword' | 'type'>>()
 
   function addSteps(steps: readonly Step[]): void {
@@ -93,7 +105,9 @@ function collectStepInfo(document: GherkinDocument): Map<string, Pick<ScenarioSt
 function mapArgument(step: PickleStep): ScenarioStep['argument'] {
   if (step.argument?.dataTable) {
     return {
-      dataTable: step.argument.dataTable.rows.map(row => row.cells.map(cell => cell.value)),
+      dataTable: step.argument.dataTable.rows.map((row) =>
+        row.cells.map((cell) => cell.value),
+      ),
     }
   }
   if (step.argument?.docString) {
@@ -116,7 +130,9 @@ function mapStep(
   }
 }
 
-export function parseSpecification(input: ParseSpecificationInput): Specification {
+export function parseSpecification(
+  input: ParseSpecificationInput,
+): Specification {
   const language = input.language ?? 'en'
   const newId = IdGenerator.incrementing()
   const parser = new Parser(
@@ -132,23 +148,30 @@ export function parseSpecification(input: ParseSpecificationInput): Specificatio
 
   const infoByAstNodeId = collectStepInfo(document)
   const scenariosById = new Map<string, { tags: string[] }>()
-  const rowsById = new Map<string, { header: string[]; cells: string[]; examplesTags: string[] }>()
+  const rowsById = new Map<
+    string,
+    { header: string[]; cells: string[]; examplesTags: string[] }
+  >()
   collectIdentityNodes(document, scenariosById, rowsById)
-  const featureIdentity = identityFromTags(feature.tags.map(tag => tag.name))
-  const scenarios: Scenario[] = compile(document, input.uri, newId).map(pickle => {
-    const scenarioIdentity = identityFromTags(scenariosById.get(pickle.astNodeIds[0] ?? '')?.tags ?? [])
-    const row = rowsById.get(pickle.astNodeIds[1] ?? '')
-    const examplesIdentity = identityFromTags(row?.examplesTags ?? [])
-    const rowId = row ? examplesRowId(row.header, row.cells) : undefined
-    return {
-      name: pickle.name,
-      tags: pickle.tags.map(({ name }) => name),
-      steps: pickle.steps.map(step => mapStep(step, infoByAstNodeId)),
-      ...(scenarioIdentity.id ? { id: scenarioIdentity.id } : {}),
-      ...(examplesIdentity.id ? { examplesId: examplesIdentity.id } : {}),
-      ...(rowId ? { examplesRowId: rowId } : {}),
-    }
-  })
+  const featureIdentity = identityFromTags(feature.tags.map((tag) => tag.name))
+  const scenarios: Scenario[] = compile(document, input.uri, newId).map(
+    (pickle) => {
+      const scenarioIdentity = identityFromTags(
+        scenariosById.get(pickle.astNodeIds[0] ?? '')?.tags ?? [],
+      )
+      const row = rowsById.get(pickle.astNodeIds[1] ?? '')
+      const examplesIdentity = identityFromTags(row?.examplesTags ?? [])
+      const rowId = row ? examplesRowId(row.header, row.cells) : undefined
+      return {
+        name: pickle.name,
+        tags: pickle.tags.map(({ name }) => name),
+        steps: pickle.steps.map((step) => mapStep(step, infoByAstNodeId)),
+        ...(scenarioIdentity.id ? { id: scenarioIdentity.id } : {}),
+        ...(examplesIdentity.id ? { examplesId: examplesIdentity.id } : {}),
+        ...(rowId ? { examplesRowId: rowId } : {}),
+      }
+    },
+  )
 
   return {
     name: feature.name,
@@ -166,15 +189,18 @@ export function parseSpecification(input: ParseSpecificationInput): Specificatio
 function collectIdentityNodes(
   document: GherkinDocument,
   scenariosById: Map<string, { tags: string[] }>,
-  rowsById: Map<string, { header: string[]; cells: string[]; examplesTags: string[] }>,
+  rowsById: Map<
+    string,
+    { header: string[]; cells: string[]; examplesTags: string[] }
+  >,
 ): void {
   function visitExamples(examples: Examples): void {
-    const header = examples.tableHeader?.cells.map(cell => cell.value) ?? []
-    const examplesTags = examples.tags.map(tag => tag.name)
+    const header = examples.tableHeader?.cells.map((cell) => cell.value) ?? []
+    const examplesTags = examples.tags.map((tag) => tag.name)
     for (const row of examples.tableBody) {
       rowsById.set(row.id, {
         header,
-        cells: row.cells.map(cell => cell.value),
+        cells: row.cells.map((cell) => cell.value),
         examplesTags,
       })
     }
@@ -182,7 +208,9 @@ function collectIdentityNodes(
 
   function visitChild(child: FeatureChild | RuleChild): void {
     if (child.scenario) {
-      scenariosById.set(child.scenario.id, { tags: child.scenario.tags.map(tag => tag.name) })
+      scenariosById.set(child.scenario.id, {
+        tags: child.scenario.tags.map((tag) => tag.name),
+      })
       for (const examples of child.scenario.examples) visitExamples(examples)
     }
     if ('rule' in child && child.rule) {
@@ -193,7 +221,10 @@ function collectIdentityNodes(
   for (const child of document.feature?.children ?? []) visitChild(child)
 }
 
-export async function parseSpecificationFile(filePath: string, language?: string): Promise<Specification> {
+export async function parseSpecificationFile(
+  filePath: string,
+  language?: string,
+): Promise<Specification> {
   return parseSpecification({
     source: await Bun.file(filePath).text(),
     uri: filePath,

--- a/packages/web/index.ts
+++ b/packages/web/index.ts
@@ -1,4 +1,3 @@
-export { createWebAdapter, validateWebAdapterOptions } from './src/web-adapter'
 export type {
   BrowserOptions,
   ScreenshotOptions,
@@ -7,3 +6,4 @@ export type {
   WebAutomationFactory,
   WebObservedAction,
 } from './src/web-adapter'
+export { createWebAdapter, validateWebAdapterOptions } from './src/web-adapter'

--- a/packages/web/src/web-adapter.test.ts
+++ b/packages/web/src/web-adapter.test.ts
@@ -1,8 +1,8 @@
 import { afterAll, describe, expect, mock, test } from 'bun:test'
-import type { Scenario, Specification } from '@pickle-spec/spec'
 import { mkdtemp, rm } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
+import type { Scenario, Specification } from '@pickle-spec/spec'
 import {
   createWebAdapter,
   type WebAutomation,
@@ -30,16 +30,27 @@ describe('createWebAdapter', () => {
   const artifactDirectories: string[] = []
 
   afterAll(async () => {
-    await Promise.all(artifactDirectories.map(directory => rm(directory, { recursive: true, force: true })))
+    await Promise.all(
+      artifactDirectories.map((directory) =>
+        rm(directory, { recursive: true, force: true }),
+      ),
+    )
   })
 
   test('translates web automation into resolved actions, runner states, and screenshot artifacts', async () => {
-    const artifactDirectory = await mkdtemp(join(tmpdir(), 'pickle-web-artifacts-'))
+    const artifactDirectory = await mkdtemp(
+      join(tmpdir(), 'pickle-web-artifacts-'),
+    )
     artifactDirectories.push(artifactDirectory)
     const navigate = mock(async () => {})
-    const observe = mock(async () => [{ description: 'Fill the search field', handle: { selector: '#search' } }])
+    const observe = mock(async () => [
+      { description: 'Fill the search field', handle: { selector: '#search' } },
+    ])
     const act = mock(async () => ({ success: true }))
-    const verify = mock(async () => ({ meetsExpectation: false, actualState: 'No results were shown' }))
+    const verify = mock(async () => ({
+      meetsExpectation: false,
+      actualState: 'No results were shown',
+    }))
     const close = mock(async () => {})
     const automation: WebAutomation = {
       navigate,
@@ -54,10 +65,13 @@ describe('createWebAdapter', () => {
     const factory: WebAutomationFactory = {
       open: mock(async () => automation),
     }
-    const adapter = createWebAdapter({
-      baseUrl: 'https://example.test',
-      screenshots: { mode: 'on-step', outputDir: artifactDirectory },
-    }, factory)
+    const adapter = createWebAdapter(
+      {
+        baseUrl: 'https://example.test',
+        screenshots: { mode: 'on-step', outputDir: artifactDirectory },
+      },
+      factory,
+    )
     const session = await adapter.openSession({
       executionTargetProfile: { id: 'web' },
       specification,
@@ -69,7 +83,10 @@ describe('createWebAdapter', () => {
     const outcome = await session.executeStep(scenario.steps[2]!)
     await session.close()
 
-    expect(navigate).toHaveBeenCalledWith('https://example.test/search', undefined)
+    expect(navigate).toHaveBeenCalledWith(
+      'https://example.test/search',
+      undefined,
+    )
     expect(action).toMatchObject({
       state: 'passed',
       resolvedActions: [{ description: 'Fill the search field' }],
@@ -77,7 +94,8 @@ describe('createWebAdapter', () => {
     })
     expect(outcome).toMatchObject({
       state: 'failed',
-      message: 'Expected: "pickle results are visible" | Actual: No results were shown',
+      message:
+        'Expected: "pickle results are visible" | Actual: No results were shown',
       artifacts: [{ kind: 'screenshot', mediaType: 'image/png' }],
     })
     expect(navigation.artifacts?.[0]?.path).toContain(artifactDirectory)
@@ -94,14 +112,25 @@ describe('createWebAdapter', () => {
     const automation: WebAutomation = {
       navigate,
       observe,
-      async act() { return { success: true } },
-      async verify() { return { meetsExpectation: true, actualState: 'Ready' } },
-      async screenshot() { return new Uint8Array() },
+      async act() {
+        return { success: true }
+      },
+      async verify() {
+        return { meetsExpectation: true, actualState: 'Ready' }
+      },
+      async screenshot() {
+        return new Uint8Array()
+      },
       async close() {},
     }
-    const adapter = createWebAdapter({ baseUrl: 'https://example.test' }, {
-      async open() { return automation },
-    })
+    const adapter = createWebAdapter(
+      { baseUrl: 'https://example.test' },
+      {
+        async open() {
+          return automation
+        },
+      },
+    )
     const session = await adapter.openSession({
       executionTargetProfile: { id: 'web' },
       specification,
@@ -117,10 +146,15 @@ describe('createWebAdapter', () => {
 
     expect(result).toMatchObject({
       state: 'passed',
-      resolvedActions: [{ description: 'Navigate to https://example.test/checkout' }],
+      resolvedActions: [
+        { description: 'Navigate to https://example.test/checkout' },
+      ],
     })
     expect(navigate).toHaveBeenCalledTimes(1)
-    expect(navigate).toHaveBeenCalledWith('https://example.test/checkout', undefined)
+    expect(navigate).toHaveBeenCalledWith(
+      'https://example.test/checkout',
+      undefined,
+    )
     expect(observe).not.toHaveBeenCalled()
   })
 })

--- a/packages/web/src/web-adapter.ts
+++ b/packages/web/src/web-adapter.ts
@@ -1,8 +1,10 @@
+import { mkdir } from 'node:fs/promises'
+import { join, resolve } from 'node:path'
 import {
-  Stagehand,
   browserbase,
   localBrowser,
   type ModelConfig,
+  Stagehand,
 } from '@browserbasehq/stagehand'
 import type {
   ExecutionTargetAdapter,
@@ -10,8 +12,6 @@ import type {
   TestArtifact,
 } from '@pickle-spec/runner'
 import type { ScenarioStep } from '@pickle-spec/spec'
-import { mkdir } from 'node:fs/promises'
-import { join, resolve } from 'node:path'
 import { z } from 'zod'
 
 export interface BrowserOptions {
@@ -49,22 +49,32 @@ function record(value: unknown, field: string): Record<string, unknown> {
   return value as Record<string, unknown>
 }
 
-function knownFields(value: Record<string, unknown>, fields: readonly string[], parent: string): void {
+function knownFields(
+  value: Record<string, unknown>,
+  fields: readonly string[],
+  parent: string,
+): void {
   for (const field of Object.keys(value)) {
-    if (!fields.includes(field)) throw new Error(`${parent}.${field} is not supported`)
+    if (!fields.includes(field))
+      throw new Error(`${parent}.${field} is not supported`)
   }
 }
 
 function optionalString(value: unknown, field: string): void {
-  if (value !== undefined && typeof value !== 'string') throw new Error(`${field} must be a string`)
+  if (value !== undefined && typeof value !== 'string')
+    throw new Error(`${field} must be a string`)
 }
 
 function optionalBoolean(value: unknown, field: string): void {
-  if (value !== undefined && typeof value !== 'boolean') throw new Error(`${field} must be a boolean`)
+  if (value !== undefined && typeof value !== 'boolean')
+    throw new Error(`${field} must be a boolean`)
 }
 
 function optionalPositiveInteger(value: unknown, field: string): void {
-  if (value !== undefined && (!Number.isInteger(value) || (value as number) < 1)) {
+  if (
+    value !== undefined &&
+    (!Number.isInteger(value) || (value as number) < 1)
+  ) {
     throw new Error(`${field} must be an integer greater than or equal to 1`)
   }
 }
@@ -83,35 +93,77 @@ export function validateWebAdapterOptions(value: unknown): WebAdapterOptions {
 
   if (web.browser !== undefined) {
     const browser = record(web.browser, 'web.browser')
-    knownFields(browser, [
-      'environment', 'modelName', 'modelApiKey', 'headless', 'browserbaseApiKey',
-      'browserbaseProjectId', 'cache', 'selfHeal', 'domSettleTimeoutMs', 'observeTimeoutMs',
-      'actTimeoutMs', 'navigationTimeoutMs',
-    ], 'web.browser')
-    if (browser.environment !== undefined && browser.environment !== 'local' && browser.environment !== 'browserbase') {
+    knownFields(
+      browser,
+      [
+        'environment',
+        'modelName',
+        'modelApiKey',
+        'headless',
+        'browserbaseApiKey',
+        'browserbaseProjectId',
+        'cache',
+        'selfHeal',
+        'domSettleTimeoutMs',
+        'observeTimeoutMs',
+        'actTimeoutMs',
+        'navigationTimeoutMs',
+      ],
+      'web.browser',
+    )
+    if (
+      browser.environment !== undefined &&
+      browser.environment !== 'local' &&
+      browser.environment !== 'browserbase'
+    ) {
       throw new Error('web.browser.environment must be local or browserbase')
     }
     optionalString(browser.modelName, 'web.browser.modelName')
     optionalString(browser.modelApiKey, 'web.browser.modelApiKey')
     optionalString(browser.browserbaseApiKey, 'web.browser.browserbaseApiKey')
-    optionalString(browser.browserbaseProjectId, 'web.browser.browserbaseProjectId')
+    optionalString(
+      browser.browserbaseProjectId,
+      'web.browser.browserbaseProjectId',
+    )
     optionalBoolean(browser.headless, 'web.browser.headless')
     optionalBoolean(browser.cache, 'web.browser.cache')
     optionalBoolean(browser.selfHeal, 'web.browser.selfHeal')
-    optionalPositiveInteger(browser.domSettleTimeoutMs, 'web.browser.domSettleTimeoutMs')
-    optionalPositiveInteger(browser.observeTimeoutMs, 'web.browser.observeTimeoutMs')
+    optionalPositiveInteger(
+      browser.domSettleTimeoutMs,
+      'web.browser.domSettleTimeoutMs',
+    )
+    optionalPositiveInteger(
+      browser.observeTimeoutMs,
+      'web.browser.observeTimeoutMs',
+    )
     optionalPositiveInteger(browser.actTimeoutMs, 'web.browser.actTimeoutMs')
-    optionalPositiveInteger(browser.navigationTimeoutMs, 'web.browser.navigationTimeoutMs')
+    optionalPositiveInteger(
+      browser.navigationTimeoutMs,
+      'web.browser.navigationTimeoutMs',
+    )
   }
 
   if (web.screenshots !== undefined) {
     const screenshots = record(web.screenshots, 'web.screenshots')
-    knownFields(screenshots, ['mode', 'outputDir', 'format', 'fullPage'], 'web.screenshots')
-    if (screenshots.mode !== undefined && !['off', 'on-failure', 'on-step'].includes(screenshots.mode as string)) {
-      throw new Error('web.screenshots.mode must be off, on-failure, or on-step')
+    knownFields(
+      screenshots,
+      ['mode', 'outputDir', 'format', 'fullPage'],
+      'web.screenshots',
+    )
+    if (
+      screenshots.mode !== undefined &&
+      !['off', 'on-failure', 'on-step'].includes(screenshots.mode as string)
+    ) {
+      throw new Error(
+        'web.screenshots.mode must be off, on-failure, or on-step',
+      )
     }
     optionalString(screenshots.outputDir, 'web.screenshots.outputDir')
-    if (screenshots.format !== undefined && screenshots.format !== 'png' && screenshots.format !== 'jpeg') {
+    if (
+      screenshots.format !== undefined &&
+      screenshots.format !== 'png' &&
+      screenshots.format !== 'jpeg'
+    ) {
       throw new Error('web.screenshots.format must be png or jpeg')
     }
     optionalBoolean(screenshots.fullPage, 'web.screenshots.fullPage')
@@ -128,17 +180,29 @@ export interface WebObservedAction {
 export interface WebAutomation {
   navigate(url: string, signal?: AbortSignal): Promise<void>
   observe(prompt: string, signal?: AbortSignal): Promise<WebObservedAction[]>
-  act(action: WebObservedAction, signal?: AbortSignal): Promise<{ success: boolean; message?: string }>
-  verify(prompt: string, signal?: AbortSignal): Promise<{
+  act(
+    action: WebObservedAction,
+    signal?: AbortSignal,
+  ): Promise<{ success: boolean; message?: string }>
+  verify(
+    prompt: string,
+    signal?: AbortSignal,
+  ): Promise<{
     meetsExpectation: boolean
     actualState: string
   }>
-  screenshot(options: { format: 'png' | 'jpeg'; fullPage: boolean }): Promise<Uint8Array>
+  screenshot(options: {
+    format: 'png' | 'jpeg'
+    fullPage: boolean
+  }): Promise<Uint8Array>
   close(): Promise<void>
 }
 
 export interface WebAutomationFactory {
-  open(input: { browser: BrowserOptions; signal?: AbortSignal }): Promise<WebAutomation>
+  open(input: {
+    browser: BrowserOptions
+    signal?: AbortSignal
+  }): Promise<WebAutomation>
 }
 
 const verificationSchema = z.object({
@@ -152,9 +216,9 @@ const navigationPattern = new RegExp(
     '|(?:eu )?(?:navego para|visito|abro|estou em)' +
     '|(?:yo )?(?:navego a|visito|abro|estoy en)' +
     '|(?:je )?(?:navigue vers|visite|ouvre|suis sur)' +
-  ')' +
-  '\\s+(?:(?:the|a|o|la|le|el|à)\\s+)?' +
-  '["\']?(.+?)["\']?\\s*$',
+    ')' +
+    '\\s+(?:(?:the|a|o|la|le|el|à)\\s+)?' +
+    '["\']?(.+?)["\']?\\s*$',
   'i',
 )
 
@@ -170,11 +234,11 @@ function withAbort<T>(operation: Promise<T>, signal?: AbortSignal): Promise<T> {
     const onAbort = () => reject(abortError())
     signal.addEventListener('abort', onAbort, { once: true })
     operation.then(
-      value => {
+      (value) => {
         signal.removeEventListener('abort', onAbort)
         resolvePromise(value)
       },
-      error => {
+      (error) => {
         signal.removeEventListener('abort', onAbort)
         reject(error)
       },
@@ -191,14 +255,19 @@ async function activePage(stagehand: Stagehand) {
 const stagehandFactory: WebAutomationFactory = {
   async open({ browser: options, signal }) {
     if (signal?.aborted) throw abortError()
-    const browser = options.environment === 'browserbase'
-      ? await browserbase.launch({
-          apiKey: options.browserbaseApiKey ?? process.env.BROWSERBASE_API_KEY!,
-          projectId: options.browserbaseProjectId ?? process.env.BROWSERBASE_PROJECT_ID!,
-        })
-      : await localBrowser.launch({ headless: options.headless ?? true })
+    const browser =
+      options.environment === 'browserbase'
+        ? await browserbase.launch({
+            apiKey:
+              options.browserbaseApiKey ?? process.env.BROWSERBASE_API_KEY!,
+            projectId:
+              options.browserbaseProjectId ??
+              process.env.BROWSERBASE_PROJECT_ID!,
+          })
+        : await localBrowser.launch({ headless: options.headless ?? true })
     const model: ModelConfig = {
-      modelName: (options.modelName ?? 'anthropic/claude-sonnet-4-6') as ModelConfig['modelName'],
+      modelName: (options.modelName ??
+        'anthropic/claude-sonnet-4-6') as ModelConfig['modelName'],
       ...(options.modelApiKey ? { apiKey: options.modelApiKey } : {}),
     }
     const stagehand = await Stagehand.create({
@@ -213,17 +282,24 @@ const stagehandFactory: WebAutomationFactory = {
     return {
       async navigate(url, operationSignal) {
         const page = await activePage(stagehand)
-        await withAbort(page.goto(url, {
-          waitUntil: 'domcontentloaded',
-          timeout: options.navigationTimeoutMs ?? 15_000,
-        }).then(() => undefined), operationSignal)
+        await withAbort(
+          page
+            .goto(url, {
+              waitUntil: 'domcontentloaded',
+              timeout: options.navigationTimeoutMs ?? 15_000,
+            })
+            .then(() => undefined),
+          operationSignal,
+        )
       },
       async observe(prompt, operationSignal) {
         const result = await withAbort(
-          stagehand.observe(prompt, { timeout: options.observeTimeoutMs ?? 10_000 }),
+          stagehand.observe(prompt, {
+            timeout: options.observeTimeoutMs ?? 10_000,
+          }),
           operationSignal,
         )
-        return result.data.map(action => ({
+        return result.data.map((action) => ({
           description: action.description,
           handle: action,
         }))
@@ -253,14 +329,20 @@ const stagehandFactory: WebAutomationFactory = {
       },
       async screenshot(screenshotOptions) {
         const page = await activePage(stagehand)
-        return new Uint8Array(await page.screenshot({
-          type: screenshotOptions.format,
-          fullPage: screenshotOptions.fullPage,
-        }))
+        return new Uint8Array(
+          await page.screenshot({
+            type: screenshotOptions.format,
+            fullPage: screenshotOptions.fullPage,
+          }),
+        )
       },
       async close() {
-        try { await stagehand.close() } catch {}
-        try { await stagehand.browser.close() } catch {}
+        try {
+          await stagehand.close()
+        } catch {}
+        try {
+          await stagehand.browser.close()
+        } catch {}
       },
     }
   },
@@ -270,7 +352,7 @@ function promptFor(step: ScenarioStep): string {
   let prompt = step.text
   if (step.argument?.dataTable) {
     prompt += '\n\nWith the following data:\n'
-    prompt += step.argument.dataTable.map(row => row.join(' | ')).join('\n')
+    prompt += step.argument.dataTable.map((row) => row.join(' | ')).join('\n')
   }
   if (step.argument?.docString) prompt += `\n\n${step.argument.docString}`
   return prompt
@@ -316,7 +398,9 @@ export function createWebAdapter(
         input.signal?.removeEventListener('abort', onAbort)
         await automation.close()
       }
-      const onAbort = () => { void close() }
+      const onAbort = () => {
+        void close()
+      }
       input.signal?.addEventListener('abort', onAbort, { once: true })
 
       async function screenshot(
@@ -326,7 +410,11 @@ export function createWebAdapter(
         const screenshotOptions = validatedOptions.screenshots
         const mode = screenshotOptions?.mode ?? 'off'
         if (mode === 'off') return undefined
-        if (mode === 'on-failure' && state !== 'failed' && state !== 'infrastructure-error') {
+        if (
+          mode === 'on-failure' &&
+          state !== 'failed' &&
+          state !== 'infrastructure-error'
+        ) {
           return undefined
         }
         if (state === 'cancelled' || state === 'skipped') return undefined
@@ -343,10 +431,13 @@ export function createWebAdapter(
             directory,
             `step-${String(stepIndex).padStart(2, '0')}-${state}-${safeName(step.text).slice(0, 40)}.${format}`,
           )
-          await Bun.write(path, await automation.screenshot({
-            format,
-            fullPage: screenshotOptions?.fullPage ?? false,
-          }))
+          await Bun.write(
+            path,
+            await automation.screenshot({
+              format,
+              fullPage: screenshotOptions?.fullPage ?? false,
+            }),
+          )
           return {
             kind: 'screenshot',
             path,
@@ -381,7 +472,10 @@ export function createWebAdapter(
           try {
             const navigation = prompt.match(navigationPattern)
             if (navigation) {
-              const url = navigationUrl(validatedOptions.baseUrl, navigation[1]!.trim())
+              const url = navigationUrl(
+                validatedOptions.baseUrl,
+                navigation[1]!.trim(),
+              )
               await automation.navigate(url, operationSignal)
               navigated = true
               return finish(step, {
@@ -392,7 +486,10 @@ export function createWebAdapter(
 
             await ensureNavigation(operationSignal)
             if (step.type === 'outcome') {
-              const verification = await automation.verify(prompt, operationSignal)
+              const verification = await automation.verify(
+                prompt,
+                operationSignal,
+              )
               if (!verification.meetsExpectation) {
                 return finish(step, {
                   state: 'failed',
@@ -407,7 +504,8 @@ export function createWebAdapter(
             }
 
             let actions = await automation.observe(prompt, operationSignal)
-            if (actions.length === 0) actions = await automation.observe(prompt, operationSignal)
+            if (actions.length === 0)
+              actions = await automation.observe(prompt, operationSignal)
             if (actions.length === 0) {
               return finish(step, {
                 state: 'infrastructure-error',
@@ -430,7 +528,10 @@ export function createWebAdapter(
             }
             return finish(step, { state: 'passed', resolvedActions })
           } catch (error) {
-            if (operationSignal?.aborted || (error instanceof Error && error.name === 'AbortError')) {
+            if (
+              operationSignal?.aborted ||
+              (error instanceof Error && error.name === 'AbortError')
+            ) {
               throw abortError()
             }
             return finish(step, {


### PR DESCRIPTION
## Summary
- Add namespaced `@pickle:id:` tags on Feature, Scenario, and Examples blocks, plus a reserved `pickle_id` column on Examples rows.
- Declare Specification state with `@pickle:state:draft|active|deprecated`.
- Introduce `pickle migrate` to preview localized metadata edits and write only after `--yes` or an interactive confirmation.
- Extend `pickle check` to reject missing, duplicate, malformed, or conflicting metadata. `pickle run` reports missing metadata and never rewrites feature files.

Closes #14

## Test plan
- [ ] `pickle migrate` on a project without metadata prints namespaced IDs and state tags and leaves files unchanged
- [ ] `pickle migrate --yes` writes those identifiers, preserves comments/whitespace, and a second run reports no changes
- [ ] `pickle check` fails on missing, duplicate, malformed, and conflicting metadata
- [ ] `pickle check` and `pickle run` do not modify feature files
- [ ] `bun run typecheck` and `bun run test` pass


Made with [Cursor](https://cursor.com)