### PR TITLE
Select test suites and execution target profiles

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -12,6 +12,18 @@ _Avoid_: Spec file, test file
 A platform-independent example of expected product behavior within a specification.
 _Avoid_: Test case, script
 
+**Identifier**:
+The durable identity of a specification, scenario, examples block, or examples row. Test results, execution plans, and history attach to this identity.
+_Avoid_: Pickle ID, cucumber ID, test ID
+
+**Derived identifier**:
+The identifier computed from the specification URI and name, together with the scenario or examples name or examples row values, when no explicit identifier is declared.
+_Avoid_: Implicit ID, automatic ID, content hash, natural key
+
+**Explicit identifier**:
+An identifier declared on a specification, scenario, examples block, or examples row that replaces the derived identifier.
+_Avoid_: Manual ID, override ID, pinned ID
+
 **Execution target**:
 The product surface where a scenario runs, such as a web application or mobile application.
 _Avoid_: Platform, engine, environment

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Create `pickle.config.jsonc` in the project root:
 }
 ```
 
-Set the API key for the configured model provider. Bun loads environment variables from `.env`.
+Set the API key for the configured model provider. Bun loads environment variables from `.env`. For local Chrome, Stagehand needs that key on `model.apiKey`: set `web.browser.modelApiKey` or the provider env var (`OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, `GOOGLE_API_KEY`, `GEMINI_API_KEY`, or `GOOGLE_GENERATIVE_AI_API_KEY`). `web.browser.modelName` must be a Stagehand-supported `provider/model` value; Pickle Spec rejects unknown names before it starts browsers.
 
 ## Run Specifications
 

--- a/README.md
+++ b/README.md
@@ -40,19 +40,29 @@ Create `pickle.config.jsonc` in the project root:
 {
   "schemaVersion": 1,
   "specifications": "features/**/*.feature",
-  "executionTargetProfile": {
-    "id": "web"
+  "suites": {
+    "smoke": {
+      "paths": ["features/checkout/**"],
+      "tagExpression": "@smoke",
+      "states": ["active"]
+    }
   },
-  "web": {
-    "baseUrl": "http://localhost:3000",
-    "browser": {
-      "environment": "local",
-      "modelName": "anthropic/claude-sonnet-4-6",
-      "headless": true
-    },
-    "screenshots": {
-      "mode": "on-failure",
-      "outputDir": ".pickle/artifacts"
+  "executionTargetProfiles": {
+    "web": {
+      "adapter": "web",
+      "capabilities": ["screenshots"],
+      "web": {
+        "baseUrl": "http://localhost:3000",
+        "browser": {
+          "environment": "local",
+          "modelName": "anthropic/claude-sonnet-4-6",
+          "headless": true
+        },
+        "screenshots": {
+          "mode": "on-failure",
+          "outputDir": ".pickle/artifacts"
+        }
+      }
     }
   },
   "execution": {
@@ -72,13 +82,10 @@ To run the configured Specification glob, use:
 
 ```bash
 pickle run
-```
-
-To select Scenarios or override execution policy, use:
-
-```bash
+pickle run --suite smoke --profile web
 pickle run "features/**/*.feature" --tag "@smoke and not @slow"
 pickle run "features/**/*.feature" --scenario "checkout"
+pickle run "features/**/*.feature" --state draft
 pickle run "features/**/*.feature" --shard 1/3
 pickle run "features/**/*.feature" --concurrency 5 --retries 1
 pickle run "features/**/*.feature" --screenshot on-step
@@ -94,6 +101,7 @@ Create `pickle.extensions.ts` when a project needs a custom execution-target ada
 import type { ExecutionTargetAdapter } from '@pickle-spec/runner'
 
 const adapter: ExecutionTargetAdapter = {
+  capabilities: ['filesystem'],
   async openSession() {
     return {
       async executeStep(step) {
@@ -108,13 +116,28 @@ const adapter: ExecutionTargetAdapter = {
 }
 
 export default {
-  executionTargetProfile: { id: 'custom' },
-  adapter,
+  adapters: {
+    custom: adapter,
+  },
+}
+```
+
+Declare the profile in `pickle.config.jsonc` and import the adapter explicitly. Pickle Spec does not discover plugins dynamically.
+
+```jsonc
+{
+  "schemaVersion": 1,
+  "executionTargetProfiles": {
+    "custom": {
+      "adapter": "custom",
+      "capabilities": ["filesystem"]
+    }
+  }
 }
 ```
 
 Run the custom adapter with:
 
 ```bash
-pickle run "features/**/*.feature" --extensions pickle.extensions.ts
+pickle run --profile custom --extensions pickle.extensions.ts
 ```

--- a/apps/example/features/google-pt.feature
+++ b/apps/example/features/google-pt.feature
@@ -1,4 +1,5 @@
 # language: pt
+@pickle:state:active
 Funcionalidade: Busca
 
   Cenário: Visitar página principal

--- a/apps/example/features/google.feature
+++ b/apps/example/features/google.feature
@@ -1,3 +1,4 @@
+@pickle:state:active
 Feature: Search
 
   @ignore

--- a/apps/example/package.json
+++ b/apps/example/package.json
@@ -3,7 +3,9 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "run:example": "pickle run"
+    "run:example": "pickle run",
+    "migrate": "pickle migrate",
+    "smoke": "pickle run --suite google --profile web"
   },
   "dependencies": {
     "@pickle-spec/cli": "workspace:*"

--- a/apps/example/pickle.config.jsonc
+++ b/apps/example/pickle.config.jsonc
@@ -8,8 +8,8 @@
     "baseUrl": "https://google.com",
     "browser": {
       "environment": "local",
-      "modelName": "openai/gpt-5.2",
-      "headless": true
+      "modelName": "google/gemini-3.6-flash",
+      "headless": false
     }
   }
 }

--- a/docs/adr/0005-use-gherkin-tags-for-durable-identity.md
+++ b/docs/adr/0005-use-gherkin-tags-for-durable-identity.md
@@ -1,3 +1,7 @@
+---
+status: superseded by ADR-0011
+---
+
 # Use Gherkin tags for durable identity
 
 Pickle Spec uses namespaced Gherkin tags as durable specification and scenario identifiers. Generated Cucumber IDs cannot identify history, test results, or execution plans because they change during parsing.

--- a/docs/adr/0011-derive-identifiers-unless-declared.md
+++ b/docs/adr/0011-derive-identifiers-unless-declared.md
@@ -1,0 +1,7 @@
+# Derive identifiers unless the specification declares one
+
+A specification, scenario, examples block, or examples row has an identifier so test results, execution plans, and history can attach to it. That identifier is derived from the specification URI and name, plus the scenario or examples name or examples row values, unless the source declares an explicit identifier.
+
+Renaming a Feature or Scenario, moving a specification to another URI, copying a same-name scenario in the same specification, or changing an examples cell produces a new derived identifier. Editing steps or reordering examples rows does not. An explicit identifier is the only way to keep the previous identity across those changes. Step text stays out of the identifier because scenario revision already answers whether an execution plan still applies.
+
+This supersedes ADR-0005, which required a random namespaced tag or `pickle_id` in source so identity would survive any edit.

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -195,10 +195,10 @@ function configuredWebOptions(
   args: RunArguments,
   profileId?: string,
 ): WebAdapterOptions | undefined {
-  const profileWeb = profileId
-    ? config.executionTargetProfiles?.[profileId]?.web
-    : undefined
-  const web = profileWeb ?? config.web
+  const web =
+    (profileId
+      ? config.executionTargetProfiles?.[profileId]?.web
+      : undefined) ?? config.web
   if (!web) return undefined
   return {
     ...web,
@@ -254,12 +254,10 @@ function configuredRunExtensions(
     )
   }
 
-  if (profiles.some((profile) => profile.adapter)) {
-    return { adapter: extensions.adapter, adapters }
-  }
-
   return {
-    adapter: configuredAdapter(extensions, configuredWebOptions(config, args)),
+    adapter: profiles.some((profile) => profile.adapter)
+      ? extensions.adapter
+      : configuredAdapter(extensions, configuredWebOptions(config, args)),
     adapters,
   }
 }
@@ -277,10 +275,10 @@ async function run(argv: string[]): Promise<number> {
       args.pattern ?? config.specifications ?? 'features/**/*.feature',
       args.language ?? config.language,
     )
-    if (args.suite && !config.suites?.[args.suite]) {
+    const suiteSelection = args.suite ? config.suites?.[args.suite] : undefined
+    if (args.suite && !suiteSelection) {
       throw new Error(`Unknown test suite "${args.suite}"`)
     }
-    const suiteSelection = args.suite ? config.suites?.[args.suite] : undefined
     const baseSelection = suiteSelection ?? config.selection
     const selections = selectScenarios(specifications, {
       ...baseSelection,

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -2,16 +2,25 @@
 
 import { relative, resolve } from 'node:path'
 import { pathToFileURL } from 'node:url'
-import type { ExecutionTargetAdapter } from '@pickle-spec/runner'
-import { resolveRunConfiguration, runScenarios } from '@pickle-spec/runner'
+import type {
+  ExecutionTargetAdapter,
+  ExecutionTargetProfile,
+  RunExtensions,
+} from '@pickle-spec/runner'
+import {
+  resolveRunConfiguration,
+  runScenarios,
+  validateTargetSelection,
+} from '@pickle-spec/runner'
 import {
   parseSpecification,
   type SelectionOptions,
+  type SpecificationState,
   selectScenarios,
   validateSpecificationMetadata,
 } from '@pickle-spec/spec'
 import { createWebAdapter, type WebAdapterOptions } from '@pickle-spec/web'
-import { loadConfig, type PickleConfig } from './config'
+import { loadConfig, type PickleConfig, runConfigurationFrom } from './config'
 import type { Extensions } from './extensions'
 import { checkProject, initializeProject, migrateProject } from './project'
 import { startServer } from './server'
@@ -20,6 +29,8 @@ interface RunArguments {
   pattern?: string
   configPath?: string
   extensionsPath?: string
+  suite?: string
+  profiles?: string[]
   selection: SelectionOptions
   retries?: number
   concurrency?: number
@@ -70,6 +81,12 @@ function parseRunArguments(argv: string[]): RunArguments {
       case '--extensions':
         args.extensionsPath = valueAfter(argv, index++)
         break
+      case '--suite':
+        args.suite = valueAfter(argv, index++)
+        break
+      case '--profile':
+        args.profiles = [...(args.profiles ?? []), valueAfter(argv, index++)]
+        break
       case '--scenario':
         args.selection.scenarioName = valueAfter(argv, index++)
         break
@@ -77,6 +94,14 @@ function parseRunArguments(argv: string[]): RunArguments {
       case '-t':
         args.selection.tagExpression = valueAfter(argv, index++)
         break
+      case '--state': {
+        const state = valueAfter(argv, index++)
+        args.selection.states = [
+          ...(args.selection.states ?? []),
+          state as SpecificationState,
+        ]
+        break
+      }
       case '--shard':
         args.selection.shard = parseShard(valueAfter(argv, index++))
         break
@@ -168,16 +193,21 @@ async function discoverSpecifications(
 function configuredWebOptions(
   config: PickleConfig,
   args: RunArguments,
+  profileId?: string,
 ): WebAdapterOptions | undefined {
-  if (!config.web) return undefined
+  const profileWeb = profileId
+    ? config.executionTargetProfiles?.[profileId]?.web
+    : undefined
+  const web = profileWeb ?? config.web
+  if (!web) return undefined
   return {
-    ...config.web,
+    ...web,
     browser: {
-      ...config.web.browser,
+      ...web.browser,
       ...(args.headed ? { headless: false } : {}),
     },
     screenshots: {
-      ...config.web.screenshots,
+      ...web.screenshots,
       ...(args.screenshotMode ? { mode: args.screenshotMode } : {}),
     },
   }
@@ -195,6 +225,45 @@ function configuredAdapter(
   return createWebAdapter(web, extensions.webAutomationFactory)
 }
 
+function configuredRunExtensions(
+  extensions: Extensions,
+  config: PickleConfig,
+  args: RunArguments,
+  profiles: readonly ExecutionTargetProfile[],
+): RunExtensions {
+  const adapters: Record<string, ExecutionTargetAdapter> = {
+    ...extensions.adapters,
+  }
+  if (extensions.adapter) adapters.custom ??= extensions.adapter
+
+  for (const profile of profiles) {
+    if (profile.adapter !== 'web' || adapters[profile.id]) continue
+    const web = configuredWebOptions(config, args, profile.id)
+    if (adapters.web) {
+      adapters[profile.id] = adapters.web
+      continue
+    }
+    if (!web) {
+      throw new Error(
+        'Configure web.baseUrl or export an adapter from pickle.extensions.ts',
+      )
+    }
+    adapters[profile.id] = createWebAdapter(
+      web,
+      extensions.webAutomationFactory,
+    )
+  }
+
+  if (profiles.some((profile) => profile.adapter)) {
+    return { adapter: extensions.adapter, adapters }
+  }
+
+  return {
+    adapter: configuredAdapter(extensions, configuredWebOptions(config, args)),
+    adapters,
+  }
+}
+
 async function run(argv: string[]): Promise<number> {
   const args = parseRunArguments(argv)
   const config = await loadConfig(args.configPath)
@@ -208,35 +277,41 @@ async function run(argv: string[]): Promise<number> {
       args.pattern ?? config.specifications ?? 'features/**/*.feature',
       args.language ?? config.language,
     )
+    if (args.suite && !config.suites?.[args.suite]) {
+      throw new Error(`Unknown test suite "${args.suite}"`)
+    }
+    const suiteSelection = args.suite ? config.suites?.[args.suite] : undefined
+    const baseSelection = suiteSelection ?? config.selection
     const selections = selectScenarios(specifications, {
-      ...config.selection,
+      ...baseSelection,
       ...args.selection,
-      shard: args.selection.shard ?? config.selection?.shard,
+      shard: args.selection.shard ?? baseSelection?.shard,
     })
     if (selections.length === 0)
       throw new Error('No Scenarios match the current selection')
 
     const extensions = await loadExtensions(args.extensionsPath)
-    const web = configuredWebOptions(config, args)
+    const runConfiguration = {
+      ...runConfigurationFrom(config, args.profiles),
+      concurrency: args.concurrency ?? config.concurrency,
+      execution: {
+        infrastructureRetries:
+          args.retries ?? config.execution?.infrastructureRetries,
+        stepTimeoutMs: args.stepTimeoutMs ?? config.execution?.stepTimeoutMs,
+        scenarioTimeoutMs:
+          args.scenarioTimeoutMs ?? config.execution?.scenarioTimeoutMs,
+      },
+    }
     const resolvedConfiguration = resolveRunConfiguration(
-      {
-        schemaVersion: config.schemaVersion,
-        executionTargetProfile: config.executionTargetProfile ?? {
-          id: web ? 'web' : 'custom',
-        },
-        concurrency: args.concurrency ?? config.concurrency,
-        execution: {
-          infrastructureRetries:
-            args.retries ?? config.execution?.infrastructureRetries,
-          stepTimeoutMs: args.stepTimeoutMs ?? config.execution?.stepTimeoutMs,
-          scenarioTimeoutMs:
-            args.scenarioTimeoutMs ?? config.execution?.scenarioTimeoutMs,
-        },
-      },
-      {
-        adapter: configuredAdapter(extensions, web),
-      },
+      runConfiguration,
+      configuredRunExtensions(
+        extensions,
+        config,
+        args,
+        runConfiguration.executionTargetProfiles ?? [],
+      ),
     )
+    validateTargetSelection(selections, resolvedConfiguration.targets)
     server = await startServer({
       ...config.server,
       ...(args.reuseServer ? { reuseExisting: true } : {}),

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -47,39 +47,43 @@ export interface PickleConfig {
   server?: ServerConfig
 }
 
+function toExecutionTargetProfile(
+  id: string,
+  profile: {
+    adapter?: string
+    capabilities?: readonly string[]
+  },
+): ExecutionTargetProfile {
+  return {
+    id,
+    ...(profile.adapter ? { adapter: profile.adapter } : {}),
+    ...(profile.capabilities ? { capabilities: profile.capabilities } : {}),
+  }
+}
+
 function selectedExecutionTargetProfiles(
   config: PickleConfig,
   profileIds?: readonly string[],
 ): ExecutionTargetProfile[] {
   if (config.executionTargetProfiles) {
-    const ids = profileIds?.length
-      ? profileIds
-      : Object.keys(config.executionTargetProfiles)
+    const profiles = config.executionTargetProfiles
+    const ids = profileIds?.length ? profileIds : Object.keys(profiles)
     return ids.map((id) => {
-      const profile = config.executionTargetProfiles?.[id]
+      const profile = profiles[id]
       if (!profile) {
         throw new Error(`Unknown execution target profile "${id}"`)
       }
-      return {
-        id,
-        adapter: profile.adapter,
-        ...(profile.capabilities ? { capabilities: profile.capabilities } : {}),
-      }
+      return toExecutionTargetProfile(id, profile)
     })
   }
   if (profileIds?.length) {
     throw new Error(`Unknown execution target profile "${profileIds[0]}"`)
   }
   return [
-    {
-      id: config.executionTargetProfile?.id ?? (config.web ? 'web' : 'custom'),
-      ...(config.executionTargetProfile?.adapter
-        ? { adapter: config.executionTargetProfile.adapter }
-        : {}),
-      ...(config.executionTargetProfile?.capabilities
-        ? { capabilities: config.executionTargetProfile.capabilities }
-        : {}),
-    },
+    toExecutionTargetProfile(
+      config.executionTargetProfile?.id ?? (config.web ? 'web' : 'custom'),
+      config.executionTargetProfile ?? {},
+    ),
   ]
 }
 

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -23,10 +23,18 @@ export interface ServerConfig {
   reuseExisting?: boolean
 }
 
+export interface ProjectExecutionTargetProfile {
+  adapter: string
+  capabilities?: readonly string[]
+  web?: WebAdapterOptions
+}
+
 export interface PickleConfig {
   schemaVersion: 1
   language?: string
   specifications?: string | string[]
+  suites?: Record<string, SelectionOptions>
+  executionTargetProfiles?: Record<string, ProjectExecutionTargetProfile>
   executionTargetProfile?: ExecutionTargetProfile
   web?: WebAdapterOptions
   selection?: SelectionOptions
@@ -39,12 +47,54 @@ export interface PickleConfig {
   server?: ServerConfig
 }
 
-export function runConfigurationFrom(config: PickleConfig): RunConfiguration {
+function selectedExecutionTargetProfiles(
+  config: PickleConfig,
+  profileIds?: readonly string[],
+): ExecutionTargetProfile[] {
+  if (config.executionTargetProfiles) {
+    const ids = profileIds?.length
+      ? profileIds
+      : Object.keys(config.executionTargetProfiles)
+    return ids.map((id) => {
+      const profile = config.executionTargetProfiles?.[id]
+      if (!profile) {
+        throw new Error(`Unknown execution target profile "${id}"`)
+      }
+      return {
+        id,
+        adapter: profile.adapter,
+        ...(profile.capabilities ? { capabilities: profile.capabilities } : {}),
+      }
+    })
+  }
+  if (profileIds?.length) {
+    throw new Error(`Unknown execution target profile "${profileIds[0]}"`)
+  }
+  return [
+    {
+      id: config.executionTargetProfile?.id ?? (config.web ? 'web' : 'custom'),
+      ...(config.executionTargetProfile?.adapter
+        ? { adapter: config.executionTargetProfile.adapter }
+        : {}),
+      ...(config.executionTargetProfile?.capabilities
+        ? { capabilities: config.executionTargetProfile.capabilities }
+        : {}),
+    },
+  ]
+}
+
+export function runConfigurationFrom(
+  config: PickleConfig,
+  profileIds?: readonly string[],
+): RunConfiguration {
+  const executionTargetProfiles = selectedExecutionTargetProfiles(
+    config,
+    profileIds,
+  )
   return {
     schemaVersion: config.schemaVersion,
-    executionTargetProfile: config.executionTargetProfile ?? {
-      id: config.web ? 'web' : 'custom',
-    },
+    executionTargetProfile: executionTargetProfiles[0],
+    executionTargetProfiles,
     concurrency: config.concurrency,
     execution: config.execution,
   }
@@ -83,6 +133,68 @@ function optionalPositiveInteger(value: unknown, field: string): void {
   }
 }
 
+function validateCapabilities(
+  value: unknown,
+  field: string,
+): readonly string[] {
+  if (!Array.isArray(value) || value.length === 0) {
+    throw new Error(`${field} must contain at least one capability`)
+  }
+  if (!value.every((item) => typeof item === 'string' && item.trim())) {
+    throw new Error(`${field} must not contain an empty capability`)
+  }
+  return value
+}
+
+function validateSuites(value: unknown): Record<string, SelectionOptions> {
+  const suites = record(value, 'suites')
+  const result: Record<string, SelectionOptions> = {}
+  for (const [name, query] of Object.entries(suites)) {
+    if (!name.trim()) throw new Error('suites keys must not be empty')
+    const options = validateSelectionOptions(query)
+    if (options.shard) {
+      throw new Error(`suites.${name}.shard is not supported`)
+    }
+    result[name] = options
+  }
+  return result
+}
+
+function validateProjectProfiles(
+  value: unknown,
+): Record<string, ProjectExecutionTargetProfile> {
+  const profiles = record(value, 'executionTargetProfiles')
+  const ids = Object.keys(profiles)
+  if (ids.length === 0) {
+    throw new Error(
+      'executionTargetProfiles must contain at least one execution target profile',
+    )
+  }
+  const result: Record<string, ProjectExecutionTargetProfile> = {}
+  for (const id of ids) {
+    if (!id.trim()) {
+      throw new Error('executionTargetProfiles keys must not be empty')
+    }
+    const field = `executionTargetProfiles.${id}`
+    const profile = record(profiles[id], field)
+    knownFields(profile, ['adapter', 'capabilities', 'web'], field)
+    if (typeof profile.adapter !== 'string' || !profile.adapter.trim()) {
+      throw new Error(`${field}.adapter must not be empty`)
+    }
+    if (profile.capabilities !== undefined) {
+      profile.capabilities = validateCapabilities(
+        profile.capabilities,
+        `${field}.capabilities`,
+      )
+    }
+    if (profile.web !== undefined) {
+      profile.web = validateWebAdapterOptions(profile.web)
+    }
+    result[id] = profile as unknown as ProjectExecutionTargetProfile
+  }
+  return result
+}
+
 function validateConfig(value: unknown): PickleConfig {
   const config = record(value, 'configuration')
   knownFields(
@@ -91,6 +203,8 @@ function validateConfig(value: unknown): PickleConfig {
       'schemaVersion',
       'language',
       'specifications',
+      'suites',
+      'executionTargetProfiles',
       'executionTargetProfile',
       'web',
       'selection',
@@ -170,6 +284,12 @@ function validateConfig(value: unknown): PickleConfig {
     }
   }
   if (config.selection !== undefined) validateSelectionOptions(config.selection)
+  if (config.suites !== undefined) config.suites = validateSuites(config.suites)
+  if (config.executionTargetProfiles !== undefined) {
+    config.executionTargetProfiles = validateProjectProfiles(
+      config.executionTargetProfiles,
+    )
+  }
   const validatedConfig = config as unknown as PickleConfig
   validateRunConfiguration(runConfigurationFrom(validatedConfig))
   return validatedConfig

--- a/packages/cli/src/extension-validation.ts
+++ b/packages/cli/src/extension-validation.ts
@@ -57,11 +57,28 @@ function extensionProvidesAdapter(
     adapter &&
     typeChecker.getTypeOfSymbolAtLocation(adapter, adapterDeclaration)
 
+  const adapters = extensionType.getProperty('adapters')
+  const adaptersDeclaration =
+    adapters?.valueDeclaration ?? adapters?.declarations?.[0] ?? sourceFile
+  const adaptersType =
+    adapters &&
+    typeChecker.getTypeOfSymbolAtLocation(adapters, adaptersDeclaration)
+  const namedAdapters = Boolean(
+    adapters &&
+      adaptersType &&
+      !(adapters.flags & ts.SymbolFlags.Optional) &&
+      !(adaptersType.flags & ts.TypeFlags.Undefined) &&
+      adaptersType
+        .getProperties()
+        .some((property) => property.name !== '__index'),
+  )
+
   return Boolean(
-    adapter &&
+    (adapter &&
       !(adapter.flags & ts.SymbolFlags.Optional) &&
       adapterType &&
-      !(adapterType.flags & ts.TypeFlags.Undefined),
+      !(adapterType.flags & ts.TypeFlags.Undefined)) ||
+      namedAdapters,
   )
 }
 

--- a/packages/cli/src/extension-validation.ts
+++ b/packages/cli/src/extension-validation.ts
@@ -33,6 +33,21 @@ function isRelevantSemanticDiagnostic(
   )
 }
 
+function requiredExtensionPropertyType(
+  typeChecker: ts.TypeChecker,
+  parent: ts.Type,
+  name: string,
+  sourceFile: ts.SourceFile,
+): ts.Type | undefined {
+  const property = parent.getProperty(name)
+  if (!property || property.flags & ts.SymbolFlags.Optional) return undefined
+  const declaration =
+    property.valueDeclaration ?? property.declarations?.[0] ?? sourceFile
+  const type = typeChecker.getTypeOfSymbolAtLocation(property, declaration)
+  if (type.flags & ts.TypeFlags.Undefined) return undefined
+  return type
+}
+
 function extensionProvidesAdapter(
   typeChecker: ts.TypeChecker,
   defaultExport: ts.Symbol,
@@ -50,35 +65,22 @@ function extensionProvidesAdapter(
     exportedSymbol,
     declaration,
   )
-  const adapter = extensionType.getProperty('adapter')
-  const adapterDeclaration =
-    adapter?.valueDeclaration ?? adapter?.declarations?.[0] ?? sourceFile
-  const adapterType =
-    adapter &&
-    typeChecker.getTypeOfSymbolAtLocation(adapter, adapterDeclaration)
-
-  const adapters = extensionType.getProperty('adapters')
-  const adaptersDeclaration =
-    adapters?.valueDeclaration ?? adapters?.declarations?.[0] ?? sourceFile
-  const adaptersType =
-    adapters &&
-    typeChecker.getTypeOfSymbolAtLocation(adapters, adaptersDeclaration)
-  const namedAdapters = Boolean(
-    adapters &&
-      adaptersType &&
-      !(adapters.flags & ts.SymbolFlags.Optional) &&
-      !(adaptersType.flags & ts.TypeFlags.Undefined) &&
-      adaptersType
-        .getProperties()
-        .some((property) => property.name !== '__index'),
+  const adaptersType = requiredExtensionPropertyType(
+    typeChecker,
+    extensionType,
+    'adapters',
+    sourceFile,
   )
-
   return Boolean(
-    (adapter &&
-      !(adapter.flags & ts.SymbolFlags.Optional) &&
-      adapterType &&
-      !(adapterType.flags & ts.TypeFlags.Undefined)) ||
-      namedAdapters,
+    requiredExtensionPropertyType(
+      typeChecker,
+      extensionType,
+      'adapter',
+      sourceFile,
+    ) ||
+      adaptersType
+        ?.getProperties()
+        .some((property) => property.name !== '__index'),
   )
 }
 

--- a/packages/cli/src/extensions.ts
+++ b/packages/cli/src/extensions.ts
@@ -3,5 +3,6 @@ import type { WebAutomationFactory } from '@pickle-spec/web'
 
 export interface Extensions {
   adapter?: ExecutionTargetAdapter
+  adapters?: Record<string, ExecutionTargetAdapter>
   webAutomationFactory?: WebAutomationFactory
 }

--- a/packages/cli/src/workspace.test.ts
+++ b/packages/cli/src/workspace.test.ts
@@ -842,4 +842,263 @@ export default {
     expect(stdout).not.toContain('Stagehand')
     expect(stdout).not.toContain('gherkinDocument')
   })
+
+  test('selects a named test suite by path, tag, state, and name query', async () => {
+    const project = await createCheckProject('named-suite', {
+      config: {
+        schemaVersion: 1,
+        specifications: 'features/**/*.feature',
+        executionTargetProfile: { id: 'deterministic' },
+        suites: {
+          smoke: {
+            paths: ['features/checkout/**'],
+            tagExpression: '@smoke',
+            states: ['active', 'draft'],
+            scenarioName: 'checkout',
+          },
+        },
+      },
+      extensions: await Bun.file(
+        join(workspace, 'pickle.extensions.ts'),
+      ).text(),
+    })
+    await mkdir(join(project, 'features', 'checkout'), { recursive: true })
+    await Bun.write(
+      join(project, 'features', 'checkout', 'guest.feature'),
+      `@pickle:id:specguestaaaaaaaa @pickle:state:active @smoke
+Feature: Guest checkout
+  @pickle:id:scnguestbbbbbbbb
+  Scenario: Checkout as a guest
+    Then the purchase succeeds`,
+    )
+    await Bun.write(
+      join(project, 'features', 'checkout', 'draft.feature'),
+      `@pickle:id:specdraftaaaaaaaa @pickle:state:draft @smoke
+Feature: Draft checkout
+  @pickle:id:scndraftbbbbbbbb
+  Scenario: Checkout as a draft customer
+    Then the purchase succeeds`,
+    )
+    await Bun.write(
+      join(project, 'features', 'search.feature'),
+      `@pickle:id:specsearchaaaaaaa @pickle:state:active @smoke
+Feature: Search
+  @pickle:id:scnsearchbbbbbbb
+  Scenario: Find a product
+    Then results are visible`,
+    )
+
+    const run = Bun.spawnSync({
+      cmd: [pickleCommand, 'run', '--suite', 'smoke'],
+      cwd: project,
+      env: { ...Bun.env, PICKLE_TEST_OUTCOME: 'passed' },
+    })
+    const records = run.stdout
+      .toString()
+      .trim()
+      .split('\n')
+      .filter(Boolean)
+      .map((line) => JSON.parse(line))
+      .filter((record) => record.kind === 'test-result')
+
+    expect(run.stderr.toString()).toBe('')
+    expect(run.exitCode).toBe(0)
+    expect(
+      records.map((record) => [
+        record.result.specification.name,
+        record.result.scenario.name,
+      ]),
+    ).toEqual([
+      ['Draft checkout', 'Checkout as a draft customer'],
+      ['Guest checkout', 'Checkout as a guest'],
+    ])
+  })
+
+  test('produces one test result per Scenario and execution target profile', async () => {
+    const project = await createCheckProject('multi-target', {
+      config: {
+        schemaVersion: 1,
+        specifications: 'features/**/*.feature',
+        executionTargetProfiles: {
+          web: { adapter: 'web', capabilities: ['screenshots'] },
+          android: { adapter: 'android', capabilities: ['geolocation'] },
+        },
+      },
+      specification: validSpecification,
+      extensions: `
+export default {
+  adapters: {
+    web: {
+      capabilities: ['screenshots', 'web'],
+      async openSession() {
+        return {
+          async executeStep(step) {
+            return {
+              state: 'passed',
+              resolvedActions: [{ description: \`web: \${step.text}\` }],
+            }
+          },
+          async close() {},
+        }
+      },
+    },
+    android: {
+      capabilities: ['geolocation'],
+      async openSession() {
+        return {
+          async executeStep(step) {
+            return {
+              state: 'passed',
+              resolvedActions: [{ description: \`android: \${step.text}\` }],
+            }
+          },
+          async close() {},
+        }
+      },
+    },
+  },
+}
+`,
+    })
+
+    const run = Bun.spawnSync({
+      cmd: [pickleCommand, 'run'],
+      cwd: project,
+      env: { ...Bun.env },
+    })
+    const records = run.stdout
+      .toString()
+      .trim()
+      .split('\n')
+      .filter(Boolean)
+      .map((line) => JSON.parse(line))
+      .filter((record) => record.kind === 'test-result')
+
+    expect(run.stderr.toString()).toBe('')
+    expect(run.exitCode).toBe(0)
+    expect(
+      records.map((record) => [
+        record.result.scenario.name,
+        record.result.executionTargetProfile.id,
+        record.result.state,
+      ]),
+    ).toEqual([
+      ['Validate project', 'web', 'passed'],
+      ['Validate project', 'android', 'passed'],
+    ])
+  })
+
+  test('rejects an incompatible target selection before starting execution resources', async () => {
+    const projectName = 'incompatible-target'
+    const projectPath = join(workspace, projectName)
+    const marker = join(projectPath, 'server-started.txt')
+    const project = await createCheckProject(projectName, {
+      config: {
+        schemaVersion: 1,
+        specifications: 'features/**/*.feature',
+        executionTargetProfiles: {
+          web: { adapter: 'web', capabilities: ['screenshots'] },
+        },
+        server: {
+          command: `bun -e "await Bun.write('${marker}', 'started')"`,
+          url: 'http://127.0.0.1:1',
+          startupTimeoutMs: 50,
+          pollIntervalMs: 10,
+        },
+      },
+      specification: {
+        path: 'features/location.feature',
+        source: `@pickle:id:speclocationaaaa @pickle:state:active @pickle:requires:geolocation
+Feature: Nearby stores
+  @pickle:id:scnlocationbbbb
+  Scenario: Show stores near the customer
+    Then nearby stores are listed`,
+      },
+      extensions: `
+export default {
+  adapters: {
+    web: {
+      capabilities: ['screenshots', 'web'],
+      async openSession() {
+        throw new Error('must not open')
+      },
+    },
+  },
+}
+`,
+    })
+
+    const run = Bun.spawnSync({
+      cmd: [pickleCommand, 'run'],
+      cwd: project,
+      env: { ...Bun.env },
+    })
+
+    expect(run.exitCode).toBe(2)
+    expect(run.stderr.toString()).toContain(
+      'Execution target profile "web" lacks required capabilities for Scenario "Show stores near the customer": geolocation',
+    )
+    expect(await Bun.file(marker).exists()).toBe(false)
+  })
+
+  test('loads custom adapters only from explicit extension imports', async () => {
+    const project = await createCheckProject('no-plugin-discovery', {
+      config: {
+        schemaVersion: 1,
+        specifications: 'features/**/*.feature',
+        executionTargetProfiles: {
+          discovered: { adapter: 'discovered' },
+        },
+      },
+      specification: validSpecification,
+      extensions: 'export default {}',
+    })
+    const pluginPath = join(
+      project,
+      'node_modules',
+      'pickle-plugin-discovered',
+      'index.ts',
+    )
+    await mkdir(dirname(pluginPath), { recursive: true })
+    await Bun.write(
+      pluginPath,
+      `throw new Error('dynamic plugin discovery must not load this module')
+export default { adapter: { async openSession() { throw new Error('no') } } }
+`,
+    )
+
+    const run = Bun.spawnSync({
+      cmd: [pickleCommand, 'run'],
+      cwd: project,
+      env: { ...Bun.env },
+    })
+
+    expect(run.exitCode).toBe(2)
+    expect(run.stderr.toString()).toContain(
+      'Execution target profile "discovered" requires adapter "discovered". Import it from pickle.extensions.ts.',
+    )
+    expect(run.stderr.toString()).not.toContain('dynamic plugin discovery')
+  })
+
+  test('check rejects an invalid named test suite query', async () => {
+    const project = await createCheckProject('invalid-suite', {
+      config: {
+        ...defaultCheckConfig,
+        suites: {
+          smoke: { states: ['published'] },
+        },
+      },
+      specification: validSpecification,
+    })
+
+    const checked = runCheck(project)
+
+    expect(checked.exitCode).toBe(2)
+    expect(checked.stderr.toString()).toContain(
+      'selection.states must be draft, active, or deprecated',
+    )
+    expect(checked.stderr.toString()).toContain(
+      'Correct the value and run pickle check again',
+    )
+  })
 })

--- a/packages/cli/src/workspace.test.ts
+++ b/packages/cli/src/workspace.test.ts
@@ -390,6 +390,29 @@ export default { adapter: missingAdapter }
     )
   })
 
+  test('check rejects an unsupported Stagehand model before execution resources start', async () => {
+    const project = await createCheckProject('invalid-model-name', {
+      config: {
+        ...defaultCheckConfig,
+        web: {
+          baseUrl: 'https://example.com',
+          browser: { modelName: 'google/gemini-3.7-flash' },
+        },
+      },
+      specification: validSpecification,
+    })
+
+    const checked = runCheck(project)
+
+    expect(checked.exitCode).toBe(2)
+    expect(checked.stderr.toString()).toContain(
+      'web.browser.modelName "google/gemini-3.7-flash" is not a Stagehand-supported model',
+    )
+    expect(checked.stderr.toString()).toContain(
+      'Correct the value and run pickle check again',
+    )
+  })
+
   test('check rejects invalid Specifications before execution resources start', async () => {
     const project = await createCheckProject('invalid-specification', {
       config: defaultCheckConfig,
@@ -478,7 +501,7 @@ export default {}
     )
   })
 
-  test('migrate previews namespaced identifiers and writes only after confirmation', async () => {
+  test('migrate previews missing Specification state and writes only after confirmation', async () => {
     const source = `# keep this comment
 
 @smoke
@@ -498,12 +521,10 @@ Feature: Checkout
       env: { ...Bun.env },
     })
     expect(preview.exitCode).toBe(0)
-    expect(preview.stdout.toString()).toMatch(
-      /Feature "Checkout": add @pickle:id:[0-9a-f]{16} @pickle:state:active/,
+    expect(preview.stdout.toString()).toContain(
+      'Feature "Checkout": add @pickle:state:active',
     )
-    expect(preview.stdout.toString()).toMatch(
-      /Scenario "Complete a purchase": add @pickle:id:[0-9a-f]{16}/,
-    )
+    expect(preview.stdout.toString()).not.toContain('@pickle:id:')
     expect(preview.stdout.toString()).toContain(
       'Re-run pickle migrate --yes after reviewing the preview',
     )
@@ -520,14 +541,9 @@ Feature: Checkout
     )
     const migrated = await Bun.file(featurePath).text()
     expect(migrated).toContain('# keep this comment')
-    expect(migrated).toContain('\n@smoke\n@pickle:id:')
-    expect(migrated).toContain('@pickle:state:active')
+    expect(migrated).toContain('\n@smoke\n@pickle:state:active')
+    expect(migrated).not.toContain('@pickle:id:')
     expect(migrated).toContain('Then the purchase succeeds')
-    for (const id of applied.stdout
-      .toString()
-      .match(/@pickle:id:[0-9a-f]{16}/g) ?? []) {
-      expect(migrated).toContain(id)
-    }
 
     const checked = runCheck(project)
     expect(checked.exitCode).toBe(0)
@@ -558,7 +574,7 @@ Feature: Checkout
     const checked = runCheck(project)
 
     expect(checked.exitCode).toBe(2)
-    expect(checked.stderr.toString()).toContain('missing a durable identifier')
+    expect(checked.stderr.toString()).toContain('missing a Specification state')
     expect(checked.stderr.toString()).toContain(
       'Run pickle migrate to add missing metadata',
     )
@@ -620,7 +636,7 @@ Feature: Checkout
     })
 
     expect(run.exitCode).toBe(0)
-    expect(run.stderr.toString()).toContain('missing a durable identifier')
+    expect(run.stderr.toString()).toContain('missing a Specification state')
     expect(run.stderr.toString()).toContain(
       'Run pickle migrate to add missing metadata',
     )

--- a/packages/runner/index.ts
+++ b/packages/runner/index.ts
@@ -26,5 +26,5 @@ export type {
   TestResultState,
 } from './src/run-scenario'
 export { runScenario } from './src/run-scenario'
-export type { RunScenariosInput } from './src/run-scenarios'
-export { runScenarios } from './src/run-scenarios'
+export type { RunScenariosInput, RunTarget } from './src/run-scenarios'
+export { runScenarios, validateTargetSelection } from './src/run-scenarios'

--- a/packages/runner/src/configuration.test.ts
+++ b/packages/runner/src/configuration.test.ts
@@ -37,6 +37,12 @@ test('combines versioned configuration and extensions into validated runner inpu
   expect(resolved).toEqual({
     adapter,
     executionTargetProfile: { id: 'configured-web' },
+    targets: [
+      {
+        executionTargetProfile: { id: 'configured-web' },
+        adapter,
+      },
+    ],
     concurrency: 3,
     retry: { infrastructureErrors: 2 },
     timeout: { scenarioMs: 30_000, stepMs: 5_000 },
@@ -93,4 +99,109 @@ test('combines project configuration with the extension manifest before executio
   ).toThrow(
     'Configure web.baseUrl or export an adapter from pickle.extensions.ts',
   )
+})
+
+test('resolves named execution target profiles with adapter configuration and capabilities', () => {
+  const webAdapter: ExecutionTargetAdapter = {
+    ...adapter,
+    capabilities: ['screenshots', 'web'],
+  }
+  const customAdapter: ExecutionTargetAdapter = {
+    ...adapter,
+    capabilities: ['filesystem'],
+  }
+
+  const resolved = resolveRunConfiguration(
+    {
+      schemaVersion: 1,
+      executionTargetProfiles: [
+        { id: 'web', adapter: 'web', capabilities: ['screenshots'] },
+        { id: 'desktop', adapter: 'custom', capabilities: ['filesystem'] },
+      ],
+    },
+    {
+      adapters: {
+        web: webAdapter,
+        custom: customAdapter,
+      },
+    },
+  )
+
+  expect(resolved.targets).toEqual([
+    {
+      executionTargetProfile: {
+        id: 'web',
+        adapter: 'web',
+        capabilities: ['screenshots'],
+      },
+      adapter: webAdapter,
+    },
+    {
+      executionTargetProfile: {
+        id: 'desktop',
+        adapter: 'custom',
+        capabilities: ['filesystem'],
+      },
+      adapter: customAdapter,
+    },
+  ])
+})
+
+test('rejects a profile that names an adapter the extensions did not import', () => {
+  expect(() =>
+    resolveRunConfiguration(
+      {
+        schemaVersion: 1,
+        executionTargetProfiles: [
+          { id: 'android', adapter: 'android', capabilities: ['geolocation'] },
+        ],
+      },
+      { adapters: { web: adapter } },
+    ),
+  ).toThrow(
+    'Execution target profile "android" requires adapter "android". Import it from pickle.extensions.ts.',
+  )
+})
+
+test('rejects a profile that claims a capability its adapter does not provide', () => {
+  expect(() =>
+    resolveRunConfiguration(
+      {
+        schemaVersion: 1,
+        executionTargetProfiles: [
+          { id: 'web', adapter: 'web', capabilities: ['geolocation'] },
+        ],
+      },
+      { adapters: { web: { ...adapter, capabilities: ['screenshots'] } } },
+    ),
+  ).toThrow(
+    'Execution target profile "web" declares capabilities the adapter does not provide: geolocation',
+  )
+})
+
+test('binds adapter configuration per execution target profile', () => {
+  const staging: ExecutionTargetAdapter = {
+    ...adapter,
+    capabilities: ['screenshots'],
+  }
+  const production: ExecutionTargetAdapter = {
+    ...adapter,
+    capabilities: ['screenshots'],
+  }
+
+  const resolved = resolveRunConfiguration(
+    {
+      schemaVersion: 1,
+      executionTargetProfiles: [
+        { id: 'staging', adapter: 'web', capabilities: ['screenshots'] },
+        { id: 'production', adapter: 'web', capabilities: ['screenshots'] },
+      ],
+    },
+    { adapters: { staging, production } },
+  )
+
+  expect(resolved.targets.map((target) => target.adapter)).toEqual([
+    staging,
+    production,
+  ])
 })

--- a/packages/runner/src/configuration.ts
+++ b/packages/runner/src/configuration.ts
@@ -252,12 +252,7 @@ export function resolveRunConfiguration(
     assertProfileCapabilities(executionTargetProfile, adapter)
     return { executionTargetProfile, adapter }
   })
-  const first = targets[0]
-  if (!first) {
-    throw new Error(
-      'executionTargetProfile or executionTargetProfiles is required',
-    )
-  }
+  const first = targets[0]!
   const retries = validatedConfiguration.execution?.infrastructureRetries
 
   return {

--- a/packages/runner/src/configuration.ts
+++ b/packages/runner/src/configuration.ts
@@ -3,10 +3,12 @@ import type {
   ExecutionTargetAdapter,
   ExecutionTargetProfile,
 } from './run-scenario'
+import type { RunTarget } from './run-scenarios'
 
 export interface RunConfiguration {
   schemaVersion: 1
-  executionTargetProfile: ExecutionTargetProfile
+  executionTargetProfile?: ExecutionTargetProfile
+  executionTargetProfiles?: ExecutionTargetProfile[]
   concurrency?: number
   execution?: {
     infrastructureRetries?: number
@@ -16,7 +18,8 @@ export interface RunConfiguration {
 }
 
 export interface RunExtensions {
-  adapter: ExecutionTargetAdapter
+  adapter?: ExecutionTargetAdapter
+  adapters?: Record<string, ExecutionTargetAdapter>
 }
 
 export interface RunExtensionManifest {
@@ -27,6 +30,7 @@ export interface RunExtensionManifest {
 export interface ResolvedRunConfiguration extends ExecutionPolicy {
   adapter: ExecutionTargetAdapter
   executionTargetProfile: ExecutionTargetProfile
+  targets: RunTarget[]
   concurrency: number
 }
 
@@ -57,11 +61,98 @@ function positiveInteger(value: unknown, field: string): void {
   }
 }
 
-function validateExecutionTargetProfile(value: unknown): void {
-  const profile = record(value, 'executionTargetProfile')
-  knownFields(profile, ['id'], 'executionTargetProfile')
+function validateCapabilities(
+  value: unknown,
+  field: string,
+): readonly string[] {
+  if (!Array.isArray(value) || value.length === 0) {
+    throw new Error(`${field} must contain at least one capability`)
+  }
+  if (!value.every((item) => typeof item === 'string' && item.trim())) {
+    throw new Error(`${field} must not contain an empty capability`)
+  }
+  return value
+}
+
+function validateExecutionTargetProfile(
+  value: unknown,
+  field = 'executionTargetProfile',
+): ExecutionTargetProfile {
+  const profile = record(value, field)
+  knownFields(profile, ['id', 'adapter', 'capabilities'], field)
   if (typeof profile.id !== 'string' || !profile.id.trim()) {
-    throw new Error('executionTargetProfile.id must not be empty')
+    throw new Error(`${field}.id must not be empty`)
+  }
+  if (
+    profile.adapter !== undefined &&
+    (typeof profile.adapter !== 'string' || !profile.adapter.trim())
+  ) {
+    throw new Error(`${field}.adapter must not be empty`)
+  }
+  if (profile.capabilities !== undefined) {
+    profile.capabilities = validateCapabilities(
+      profile.capabilities,
+      `${field}.capabilities`,
+    )
+  }
+  return profile as unknown as ExecutionTargetProfile
+}
+
+function configuredProfiles(
+  configuration: RunConfiguration,
+): ExecutionTargetProfile[] {
+  if (configuration.executionTargetProfiles?.length) {
+    return configuration.executionTargetProfiles
+  }
+  if (configuration.executionTargetProfile) {
+    return [configuration.executionTargetProfile]
+  }
+  throw new Error(
+    'executionTargetProfile or executionTargetProfiles is required',
+  )
+}
+
+function isAdapter(
+  value: ExecutionTargetAdapter | undefined,
+): value is ExecutionTargetAdapter {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    typeof value.openSession === 'function'
+  )
+}
+
+function adapterForProfile(
+  profile: ExecutionTargetProfile,
+  extensions: RunExtensions,
+): ExecutionTargetAdapter {
+  const resolved = profile.adapter
+    ? (extensions.adapters?.[profile.id] ??
+      extensions.adapters?.[profile.adapter])
+    : extensions.adapter
+  if (!isAdapter(resolved)) {
+    throw new Error(
+      `Execution target profile "${profile.id}" requires adapter ` +
+        `"${profile.adapter ?? 'custom'}". Import it from pickle.extensions.ts.`,
+    )
+  }
+  return resolved
+}
+
+function assertProfileCapabilities(
+  profile: ExecutionTargetProfile,
+  adapter: ExecutionTargetAdapter,
+): void {
+  const adapterCapabilities = adapter.capabilities
+  if (!profile.capabilities || !adapterCapabilities) return
+  const available = new Set(adapterCapabilities)
+  const missing = profile.capabilities.filter(
+    (capability) => !available.has(capability),
+  )
+  if (missing.length > 0) {
+    throw new Error(
+      `Execution target profile "${profile.id}" declares capabilities the adapter does not provide: ${missing.join(', ')}`,
+    )
   }
 }
 
@@ -69,7 +160,13 @@ export function validateRunConfiguration(value: unknown): RunConfiguration {
   const configuration = record(value, 'run configuration')
   knownFields(
     configuration,
-    ['schemaVersion', 'executionTargetProfile', 'concurrency', 'execution'],
+    [
+      'schemaVersion',
+      'executionTargetProfile',
+      'executionTargetProfiles',
+      'concurrency',
+      'execution',
+    ],
     'run configuration',
   )
   if (configuration.schemaVersion !== 1) {
@@ -77,7 +174,36 @@ export function validateRunConfiguration(value: unknown): RunConfiguration {
       `Unsupported configuration schemaVersion: ${String(configuration.schemaVersion)}`,
     )
   }
-  validateExecutionTargetProfile(configuration.executionTargetProfile)
+  if (configuration.executionTargetProfile !== undefined) {
+    configuration.executionTargetProfile = validateExecutionTargetProfile(
+      configuration.executionTargetProfile,
+    )
+  }
+  if (configuration.executionTargetProfiles !== undefined) {
+    if (
+      !Array.isArray(configuration.executionTargetProfiles) ||
+      configuration.executionTargetProfiles.length === 0
+    ) {
+      throw new Error(
+        'executionTargetProfiles must contain at least one execution target profile',
+      )
+    }
+    configuration.executionTargetProfiles =
+      configuration.executionTargetProfiles.map((profile, index) =>
+        validateExecutionTargetProfile(
+          profile,
+          `executionTargetProfiles[${index}]`,
+        ),
+      )
+  }
+  if (
+    configuration.executionTargetProfile === undefined &&
+    configuration.executionTargetProfiles === undefined
+  ) {
+    throw new Error(
+      'executionTargetProfile or executionTargetProfiles is required',
+    )
+  }
   positiveInteger(configuration.concurrency, 'concurrency')
   if (configuration.execution !== undefined) {
     const execution = record(configuration.execution, 'execution')
@@ -120,18 +246,24 @@ export function resolveRunConfiguration(
   extensions: RunExtensions,
 ): ResolvedRunConfiguration {
   const validatedConfiguration = validateRunConfiguration(configuration)
-  if (
-    typeof extensions.adapter !== 'object' ||
-    extensions.adapter === null ||
-    typeof extensions.adapter.openSession !== 'function'
-  ) {
-    throw new Error('extensions.adapter must provide openSession')
+  const profiles = configuredProfiles(validatedConfiguration)
+  const targets = profiles.map((executionTargetProfile) => {
+    const adapter = adapterForProfile(executionTargetProfile, extensions)
+    assertProfileCapabilities(executionTargetProfile, adapter)
+    return { executionTargetProfile, adapter }
+  })
+  const first = targets[0]
+  if (!first) {
+    throw new Error(
+      'executionTargetProfile or executionTargetProfiles is required',
+    )
   }
   const retries = validatedConfiguration.execution?.infrastructureRetries
 
   return {
-    adapter: extensions.adapter,
-    executionTargetProfile: validatedConfiguration.executionTargetProfile,
+    adapter: first.adapter,
+    executionTargetProfile: first.executionTargetProfile,
+    targets,
     concurrency: validatedConfiguration.concurrency ?? 1,
     retry: { infrastructureErrors: retries ?? 0 },
     timeout: {

--- a/packages/runner/src/run-scenario.ts
+++ b/packages/runner/src/run-scenario.ts
@@ -10,6 +10,8 @@ export type TestResultState =
 
 export interface ExecutionTargetProfile {
   id: string
+  adapter?: string
+  capabilities?: readonly string[]
 }
 
 export interface ResolvedAction {

--- a/packages/runner/src/run-scenarios.test.ts
+++ b/packages/runner/src/run-scenarios.test.ts
@@ -88,3 +88,99 @@ test('rejects a target that lacks a Scenario capability requirement before openi
   )
   expect(openSession).not.toHaveBeenCalled()
 })
+
+test('produces one test result per Scenario and execution target profile', async () => {
+  const webOpen = mock(async () => ({
+    async executeStep() {
+      return { state: 'passed' as const, resolvedActions: [] }
+    },
+    async close() {},
+  }))
+  const mobileOpen = mock(async () => ({
+    async executeStep() {
+      return { state: 'passed' as const, resolvedActions: [] }
+    },
+    async close() {},
+  }))
+
+  const runs = await runScenarios({
+    selections: [selections[0]!, selections[2]!],
+    targets: [
+      {
+        executionTargetProfile: {
+          id: 'web',
+          adapter: 'web',
+          capabilities: ['screenshots'],
+        },
+        adapter: { capabilities: ['screenshots', 'web'], openSession: webOpen },
+      },
+      {
+        executionTargetProfile: {
+          id: 'android',
+          adapter: 'android',
+          capabilities: ['geolocation'],
+        },
+        adapter: {
+          capabilities: ['geolocation'],
+          openSession: mobileOpen,
+        },
+      },
+    ],
+  })
+
+  expect(
+    runs.map((run) => [
+      run.result.scenario.name,
+      run.result.executionTargetProfile.id,
+      run.result.state,
+    ]),
+  ).toEqual([
+    ['First', 'web', 'passed'],
+    ['First', 'android', 'passed'],
+    ['Third', 'web', 'passed'],
+    ['Third', 'android', 'passed'],
+  ])
+  expect(webOpen).toHaveBeenCalledTimes(2)
+  expect(mobileOpen).toHaveBeenCalledTimes(2)
+})
+
+test('fails validation for an incompatible target instead of skipping the Scenario', async () => {
+  const openSession = mock(async () => {
+    throw new Error('must not open')
+  })
+
+  await expect(
+    runScenarios({
+      selections: [
+        {
+          ...selections[0]!,
+          scenario: {
+            ...selections[0]!.scenario,
+            capabilityRequirements: ['geolocation'],
+          },
+        },
+      ],
+      targets: [
+        {
+          executionTargetProfile: {
+            id: 'web',
+            adapter: 'web',
+            capabilities: ['screenshots'],
+          },
+          adapter: { capabilities: ['screenshots', 'web'], openSession },
+        },
+        {
+          executionTargetProfile: {
+            id: 'android',
+            adapter: 'android',
+            capabilities: ['geolocation'],
+          },
+          adapter: { capabilities: ['geolocation'], openSession },
+        },
+      ],
+    }),
+  ).rejects.toThrow(
+    'Execution target profile "web" lacks required capabilities for Scenario "First": geolocation',
+  )
+  expect(openSession).not.toHaveBeenCalled()
+})

--- a/packages/runner/src/run-scenarios.ts
+++ b/packages/runner/src/run-scenarios.ts
@@ -8,16 +8,71 @@ import {
   type ScenarioRun,
 } from './run-scenario'
 
-export interface RunScenariosInput extends ExecutionPolicy {
-  selections: readonly ScenarioSelection[]
+export interface RunTarget {
   executionTargetProfile: ExecutionTargetProfile
   adapter: ExecutionTargetAdapter
+}
+
+export interface RunScenariosInput extends ExecutionPolicy {
+  selections: readonly ScenarioSelection[]
+  targets?: readonly RunTarget[]
+  executionTargetProfile?: ExecutionTargetProfile
+  adapter?: ExecutionTargetAdapter
   concurrency?: number
   signal?: AbortSignal
   onEvent?: (
     event: RunEvent,
     selection: ScenarioSelection,
   ) => void | Promise<void>
+}
+
+function availableCapabilities(target: RunTarget): Set<string> {
+  return new Set(
+    target.executionTargetProfile.capabilities ??
+      target.adapter.capabilities ??
+      [],
+  )
+}
+
+export function validateTargetSelection(
+  selections: readonly ScenarioSelection[],
+  targets: readonly RunTarget[],
+): void {
+  if (targets.length === 0) {
+    throw new Error(
+      'A test run must select at least one execution target profile',
+    )
+  }
+
+  for (const target of targets) {
+    const capabilities = availableCapabilities(target)
+    for (const { scenario } of selections) {
+      const missing = (scenario.capabilityRequirements ?? []).filter(
+        (requirement) => !capabilities.has(requirement),
+      )
+      if (missing.length > 0) {
+        throw new Error(
+          `Execution target profile "${target.executionTargetProfile.id}" lacks required capabilities ` +
+            `for Scenario "${scenario.name}": ${missing.join(', ')}`,
+        )
+      }
+    }
+  }
+}
+
+function resolveTargets(input: RunScenariosInput): readonly RunTarget[] {
+  if (input.targets) return input.targets
+  if (input.executionTargetProfile && input.adapter) {
+    return [
+      {
+        executionTargetProfile: input.executionTargetProfile,
+        adapter: input.adapter,
+      },
+    ]
+  }
+  throw new Error(
+    'A test run must select at least one execution target profile',
+  )
 }
 
 export async function runScenarios(
@@ -28,32 +83,25 @@ export async function runScenarios(
     throw new Error('concurrency must be an integer greater than or equal to 1')
   }
 
-  const capabilities = new Set(input.adapter.capabilities ?? [])
-  for (const { scenario } of input.selections) {
-    const missing = (scenario.capabilityRequirements ?? []).filter(
-      (requirement) => !capabilities.has(requirement),
-    )
-    if (missing.length > 0) {
-      throw new Error(
-        `Execution target profile "${input.executionTargetProfile.id}" lacks required capabilities ` +
-          `for Scenario "${scenario.name}": ${missing.join(', ')}`,
-      )
-    }
-  }
+  const targets = resolveTargets(input)
+  validateTargetSelection(input.selections, targets)
 
-  const runs = new Array<ScenarioRun>(input.selections.length)
+  const scenarioTargets = input.selections.flatMap((selection) =>
+    targets.map((target) => ({ selection, target })),
+  )
+  const runs = new Array<ScenarioRun>(scenarioTargets.length)
   let nextIndex = 0
-  const workerCount = Math.min(concurrency, input.selections.length)
+  const workerCount = Math.min(concurrency, scenarioTargets.length)
 
   async function work(): Promise<void> {
-    while (nextIndex < input.selections.length) {
+    while (nextIndex < scenarioTargets.length) {
       const index = nextIndex++
-      const selection = input.selections[index]!
+      const { selection, target } = scenarioTargets[index]!
       runs[index] = await runScenario({
         specification: selection.specification,
         scenario: selection.scenario,
-        executionTargetProfile: input.executionTargetProfile,
-        adapter: input.adapter,
+        executionTargetProfile: target.executionTargetProfile,
+        adapter: target.adapter,
         signal: input.signal,
         retry: input.retry,
         timeout: input.timeout,

--- a/packages/spec/src/identity.test.ts
+++ b/packages/spec/src/identity.test.ts
@@ -26,32 +26,24 @@ Feature: Checkout
 `
 
 describe('planSpecificationMigration', () => {
-  test('previews namespaced identifiers and lifecycle tags without rewriting unrelated source', () => {
+  test('previews missing Specification state without rewriting unrelated source or adding identifiers', () => {
     const plan = planSpecificationMigration([
       { uri: 'features/checkout.feature', source: checkoutSource },
     ])
     const preview = formatMigrationPreview(plan)
 
     expect(preview).toContain('features/checkout.feature')
-    expect(preview).toMatch(
-      /Feature "Checkout": add @pickle:id:[0-9a-f]{16} @pickle:state:active/,
-    )
-    expect(preview).toMatch(
-      /Scenario "Complete a purchase": add @pickle:id:[0-9a-f]{16}/,
-    )
-    expect(preview).toMatch(/Scenario "Pay": add @pickle:id:[0-9a-f]{16}/)
-    expect(preview).toMatch(
-      /Examples "Payment methods": add @pickle:id:[0-9a-f]{16}/,
-    )
-    expect(preview).toMatch(/Examples row 1: add pickle_id [0-9a-f]{16}/)
-    expect(preview).toMatch(/Examples row 2: add pickle_id [0-9a-f]{16}/)
+    expect(preview).toContain('Feature "Checkout": add @pickle:state:active')
+    expect(preview).not.toContain('@pickle:id:')
+    expect(preview).not.toContain('pickle_id')
 
     const nextSource = plan.files[0]?.nextSource ?? ''
     expect(nextSource).toContain('# keep this comment')
     expect(nextSource).toContain('  # scenario comment')
-    expect(nextSource).toContain('\n@smoke\n@pickle:id:')
-    expect(nextSource).toContain('@pickle:state:active')
-    expect(nextSource).toContain('| pickle_id | method |')
+    expect(nextSource).toContain('\n@smoke\n@pickle:state:active')
+    expect(nextSource).not.toContain('@pickle:id:')
+    expect(nextSource).not.toContain('pickle_id')
+    expect(nextSource).toContain('| method |')
     expect(nextSource).toContain('| card   |')
     expect(nextSource).toContain('| cash   |')
     expect(plan.files[0]?.source).toBe(checkoutSource)
@@ -91,7 +83,22 @@ Feature: Checkout
     ).not.toThrow()
   })
 
-  test('rejects missing, duplicate, malformed, and conflicting metadata', () => {
+  test('accepts a Specification that declares state and derives identifiers', () => {
+    expect(() =>
+      validateSpecificationMetadata([
+        {
+          uri: 'features/checkout.feature',
+          source: `@pickle:state:active
+Feature: Checkout
+  Scenario: Complete a purchase
+    Then the purchase succeeds
+`,
+        },
+      ]),
+    ).not.toThrow()
+  })
+
+  test('rejects missing state, duplicate, malformed, and conflicting metadata', () => {
     expect(() =>
       validateSpecificationMetadata([
         {
@@ -102,7 +109,22 @@ Feature: Checkout
 `,
         },
       ]),
-    ).toThrow(/missing a durable identifier/)
+    ).toThrow(/missing a Specification state/)
+
+    expect(() =>
+      validateSpecificationMetadata([
+        {
+          uri: 'features/checkout.feature',
+          source: `@pickle:state:active
+Feature: Checkout
+  Scenario: Login
+    Then it works
+  Scenario: Login
+    Then it also works
+`,
+        },
+      ]),
+    ).toThrow(/Duplicate identifier/)
 
     expect(() =>
       validateSpecificationMetadata([

--- a/packages/spec/src/identity.ts
+++ b/packages/spec/src/identity.ts
@@ -48,16 +48,15 @@ interface IdentityNode {
   line: number
   column: number
   tags: string[]
+  specificationName: string
+  scenarioName?: string
+  examplesName?: string
+  rowValues?: string[]
   rowIndex?: number
   pickleIdValue?: string
-  pickleIdColumnIndex?: number
-  headerLine?: number
 }
 
-type SourceEdit =
-  | { type: 'insert-line'; beforeLine: number; text: string }
-  | { type: 'insert-column'; line: number; value: string }
-  | { type: 'fill-cell'; line: number; columnIndex: number; value: string }
+type SourceEdit = { type: 'insert-line'; beforeLine: number; text: string }
 
 function parseDocument(source: string, language = 'en') {
   return new Parser(
@@ -105,6 +104,70 @@ export function examplesRowId(
   return value || undefined
 }
 
+function identifierDigest(parts: readonly string[]): string {
+  const hasher = new Bun.CryptoHasher('sha256')
+  hasher.update(parts.join('\0'))
+  return hasher.digest('hex').slice(0, 16)
+}
+
+function explicitId(tags: readonly string[]): string | undefined {
+  return idValues(tags)[0] || undefined
+}
+
+export function resolveSpecificationId(
+  uri: string,
+  name: string,
+  tags: readonly string[],
+): string {
+  return explicitId(tags) ?? identifierDigest(['specification', uri, name])
+}
+
+export function resolveScenarioId(
+  uri: string,
+  specificationName: string,
+  name: string,
+  tags: readonly string[],
+): string {
+  return (
+    explicitId(tags) ??
+    identifierDigest(['scenario', uri, specificationName, name])
+  )
+}
+
+export function resolveExamplesId(
+  uri: string,
+  specificationName: string,
+  scenarioName: string,
+  name: string,
+  tags: readonly string[],
+): string {
+  return (
+    explicitId(tags) ??
+    identifierDigest(['examples', uri, specificationName, scenarioName, name])
+  )
+}
+
+export function resolveExamplesRowId(
+  uri: string,
+  specificationName: string,
+  scenarioName: string,
+  examplesName: string,
+  header: readonly string[],
+  cells: readonly string[],
+): string {
+  const explicit = examplesRowId(header, cells)
+  if (explicit) return explicit
+  const values = cells.filter((_, index) => header[index] !== rowIdColumn)
+  return identifierDigest([
+    'examples-row',
+    uri,
+    specificationName,
+    scenarioName,
+    examplesName,
+    ...values,
+  ])
+}
+
 function nodeLabel(node: IdentityNode): string {
   switch (node.kind) {
     case 'feature':
@@ -124,61 +187,91 @@ function sourcePosition(
   return { line: location?.line ?? 1, column: location?.column ?? 1 }
 }
 
-function visitScenario(scenario: Scenario, nodes: IdentityNode[]): void {
+function visitScenario(
+  scenario: Scenario,
+  specificationName: string,
+  nodes: IdentityNode[],
+): void {
   nodes.push({
     kind: 'scenario',
     name: scenario.name,
+    specificationName,
+    scenarioName: scenario.name,
     ...sourcePosition(scenario.location),
     tags: scenario.tags.map((tag) => tag.name),
   })
-  for (const examples of scenario.examples) collectExamples(examples, nodes)
+  for (const examples of scenario.examples)
+    collectExamples(examples, specificationName, scenario.name, nodes)
 }
 
-function collectExamples(examples: Examples, nodes: IdentityNode[]): void {
+function collectExamples(
+  examples: Examples,
+  specificationName: string,
+  scenarioName: string,
+  nodes: IdentityNode[],
+): void {
   const header = examples.tableHeader?.cells.map((cell) => cell.value) ?? []
   const pickleIdColumnIndex = header.indexOf(rowIdColumn)
   nodes.push({
     kind: 'examples',
     name: examples.name,
+    specificationName,
+    scenarioName,
+    examplesName: examples.name,
     ...sourcePosition(examples.location),
     tags: examples.tags.map((tag) => tag.name),
-    headerLine: examples.tableHeader?.location.line,
-    pickleIdColumnIndex:
-      pickleIdColumnIndex >= 0 ? pickleIdColumnIndex : undefined,
   })
   for (const [index, row] of examples.tableBody.entries()) {
-    collectExamplesRow(row, index, pickleIdColumnIndex, nodes)
+    collectExamplesRow(
+      row,
+      index,
+      header,
+      pickleIdColumnIndex,
+      specificationName,
+      scenarioName,
+      examples.name,
+      nodes,
+    )
   }
 }
 
 function collectExamplesRow(
   row: TableRow,
   index: number,
+  header: readonly string[],
   pickleIdColumnIndex: number,
+  specificationName: string,
+  scenarioName: string,
+  examplesName: string,
   nodes: IdentityNode[],
 ): void {
+  const cells = row.cells.map((cell) => cell.value)
   const value =
-    pickleIdColumnIndex >= 0
-      ? (row.cells[pickleIdColumnIndex]?.value ?? '')
-      : ''
+    pickleIdColumnIndex >= 0 ? (cells[pickleIdColumnIndex] ?? '') : ''
   nodes.push({
     kind: 'examples-row',
+    specificationName,
+    scenarioName,
+    examplesName,
+    rowValues: cells.filter(
+      (_, cellIndex) => header[cellIndex] !== rowIdColumn,
+    ),
     ...sourcePosition(row.location),
     tags: [],
     rowIndex: index + 1,
     pickleIdValue: value,
-    pickleIdColumnIndex:
-      pickleIdColumnIndex >= 0 ? pickleIdColumnIndex : undefined,
   })
 }
 
 function visitChild(
   child: FeatureChild | RuleChild,
+  specificationName: string,
   nodes: IdentityNode[],
 ): void {
-  if (child.scenario) visitScenario(child.scenario, nodes)
+  if (child.scenario) visitScenario(child.scenario, specificationName, nodes)
   if ('rule' in child && child.rule) {
-    for (const ruleChild of child.rule.children) visitChild(ruleChild, nodes)
+    for (const ruleChild of child.rule.children)
+      visitChild(ruleChild, specificationName, nodes)
   }
 }
 
@@ -187,11 +280,12 @@ function identityNodes(feature: Feature): IdentityNode[] {
     {
       kind: 'feature',
       name: feature.name,
+      specificationName: feature.name,
       ...sourcePosition(feature.location),
       tags: feature.tags.map((tag) => tag.name),
     },
   ]
-  for (const child of feature.children) visitChild(child, nodes)
+  for (const child of feature.children) visitChild(child, feature.name, nodes)
   return nodes
 }
 
@@ -212,6 +306,39 @@ function recordIdentifier(
   seen.set(id, uri)
 }
 
+function resolvedNodeId(node: IdentityNode, uri: string): string {
+  if (node.kind === 'examples-row') {
+    const explicit = node.pickleIdValue?.trim()
+    if (explicit) return explicit
+    return identifierDigest([
+      'examples-row',
+      uri,
+      node.specificationName,
+      node.scenarioName ?? '',
+      node.examplesName ?? '',
+      ...(node.rowValues ?? []),
+    ])
+  }
+  if (node.kind === 'feature') {
+    return resolveSpecificationId(uri, node.specificationName, node.tags)
+  }
+  if (node.kind === 'scenario') {
+    return resolveScenarioId(
+      uri,
+      node.specificationName,
+      node.scenarioName ?? '',
+      node.tags,
+    )
+  }
+  return resolveExamplesId(
+    uri,
+    node.specificationName,
+    node.scenarioName ?? '',
+    node.examplesName ?? '',
+    node.tags,
+  )
+}
+
 function validateNode(
   node: IdentityNode,
   uri: string,
@@ -219,22 +346,15 @@ function validateNode(
   errors: string[],
 ): void {
   if (node.kind === 'examples-row') {
-    const id = node.pickleIdValue?.trim() ?? ''
-    if (!id) {
+    const explicit = node.pickleIdValue?.trim() ?? ''
+    if (explicit && !idPattern.test(explicit)) {
       errors.push(
-        `Invalid Specification ${uri}: Examples row ${node.rowIndex} is missing a pickle_id. ` +
-          'Run pickle migrate to add missing metadata.',
-      )
-      return
-    }
-    if (!idPattern.test(id)) {
-      errors.push(
-        `Invalid Specification ${uri}: Examples row ${node.rowIndex} has a malformed durable identifier "${id}". ` +
+        `Invalid Specification ${uri}: Examples row ${node.rowIndex} has a malformed durable identifier "${explicit}". ` +
           'Use letters, numbers, underscores, or hyphens and run pickle check again.',
       )
       return
     }
-    recordIdentifier(seen, id, uri, errors)
+    recordIdentifier(seen, resolvedNodeId(node, uri), uri, errors)
     return
   }
 
@@ -272,14 +392,7 @@ function validateNode(
     )
     return
   }
-  if (ids.length === 0) {
-    errors.push(
-      `Invalid Specification ${uri}: ${nodeLabel(node)} is missing a durable identifier. ` +
-        'Run pickle migrate to add missing metadata.',
-    )
-    return
-  }
-  if (!ids[0] || !idPattern.test(ids[0])) {
+  if (ids.length === 1 && (!ids[0] || !idPattern.test(ids[0]))) {
     errors.push(
       `Invalid Specification ${uri}: ${nodeLabel(node)} has a malformed durable identifier` +
         `${ids[0] ? ` "${ids[0]}"` : ''}. ` +
@@ -287,7 +400,7 @@ function validateNode(
     )
     return
   }
-  recordIdentifier(seen, ids[0], uri, errors)
+  recordIdentifier(seen, resolvedNodeId(node, uri), uri, errors)
 }
 
 export function validateSpecificationMetadata(
@@ -311,71 +424,16 @@ export function validateSpecificationMetadata(
   if (errors.length > 0) throw new Error(errors.join('\n'))
 }
 
-function createDurableId(existing: Set<string>): string {
-  for (;;) {
-    const id = Buffer.from(crypto.getRandomValues(new Uint8Array(8))).toString(
-      'hex',
-    )
-    if (!existing.has(id)) {
-      existing.add(id)
-      return id
-    }
-  }
-}
-
-function collectExistingIds(
-  features: readonly (Feature | undefined)[],
-): Set<string> {
-  const existing = new Set<string>()
-  for (const feature of features) {
-    if (!feature) continue
-    for (const node of identityNodes(feature)) {
-      for (const id of idValues(node.tags)) {
-        if (id) existing.add(id)
-      }
-      const rowId = node.pickleIdValue?.trim()
-      if (rowId) existing.add(rowId)
-    }
-  }
-  return existing
-}
-
 function splitSource(source: string): { lines: string[]; newline: string } {
   const newline = source.includes('\r\n') ? '\r\n' : '\n'
   return { lines: source.split(newline), newline }
 }
 
-function insertTableColumn(line: string, value: string): string {
-  const parts = line.split('|')
-  parts.splice(1, 0, ` ${value} `)
-  return parts.join('|')
-}
-
-function fillTableCell(
-  line: string,
-  columnIndex: number,
-  value: string,
-): string {
-  const parts = line.split('|')
-  parts[columnIndex + 1] = ` ${value} `
-  return parts.join('|')
-}
-
 function applyEdits(source: string, edits: readonly SourceEdit[]): string {
   const { lines, newline } = splitSource(source)
-  const lineEdits = edits
-    .filter((edit) => edit.type === 'insert-line')
-    .sort((left, right) => right.beforeLine - left.beforeLine)
-
-  for (const edit of edits) {
-    if (edit.type === 'insert-line') continue
-    const line = lines[edit.line - 1]
-    if (line === undefined) continue
-    if (edit.type === 'insert-column')
-      lines[edit.line - 1] = insertTableColumn(line, edit.value)
-    else
-      lines[edit.line - 1] = fillTableCell(line, edit.columnIndex, edit.value)
-  }
+  const lineEdits = [...edits].sort(
+    (left, right) => right.beforeLine - left.beforeLine,
+  )
   for (const edit of lineEdits) {
     lines.splice(edit.beforeLine - 1, 0, edit.text)
   }
@@ -389,7 +447,6 @@ function tagLine(column: number, tags: readonly string[]): string {
 function migrateFile(
   file: SpecificationSourceFile,
   feature: Feature | undefined,
-  existing: Set<string>,
 ): { nextSource: string; changes: SpecificationMigrationChange[] } {
   if (!feature) return { nextSource: file.source, changes: [] }
 
@@ -398,50 +455,9 @@ function migrateFile(
   const nodes = identityNodes(feature)
 
   for (const node of nodes) {
-    if (node.kind === 'examples-row') {
-      const current = node.pickleIdValue?.trim() ?? ''
-      if (current) continue
-      const id = createDurableId(existing)
-      if (node.pickleIdColumnIndex === undefined) {
-        edits.push({ type: 'insert-column', line: node.line, value: id })
-      } else {
-        edits.push({
-          type: 'fill-cell',
-          line: node.line,
-          columnIndex: node.pickleIdColumnIndex,
-          value: id,
-        })
-      }
-      changes.push({
-        uri: file.uri,
-        description: `Examples row ${node.rowIndex}: add pickle_id ${id}`,
-      })
-      continue
-    }
-
-    if (
-      node.kind === 'examples' &&
-      node.pickleIdColumnIndex === undefined &&
-      node.headerLine
-    ) {
-      edits.push({
-        type: 'insert-column',
-        line: node.headerLine,
-        value: rowIdColumn,
-      })
-    }
-
-    const tagsToAdd: string[] = []
-    const ids = idValues(node.tags)
-    const states = stateValues(node.tags)
-    if (ids.length === 0) {
-      const id = createDurableId(existing)
-      tagsToAdd.push(`${idTagPrefix}${id}`)
-    }
-    if (node.kind === 'feature' && states.length === 0) {
-      tagsToAdd.push(`${stateTagPrefix}active`)
-    }
-    if (tagsToAdd.length === 0) continue
+    if (node.kind !== 'feature') continue
+    if (stateValues(node.tags).length > 0) continue
+    const tagsToAdd = [`${stateTagPrefix}active`]
     edits.push({
       type: 'insert-line',
       beforeLine: node.line,
@@ -464,11 +480,10 @@ export function planSpecificationMigration(
     file,
     feature: parseDocument(file.source, language).feature,
   }))
-  const existing = collectExistingIds(parsed.map(({ feature }) => feature))
   const changes: SpecificationMigrationChange[] = []
   const nextFiles: SpecificationMigrationFile[] = []
   for (const { file, feature } of parsed) {
-    const migrated = migrateFile(file, feature, existing)
+    const migrated = migrateFile(file, feature)
     changes.push(...migrated.changes)
     nextFiles.push({
       uri: file.uri,

--- a/packages/spec/src/selection.test.ts
+++ b/packages/spec/src/selection.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from 'bun:test'
 import {
   type Scenario,
   type Specification,
+  type SpecificationState,
   selectScenarios,
   validateSelectionOptions,
 } from '../index'
@@ -10,12 +11,17 @@ function scenario(name: string, tags: string[] = []): Scenario {
   return { name, tags, steps: [] }
 }
 
-function specification(uri: string, scenarios: Scenario[]): Specification {
+function specification(
+  uri: string,
+  scenarios: Scenario[],
+  state?: SpecificationState,
+): Specification {
   return {
     name: uri,
     source: { uri, language: 'en' },
     tags: [],
     scenarios,
+    ...(state ? { state } : {}),
   }
 }
 
@@ -78,5 +84,113 @@ describe('selectScenarios', () => {
     expect(selected.map(({ scenario }) => scenario.name)).toEqual([
       'First runnable',
     ])
+  })
+
+  test('selects Scenarios by path, tag, state, and name query', () => {
+    const specifications = [
+      specification(
+        'features/checkout/guest.feature',
+        [scenario('Checkout as a guest', ['@smoke'])],
+        'active',
+      ),
+      specification(
+        'features/checkout/member.feature',
+        [scenario('Checkout as a member', ['@smoke'])],
+        'draft',
+      ),
+      specification(
+        'features/search.feature',
+        [scenario('Find a product', ['@smoke'])],
+        'active',
+      ),
+      specification(
+        'features/legacy.feature',
+        [scenario('Deprecated checkout', ['@smoke'])],
+        'deprecated',
+      ),
+    ]
+
+    const selected = selectScenarios(specifications, {
+      paths: ['features/checkout/**'],
+      tagExpression: '@smoke',
+      states: ['active', 'draft'],
+      scenarioName: 'checkout',
+    })
+
+    expect(
+      selected.map(({ specification, scenario }) => [
+        specification.source.uri,
+        specification.state,
+        scenario.name,
+      ]),
+    ).toEqual([
+      ['features/checkout/guest.feature', 'active', 'Checkout as a guest'],
+      ['features/checkout/member.feature', 'draft', 'Checkout as a member'],
+    ])
+  })
+
+  test('runs active Specifications by default and keeps draft and deprecated outside normal selection', () => {
+    const selected = selectScenarios([
+      specification(
+        'features/active.feature',
+        [scenario('Active checkout')],
+        'active',
+      ),
+      specification('features/untagged.feature', [
+        scenario('Untagged checkout'),
+      ]),
+      specification(
+        'features/draft.feature',
+        [scenario('Draft checkout')],
+        'draft',
+      ),
+      specification(
+        'features/deprecated.feature',
+        [scenario('Deprecated checkout')],
+        'deprecated',
+      ),
+    ])
+
+    expect(selected.map(({ scenario }) => scenario.name)).toEqual([
+      'Active checkout',
+      'Untagged checkout',
+    ])
+  })
+
+  test('includes draft or deprecated Specifications only when a state query selects them', () => {
+    const specifications = [
+      specification('features/draft.feature', [scenario('Draft')], 'draft'),
+      specification(
+        'features/deprecated.feature',
+        [scenario('Deprecated')],
+        'deprecated',
+      ),
+    ]
+
+    expect(
+      selectScenarios(specifications, { states: ['draft'] }).map(
+        ({ scenario }) => scenario.name,
+      ),
+    ).toEqual(['Draft'])
+    expect(
+      selectScenarios(specifications, { states: ['deprecated'] }).map(
+        ({ scenario }) => scenario.name,
+      ),
+    ).toEqual(['Deprecated'])
+  })
+
+  test('rejects unsupported selection path and state queries', () => {
+    expect(() => validateSelectionOptions({ paths: '' })).toThrow(
+      'selection.paths must contain at least one path',
+    )
+    expect(() => validateSelectionOptions({ paths: [''] })).toThrow(
+      'selection.paths must not contain an empty path',
+    )
+    expect(() => validateSelectionOptions({ states: [] })).toThrow(
+      'selection.states must contain at least one Specification state',
+    )
+    expect(() => validateSelectionOptions({ states: ['published'] })).toThrow(
+      'selection.states must be draft, active, or deprecated',
+    )
   })
 })

--- a/packages/spec/src/selection.ts
+++ b/packages/spec/src/selection.ts
@@ -1,3 +1,4 @@
+import type { SpecificationState } from './identity'
 import type { Scenario, Specification } from './specification'
 
 export interface Shard {
@@ -6,10 +7,14 @@ export interface Shard {
 }
 
 export interface SelectionOptions {
+  paths?: string | readonly string[]
   scenarioName?: string
   tagExpression?: string
+  states?: readonly SpecificationState[]
   shard?: Shard
 }
+
+const specificationStates = ['draft', 'active', 'deprecated'] as const
 
 export interface ScenarioSelection {
   specification: Specification
@@ -159,11 +164,80 @@ function validateShard(value: unknown): void {
   }
 }
 
+function globToRegExp(pattern: string): RegExp {
+  let regex = '^'
+  for (let index = 0; index < pattern.length; index++) {
+    const character = pattern[index]!
+    if (character === '*') {
+      if (pattern[index + 1] === '*') {
+        regex += '.*'
+        index++
+        continue
+      }
+      regex += '[^/]*'
+      continue
+    }
+    if ('\\^$+{}()|[]?'.includes(character) || character === '.') {
+      regex += `\\${character}`
+      continue
+    }
+    regex += character
+  }
+  return new RegExp(`${regex}$`)
+}
+
+function normalizePaths(value: unknown): string[] {
+  if (typeof value === 'string') {
+    if (!value.trim()) {
+      throw new Error('selection.paths must contain at least one path')
+    }
+    return [value]
+  }
+  if (!Array.isArray(value) || value.length === 0) {
+    throw new Error('selection.paths must contain at least one path')
+  }
+  if (!value.every((path) => typeof path === 'string' && path.trim())) {
+    throw new Error('selection.paths must not contain an empty path')
+  }
+  return value
+}
+
+function matchesPath(uri: string, pattern: string): boolean {
+  return globToRegExp(pattern.replaceAll('\\', '/')).test(
+    uri.replaceAll('\\', '/'),
+  )
+}
+
+function validateStates(value: unknown): SpecificationState[] {
+  if (!Array.isArray(value) || value.length === 0) {
+    throw new Error(
+      'selection.states must contain at least one Specification state',
+    )
+  }
+  if (
+    !value.every(
+      (state) =>
+        typeof state === 'string' &&
+        specificationStates.includes(state as SpecificationState),
+    )
+  ) {
+    throw new Error('selection.states must be draft, active, or deprecated')
+  }
+  return value as SpecificationState[]
+}
+
 export function validateSelectionOptions(value: unknown): SelectionOptions {
   const options = record(value, 'selection')
-  knownFields(options, ['scenarioName', 'tagExpression', 'shard'], 'selection')
+  knownFields(
+    options,
+    ['paths', 'scenarioName', 'tagExpression', 'states', 'shard'],
+    'selection',
+  )
   optionalString(options.scenarioName, 'selection.scenarioName')
   optionalString(options.tagExpression, 'selection.tagExpression')
+  if (options.paths !== undefined) options.paths = normalizePaths(options.paths)
+  if (options.states !== undefined)
+    options.states = validateStates(options.states)
   if (options.tagExpression) parseTagExpression(options.tagExpression as string)
   if (options.shard !== undefined) validateShard(options.shard)
   return options as unknown as SelectionOptions
@@ -179,8 +253,19 @@ export function selectScenarios(
     ? parseTagExpression(validatedOptions.tagExpression)
     : undefined
 
+  const paths = validatedOptions.paths ? [validatedOptions.paths].flat() : []
+  const states = new Set<SpecificationState>(
+    validatedOptions.states ?? ['active'],
+  )
+
   const selected = [...specifications]
     .sort((left, right) => left.source.uri.localeCompare(right.source.uri))
+    .filter(
+      (specification) =>
+        paths.length === 0 ||
+        paths.some((path) => matchesPath(specification.source.uri, path)),
+    )
+    .filter((specification) => states.has(specification.state ?? 'active'))
     .flatMap((specification) =>
       specification.scenarios.map((scenario) => ({ specification, scenario })),
     )

--- a/packages/spec/src/selection.ts
+++ b/packages/spec/src/selection.ts
@@ -177,7 +177,7 @@ function globToRegExp(pattern: string): RegExp {
       regex += '[^/]*'
       continue
     }
-    if ('\\^$+{}()|[]?'.includes(character) || character === '.') {
+    if ('\\^$+{}()|[]?.'.includes(character)) {
       regex += `\\${character}`
       continue
     }

--- a/packages/spec/src/specification.test.ts
+++ b/packages/spec/src/specification.test.ts
@@ -170,6 +170,27 @@ Feature: Search
     ])
   })
 
+  test('collects adapter-neutral capability requirements without naming an adapter', () => {
+    const specification = parseSpecification({
+      uri: 'features/location.feature',
+      source: `@pickle:requires:camera
+Feature: Nearby stores
+  @pickle:requires:geolocation
+  Scenario: Show stores near the customer
+    When the customer shares their location
+    Then nearby stores are listed`,
+    })
+
+    expect(specification.scenarios[0]?.capabilityRequirements).toEqual([
+      'camera',
+      'geolocation',
+    ])
+    expect(JSON.stringify(specification)).not.toContain('adapter')
+    expect(JSON.stringify(specification.scenarios[0])).not.toMatch(
+      /stagehand|agent-device/i,
+    )
+  })
+
   test('expands Scenario Outlines and exposes adapter-neutral step types', () => {
     const specification = parseSpecification({
       uri: 'features/search.feature',

--- a/packages/spec/src/specification.test.ts
+++ b/packages/spec/src/specification.test.ts
@@ -15,6 +15,7 @@ Feature: Checkout
 
     expect(specification).toEqual({
       name: 'Checkout',
+      id: expect.any(String),
       source: {
         uri: 'features/checkout.feature',
         language: 'en',
@@ -23,6 +24,7 @@ Feature: Checkout
       scenarios: [
         {
           name: 'Complete a purchase',
+          id: expect.any(String),
           tags: ['@smoke'],
           steps: [
             {
@@ -142,6 +144,7 @@ Feature: Search
     expect(specification.scenarios).toEqual([
       {
         name: 'View the account',
+        id: expect.any(String),
         tags: [],
         steps: [
           { keyword: 'Given', text: 'an account exists', type: 'context' },
@@ -155,6 +158,7 @@ Feature: Search
       },
       {
         name: 'Reject access',
+        id: expect.any(String),
         tags: ['@locked', '@security'],
         steps: [
           { keyword: 'Given', text: 'an account exists', type: 'context' },
@@ -213,6 +217,9 @@ Feature: Search
     expect(specification.scenarios).toEqual([
       {
         name: 'Find a product',
+        id: expect.any(String),
+        examplesId: expect.any(String),
+        examplesRowId: expect.any(String),
         tags: ['@web'],
         steps: [
           {
@@ -235,6 +242,9 @@ Feature: Search
       },
       {
         name: 'Find a product',
+        id: expect.any(String),
+        examplesId: expect.any(String),
+        examplesRowId: expect.any(String),
         tags: ['@web'],
         steps: [
           {
@@ -256,5 +266,81 @@ Feature: Search
         ],
       },
     ])
+  })
+
+  test('derives a stable identifier from the specification URI and names', () => {
+    const source = `@pickle:state:active
+Feature: Checkout
+  Scenario: Complete a purchase
+    Given a product is in the basket
+    Then the purchase succeeds`
+    const first = parseSpecification({
+      uri: 'features/checkout.feature',
+      source,
+    })
+    const extraStep = parseSpecification({
+      uri: 'features/checkout.feature',
+      source: `${source}
+    And a receipt is shown`,
+    })
+    const renamed = parseSpecification({
+      uri: 'features/checkout.feature',
+      source: source.replace('Complete a purchase', 'Complete checkout'),
+    })
+    const moved = parseSpecification({
+      uri: 'features/shop/checkout.feature',
+      source,
+    })
+    const renamedFeature = parseSpecification({
+      uri: 'features/checkout.feature',
+      source: source.replace('Feature: Checkout', 'Feature: Basket'),
+    })
+
+    expect(first.id).toBeTruthy()
+    expect(first.scenarios[0]?.id).toBeTruthy()
+    expect(extraStep.id).toBe(first.id)
+    expect(extraStep.scenarios[0]?.id).toBe(first.scenarios[0]?.id)
+    expect(renamed.scenarios[0]?.id).not.toBe(first.scenarios[0]?.id)
+    expect(moved.id).not.toBe(first.id)
+    expect(renamedFeature.id).not.toBe(first.id)
+  })
+
+  test('derives examples row identifiers from row values so reordering keeps identity', () => {
+    const outline = (rows: string) => `Feature: Pay
+  Scenario Outline: Pay
+    When the customer pays with <method>
+    Then the payment succeeds
+
+    Examples:
+      | method |
+${rows}`
+    const cardFirst = parseSpecification({
+      uri: 'features/pay.feature',
+      source: outline('      | card   |\n      | cash   |'),
+    })
+    const cashFirst = parseSpecification({
+      uri: 'features/pay.feature',
+      source: outline('      | cash   |\n      | card   |'),
+    })
+    const visa = parseSpecification({
+      uri: 'features/pay.feature',
+      source: outline('      | visa   |\n      | cash   |'),
+    })
+    const cardId = cardFirst.scenarios.find((scenario) =>
+      scenario.steps.some((step) => step.text.includes('card')),
+    )?.examplesRowId
+    const reorderedCardId = cashFirst.scenarios.find((scenario) =>
+      scenario.steps.some((step) => step.text.includes('card')),
+    )?.examplesRowId
+    const visaId = visa.scenarios.find((scenario) =>
+      scenario.steps.some((step) => step.text.includes('visa')),
+    )?.examplesRowId
+
+    expect(cardId).toBeTruthy()
+    expect(reorderedCardId).toBe(cardId)
+    expect(visaId).not.toBe(cardId)
+    expect(cardFirst.scenarios[0]?.examplesId).toBe(
+      cashFirst.scenarios[0]?.examplesId,
+    )
   })
 })

--- a/packages/spec/src/specification.ts
+++ b/packages/spec/src/specification.ts
@@ -14,8 +14,11 @@ import type {
 } from '@cucumber/messages'
 import { IdGenerator, StepKeywordType } from '@cucumber/messages'
 import {
-  examplesRowId,
   identityFromTags,
+  resolveExamplesId,
+  resolveExamplesRowId,
+  resolveScenarioId,
+  resolveSpecificationId,
   type SpecificationState,
 } from './identity'
 
@@ -161,30 +164,56 @@ export function parseSpecification(
   }
 
   const infoByAstNodeId = collectStepInfo(document)
-  const scenariosById = new Map<string, { tags: string[] }>()
+  const scenariosById = new Map<string, { tags: string[]; name: string }>()
   const rowsById = new Map<
     string,
-    { header: string[]; cells: string[]; examplesTags: string[] }
+    {
+      header: string[]
+      cells: string[]
+      examplesTags: string[]
+      examplesName: string
+      scenarioName: string
+    }
   >()
   collectIdentityNodes(document, scenariosById, rowsById)
-  const featureIdentity = identityFromTags(feature.tags.map((tag) => tag.name))
+  const featureTags = feature.tags.map((tag) => tag.name)
+  const featureIdentity = identityFromTags(featureTags)
   const scenarios: Scenario[] = compile(document, input.uri, newId).map(
     (pickle) => {
-      const scenarioIdentity = identityFromTags(
-        scenariosById.get(pickle.astNodeIds[0] ?? '')?.tags ?? [],
-      )
+      const scenarioNode = scenariosById.get(pickle.astNodeIds[0] ?? '')
+      const scenarioTags = scenarioNode?.tags ?? []
       const row = rowsById.get(pickle.astNodeIds[1] ?? '')
-      const examplesIdentity = identityFromTags(row?.examplesTags ?? [])
-      const rowId = row ? examplesRowId(row.header, row.cells) : undefined
       const tags = pickle.tags.map(({ name }) => name)
       const requirements = capabilityRequirements(tags)
       return {
         name: pickle.name,
         tags,
         steps: pickle.steps.map((step) => mapStep(step, infoByAstNodeId)),
-        ...(scenarioIdentity.id ? { id: scenarioIdentity.id } : {}),
-        ...(examplesIdentity.id ? { examplesId: examplesIdentity.id } : {}),
-        ...(rowId ? { examplesRowId: rowId } : {}),
+        id: resolveScenarioId(
+          input.uri,
+          feature.name,
+          scenarioNode?.name ?? pickle.name,
+          scenarioTags,
+        ),
+        ...(row
+          ? {
+              examplesId: resolveExamplesId(
+                input.uri,
+                feature.name,
+                row.scenarioName,
+                row.examplesName,
+                row.examplesTags,
+              ),
+              examplesRowId: resolveExamplesRowId(
+                input.uri,
+                feature.name,
+                row.scenarioName,
+                row.examplesName,
+                row.header,
+                row.cells,
+              ),
+            }
+          : {}),
         ...(requirements ? { capabilityRequirements: requirements } : {}),
       }
     },
@@ -196,22 +225,28 @@ export function parseSpecification(
       uri: input.uri,
       language: feature.language,
     },
-    tags: feature.tags.map(({ name }) => name),
+    tags: featureTags,
     scenarios,
-    ...(featureIdentity.id ? { id: featureIdentity.id } : {}),
+    id: resolveSpecificationId(input.uri, feature.name, featureTags),
     ...(featureIdentity.state ? { state: featureIdentity.state } : {}),
   }
 }
 
 function collectIdentityNodes(
   document: GherkinDocument,
-  scenariosById: Map<string, { tags: string[] }>,
+  scenariosById: Map<string, { tags: string[]; name: string }>,
   rowsById: Map<
     string,
-    { header: string[]; cells: string[]; examplesTags: string[] }
+    {
+      header: string[]
+      cells: string[]
+      examplesTags: string[]
+      examplesName: string
+      scenarioName: string
+    }
   >,
 ): void {
-  function visitExamples(examples: Examples): void {
+  function visitExamples(scenarioName: string, examples: Examples): void {
     const header = examples.tableHeader?.cells.map((cell) => cell.value) ?? []
     const examplesTags = examples.tags.map((tag) => tag.name)
     for (const row of examples.tableBody) {
@@ -219,6 +254,8 @@ function collectIdentityNodes(
         header,
         cells: row.cells.map((cell) => cell.value),
         examplesTags,
+        examplesName: examples.name,
+        scenarioName,
       })
     }
   }
@@ -227,8 +264,10 @@ function collectIdentityNodes(
     if (child.scenario) {
       scenariosById.set(child.scenario.id, {
         tags: child.scenario.tags.map((tag) => tag.name),
+        name: child.scenario.name,
       })
-      for (const examples of child.scenario.examples) visitExamples(examples)
+      for (const examples of child.scenario.examples)
+        visitExamples(child.scenario.name, examples)
     }
     if ('rule' in child && child.rule) {
       for (const ruleChild of child.rule.children) visitChild(ruleChild)

--- a/packages/spec/src/specification.ts
+++ b/packages/spec/src/specification.ts
@@ -59,7 +59,21 @@ export interface ParseSpecificationInput {
   language?: string
 }
 
+const requiresTagPrefix = '@pickle:requires:'
+
 type ScenarioStepType = ScenarioStep['type']
+
+function capabilityRequirements(tags: readonly string[]): string[] | undefined {
+  const required = [
+    ...new Set(
+      tags
+        .filter((tag) => tag.startsWith(requiresTagPrefix))
+        .map((tag) => tag.slice(requiresTagPrefix.length))
+        .filter((value) => value.length > 0),
+    ),
+  ]
+  return required.length > 0 ? required : undefined
+}
 
 function stepType(
   keywordType: StepKeywordType | undefined,
@@ -162,13 +176,16 @@ export function parseSpecification(
       const row = rowsById.get(pickle.astNodeIds[1] ?? '')
       const examplesIdentity = identityFromTags(row?.examplesTags ?? [])
       const rowId = row ? examplesRowId(row.header, row.cells) : undefined
+      const tags = pickle.tags.map(({ name }) => name)
+      const requirements = capabilityRequirements(tags)
       return {
         name: pickle.name,
-        tags: pickle.tags.map(({ name }) => name),
+        tags,
         steps: pickle.steps.map((step) => mapStep(step, infoByAstNodeId)),
         ...(scenarioIdentity.id ? { id: scenarioIdentity.id } : {}),
         ...(examplesIdentity.id ? { examplesId: examplesIdentity.id } : {}),
         ...(rowId ? { examplesRowId: rowId } : {}),
+        ...(requirements ? { capabilityRequirements: requirements } : {}),
       }
     },
   )

--- a/packages/web/src/web-adapter.test.ts
+++ b/packages/web/src/web-adapter.test.ts
@@ -157,4 +157,118 @@ describe('createWebAdapter', () => {
     )
     expect(observe).not.toHaveBeenCalled()
   })
+
+  test('rejects an unsupported Stagehand model before opening a logical session', () => {
+    const open = mock(async () => {
+      throw new Error('logical session must not start')
+    })
+
+    expect(() =>
+      createWebAdapter(
+        {
+          baseUrl: 'https://example.test',
+          browser: { modelName: 'google/gemini-3.7-flash' },
+        },
+        { open },
+      ),
+    ).toThrow(
+      'web.browser.modelName "google/gemini-3.7-flash" is not a Stagehand-supported model',
+    )
+    expect(open).not.toHaveBeenCalled()
+  })
+
+  test('accepts a Stagehand-supported model name', () => {
+    expect(() =>
+      createWebAdapter({
+        baseUrl: 'https://example.test',
+        browser: { modelName: 'google/gemini-3.6-flash' },
+      }),
+    ).not.toThrow()
+  })
+
+  test('forwards GOOGLE_API_KEY to the automation factory for a Google model', async () => {
+    const names = [
+      'GOOGLE_API_KEY',
+      'GOOGLE_GENERATIVE_AI_API_KEY',
+      'GEMINI_API_KEY',
+    ]
+    const previous = Object.fromEntries(
+      names.map((name) => [name, process.env[name]]),
+    )
+    for (const name of names) delete process.env[name]
+    process.env.GOOGLE_API_KEY = 'test-google-key'
+    const open = mock(async () => ({
+      async navigate() {},
+      async observe() {
+        return []
+      },
+      async act() {
+        return { success: true }
+      },
+      async verify() {
+        return { meetsExpectation: true, actualState: 'Ready' }
+      },
+      async screenshot() {
+        return new Uint8Array()
+      },
+      async close() {},
+    }))
+    try {
+      const adapter = createWebAdapter(
+        {
+          baseUrl: 'https://example.test',
+          browser: { modelName: 'google/gemini-3.6-flash' },
+        },
+        { open },
+      )
+      const session = await adapter.openSession({
+        executionTargetProfile: { id: 'web' },
+        specification,
+        scenario,
+      })
+      await session.close()
+    } finally {
+      for (const name of names) {
+        if (previous[name] === undefined) delete process.env[name]
+        else process.env[name] = previous[name]
+      }
+    }
+
+    expect(open).toHaveBeenCalledWith(
+      expect.objectContaining({
+        browser: expect.objectContaining({ modelApiKey: 'test-google-key' }),
+      }),
+    )
+  })
+
+  test('rejects a local Stagehand session without a provider API key before launching a browser', async () => {
+    const previous = {
+      GOOGLE_API_KEY: process.env.GOOGLE_API_KEY,
+      GOOGLE_GENERATIVE_AI_API_KEY: process.env.GOOGLE_GENERATIVE_AI_API_KEY,
+      GEMINI_API_KEY: process.env.GEMINI_API_KEY,
+    }
+    delete process.env.GOOGLE_API_KEY
+    delete process.env.GOOGLE_GENERATIVE_AI_API_KEY
+    delete process.env.GEMINI_API_KEY
+    const adapter = createWebAdapter({
+      baseUrl: 'https://example.test',
+      browser: { modelName: 'google/gemini-3.6-flash' },
+    })
+    try {
+      await expect(
+        adapter.openSession({
+          executionTargetProfile: { id: 'web' },
+          specification,
+          scenario,
+        }),
+      ).rejects.toThrow(
+        'Model inference requires a provider API key or a Browserbase session',
+      )
+    } finally {
+      for (const [name, value] of Object.entries(previous)) {
+        if (value === undefined) delete process.env[name]
+        else process.env[name] = value
+      }
+    }
+  })
 })

--- a/packages/web/src/web-adapter.ts
+++ b/packages/web/src/web-adapter.ts
@@ -5,6 +5,7 @@ import {
   localBrowser,
   type ModelConfig,
   Stagehand,
+  StagehandCreateOptionsSchema,
 } from '@browserbasehq/stagehand'
 import type {
   ExecutionTargetAdapter,
@@ -79,6 +80,22 @@ function optionalPositiveInteger(value: unknown, field: string): void {
   }
 }
 
+function validateModelName(value: unknown): void {
+  optionalString(value, 'web.browser.modelName')
+  if (value === undefined) return
+  if (!(value as string).trim()) {
+    throw new Error('web.browser.modelName must not be empty')
+  }
+  const parsed = StagehandCreateOptionsSchema.shape.model.safeParse({
+    modelName: value,
+  })
+  if (!parsed.success) {
+    throw new Error(
+      `web.browser.modelName "${value}" is not a Stagehand-supported model`,
+    )
+  }
+}
+
 export function validateWebAdapterOptions(value: unknown): WebAdapterOptions {
   const web = record(value, 'web')
   knownFields(web, ['baseUrl', 'browser', 'screenshots'], 'web')
@@ -118,7 +135,7 @@ export function validateWebAdapterOptions(value: unknown): WebAdapterOptions {
     ) {
       throw new Error('web.browser.environment must be local or browserbase')
     }
-    optionalString(browser.modelName, 'web.browser.modelName')
+    validateModelName(browser.modelName)
     optionalString(browser.modelApiKey, 'web.browser.modelApiKey')
     optionalString(browser.browserbaseApiKey, 'web.browser.browserbaseApiKey')
     optionalString(
@@ -270,14 +287,22 @@ const stagehandFactory: WebAutomationFactory = {
         'anthropic/claude-sonnet-4-6') as ModelConfig['modelName'],
       ...(options.modelApiKey ? { apiKey: options.modelApiKey } : {}),
     }
-    const stagehand = await Stagehand.create({
-      browser,
-      model,
-      logging: { level: 'off', format: 'json' },
-      selfHeal: options.selfHeal ?? true,
-      domSettleTimeoutMs: options.domSettleTimeoutMs ?? 3_000,
-      ...(options.cache !== undefined ? { cache: options.cache } : {}),
-    })
+    let stagehand: Stagehand
+    try {
+      stagehand = await Stagehand.create({
+        browser,
+        model,
+        logging: { level: 'off', format: 'json' },
+        selfHeal: options.selfHeal ?? true,
+        domSettleTimeoutMs: options.domSettleTimeoutMs ?? 3_000,
+        ...(options.cache !== undefined ? { cache: options.cache } : {}),
+      })
+    } catch (error) {
+      try {
+        await browser.close()
+      } catch {}
+      throw error
+    }
 
     return {
       async navigate(url, operationSignal) {
@@ -376,6 +401,62 @@ function errorMessage(error: unknown): string {
   return error instanceof Error ? error.message : String(error)
 }
 
+function providerApiKeyEnvNames(modelName: string | undefined): string[] {
+  const provider = (modelName ?? 'anthropic/claude-sonnet-4-6').split('/')[0]
+  switch (provider) {
+    case 'openai':
+      return ['OPENAI_API_KEY']
+    case 'anthropic':
+      return ['ANTHROPIC_API_KEY']
+    case 'google':
+      return [
+        'GOOGLE_GENERATIVE_AI_API_KEY',
+        'GOOGLE_API_KEY',
+        'GEMINI_API_KEY',
+      ]
+    case 'groq':
+      return ['GROQ_API_KEY']
+    case 'cerebras':
+      return ['CEREBRAS_API_KEY']
+    default:
+      return []
+  }
+}
+
+function resolveModelApiKey(
+  browser: BrowserOptions | undefined,
+): string | undefined {
+  const configured = browser?.modelApiKey?.trim()
+  if (configured) return configured
+  for (const name of providerApiKeyEnvNames(browser?.modelName)) {
+    const value = process.env[name]?.trim()
+    if (value) return value
+  }
+}
+
+function stagehandBrowserOptions(
+  browser: BrowserOptions | undefined,
+  requireProviderApiKey: boolean,
+): BrowserOptions {
+  const modelApiKey = resolveModelApiKey(browser)
+  const next = {
+    ...browser,
+    ...(modelApiKey ? { modelApiKey } : {}),
+  }
+  if (
+    requireProviderApiKey &&
+    next.environment !== 'browserbase' &&
+    !next.modelApiKey
+  ) {
+    const envNames = providerApiKeyEnvNames(next.modelName)
+    throw new Error(
+      'Model inference requires a provider API key or a Browserbase session. ' +
+        `Set ${envNames.join(', ')}, or web.browser.modelApiKey.`,
+    )
+  }
+  return next
+}
+
 export function createWebAdapter(
   options: WebAdapterOptions,
   factory: WebAutomationFactory = stagehandFactory,
@@ -385,7 +466,10 @@ export function createWebAdapter(
     capabilities: ['web', 'screenshots'],
     async openSession(input) {
       const automation = await factory.open({
-        browser: validatedOptions.browser ?? {},
+        browser: stagehandBrowserOptions(
+          validatedOptions.browser,
+          factory === stagehandFactory,
+        ),
         signal: input.signal,
       })
       let closed = false


### PR DESCRIPTION
## Summary
- Named test suites in `pickle.config.jsonc` select Scenarios by path, tag, state, or name query (`pickle run --suite`).
- Named execution target profiles declare adapter configuration and capabilities; a multi-target run produces one test result per Scenario and profile.
- Incompatible capability selections fail validation before execution resources start. Custom adapters load only from explicit `pickle.extensions.ts` imports.

Closes #15

## Test plan
- [x] `bun run lint`
- [x] `bun run typecheck`
- [x] `bun run test`
- [ ] `pickle run --suite smoke --profile web` in a project with named suites and profiles
- [ ] Confirm a Scenario with `@pickle:requires:geolocation` fails `pickle run` before the application server starts when the selected profile lacks that capability
