### PR TITLE
Run web Scenarios in Adaptive and Replay modes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,7 +25,9 @@ report.[0-9]_.[0-9]_.[0-9]_.[0-9]_.json
 # caches
 .eslintcache
 .cache
-.pickle
+.pickle/*
+!.pickle/plans/
+!.pickle/plans/**
 .turbo
 *.tsbuildinfo
 

--- a/README.md
+++ b/README.md
@@ -65,6 +65,10 @@ Create `pickle.config.jsonc` in the project root:
       }
     }
   },
+  "applicationRevision": "git:HEAD",
+  "policy": {
+    "adaptedResults": "reject"
+  },
   "execution": {
     "infrastructureRetries": 1,
     "scenarioTimeoutMs": 30000,
@@ -92,6 +96,29 @@ pickle run "features/**/*.feature" --screenshot on-step
 ```
 
 The command writes versioned run-event and test-result records as newline-delimited JSON.
+
+## Run Adaptive and Replay modes
+
+A Scenario without an applicable approved plan runs in Adaptive mode. Adaptive mode resolves actions while the Scenario runs and writes a candidate plan under `.pickle/candidates/`.
+
+An applicable approved plan runs in Replay mode. Replay mode uses the stored resolved actions and does not resolve actions with a model. Approved plans live under `.pickle/plans/` and belong in Git.
+
+A plan applies to one Scenario revision, execution target profile, plan-format version, and application revision. A plan for one execution target profile cannot run on another profile.
+
+If Replay cannot complete a Scenario and Adaptive mode then succeeds, the test result is `passed-with-adaptation`. That run writes a candidate plan. It does not change the approved plan.
+
+Set `applicationRevision` in `pickle.config.jsonc` or pass `--application-revision`. CI Replay requires that value. CI can reject adapted results:
+
+```jsonc
+{
+  "applicationRevision": "git:abc123",
+  "policy": {
+    "adaptedResults": "reject"
+  }
+}
+```
+
+`policy.adaptedResults` accepts `accept` or `reject`. The default is `accept`.
 
 ## Add a custom adapter
 

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -325,6 +325,7 @@ async function run(argv: string[]): Promise<number> {
       selections,
       ...resolvedConfiguration,
       plans: createFilePlanStore(process.cwd()),
+      ci: Boolean(process.env.CI),
       signal: controller.signal,
       onEvent(event) {
         console.log(JSON.stringify({ kind: 'run-event', event }))
@@ -336,15 +337,13 @@ async function run(argv: string[]): Promise<number> {
         JSON.stringify({ kind: 'test-result', result: scenarioRun.result }),
       )
     }
-    if (runs.some(({ result }) => result.state === 'cancelled')) return 130
+    const states = runs.map(({ result }) => result.state)
+    if (states.includes('cancelled')) return 130
     if (
-      runs.some(
-        ({ result }) =>
-          result.state === 'failed' ||
-          result.state === 'infrastructure-error' ||
-          (result.state === 'passed-with-adaptation' &&
-            config.policy?.adaptedResults === 'reject'),
-      )
+      states.includes('failed') ||
+      states.includes('infrastructure-error') ||
+      (config.policy?.adaptedResults === 'reject' &&
+        states.includes('passed-with-adaptation'))
     ) {
       return 1
     }

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -8,6 +8,7 @@ import type {
   RunExtensions,
 } from '@pickle-spec/runner'
 import {
+  createFilePlanStore,
   resolveRunConfiguration,
   runScenarios,
   validateTargetSelection,
@@ -40,6 +41,7 @@ interface RunArguments {
   reuseServer?: boolean
   headed?: boolean
   screenshotMode?: NonNullable<WebAdapterOptions['screenshots']>['mode']
+  applicationRevision?: string
 }
 
 function integer(value: string, flag: string, minimum: number): number {
@@ -137,6 +139,9 @@ function parseRunArguments(argv: string[]): RunArguments {
         args.screenshotMode = mode as RunArguments['screenshotMode']
         break
       }
+      case '--application-revision':
+        args.applicationRevision = valueAfter(argv, index++)
+        break
       default:
         throw new Error(`Unknown option: ${flag}`)
     }
@@ -292,6 +297,8 @@ async function run(argv: string[]): Promise<number> {
     const runConfiguration = {
       ...runConfigurationFrom(config, args.profiles),
       concurrency: args.concurrency ?? config.concurrency,
+      applicationRevision:
+        args.applicationRevision ?? config.applicationRevision,
       execution: {
         infrastructureRetries:
           args.retries ?? config.execution?.infrastructureRetries,
@@ -317,6 +324,7 @@ async function run(argv: string[]): Promise<number> {
     const runs = await runScenarios({
       selections,
       ...resolvedConfiguration,
+      plans: createFilePlanStore(process.cwd()),
       signal: controller.signal,
       onEvent(event) {
         console.log(JSON.stringify({ kind: 'run-event', event }))
@@ -332,7 +340,10 @@ async function run(argv: string[]): Promise<number> {
     if (
       runs.some(
         ({ result }) =>
-          result.state === 'failed' || result.state === 'infrastructure-error',
+          result.state === 'failed' ||
+          result.state === 'infrastructure-error' ||
+          (result.state === 'passed-with-adaptation' &&
+            config.policy?.adaptedResults === 'reject'),
       )
     ) {
       return 1

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -29,6 +29,10 @@ export interface ProjectExecutionTargetProfile {
   web?: WebAdapterOptions
 }
 
+export interface ProjectPolicy {
+  adaptedResults?: 'accept' | 'reject'
+}
+
 export interface PickleConfig {
   schemaVersion: 1
   language?: string
@@ -36,6 +40,8 @@ export interface PickleConfig {
   suites?: Record<string, SelectionOptions>
   executionTargetProfiles?: Record<string, ProjectExecutionTargetProfile>
   executionTargetProfile?: ExecutionTargetProfile
+  applicationRevision?: string
+  policy?: ProjectPolicy
   web?: WebAdapterOptions
   selection?: SelectionOptions
   execution?: {
@@ -101,6 +107,9 @@ export function runConfigurationFrom(
     executionTargetProfiles,
     concurrency: config.concurrency,
     execution: config.execution,
+    ...(config.applicationRevision
+      ? { applicationRevision: config.applicationRevision }
+      : {}),
   }
 }
 
@@ -210,6 +219,8 @@ function validateConfig(value: unknown): PickleConfig {
       'suites',
       'executionTargetProfiles',
       'executionTargetProfile',
+      'applicationRevision',
+      'policy',
       'web',
       'selection',
       'execution',
@@ -285,6 +296,24 @@ function validateConfig(value: unknown): PickleConfig {
     }
     if (typeof server.port === 'number' && server.port > 65_535) {
       throw new Error('server.port must be less than or equal to 65535')
+    }
+  }
+  if (
+    config.applicationRevision !== undefined &&
+    (typeof config.applicationRevision !== 'string' ||
+      !config.applicationRevision.trim())
+  ) {
+    throw new Error('applicationRevision must not be empty')
+  }
+  if (config.policy !== undefined) {
+    const policy = record(config.policy, 'policy')
+    knownFields(policy, ['adaptedResults'], 'policy')
+    if (
+      policy.adaptedResults !== undefined &&
+      policy.adaptedResults !== 'accept' &&
+      policy.adaptedResults !== 'reject'
+    ) {
+      throw new Error('policy.adaptedResults must be accept or reject')
     }
   }
   if (config.selection !== undefined) validateSelectionOptions(config.selection)

--- a/packages/cli/src/workspace.test.ts
+++ b/packages/cli/src/workspace.test.ts
@@ -1117,4 +1117,156 @@ export default { adapter: { async openSession() { throw new Error('no') } } }
       'Correct the value and run pickle check again',
     )
   })
+
+  test('runs Adaptive then Replay from reviewable plan files and rejects adapted results by policy', async () => {
+    const extensions = await Bun.file(
+      join(workspace, 'pickle.extensions.ts'),
+    ).text()
+    const project = await createCheckProject('execution-plans', {
+      config: {
+        schemaVersion: 1,
+        specifications: 'features/**/*.feature',
+        applicationRevision: 'app-1',
+        executionTargetProfiles: {
+          web: { adapter: 'custom' },
+          android: { adapter: 'custom' },
+        },
+        policy: { adaptedResults: 'accept' },
+      },
+      specification: {
+        path: 'features/purchase.feature',
+        source: `@pickle:id:specpurchaseaaaaaa @pickle:state:active
+Feature: Purchase
+  @pickle:id:scnpurchasebbbbbb
+  Scenario: Complete a purchase
+    Given a product is in the basket
+    Then the purchase succeeds`,
+      },
+      extensions,
+    })
+    const approvedPath = join(
+      project,
+      '.pickle',
+      'plans',
+      'web',
+      'scnpurchasebbbbbb.json',
+    )
+    const candidatePath = join(
+      project,
+      '.pickle',
+      'candidates',
+      'web',
+      'scnpurchasebbbbbb.json',
+    )
+
+    const first = Bun.spawnSync({
+      cmd: [pickleCommand, 'run', '--profile', 'web'],
+      cwd: project,
+      env: { ...Bun.env, PICKLE_TEST_OUTCOME: 'passed' },
+    })
+    const firstResult = JSON.parse(
+      first.stdout.toString().trim().split('\n').at(-1) ?? '{}',
+    )
+    expect(first.exitCode).toBe(0)
+    expect(firstResult).toMatchObject({
+      kind: 'test-result',
+      result: { state: 'passed', executionMode: 'adaptive' },
+    })
+    expect(await Bun.file(candidatePath).exists()).toBe(true)
+    expect(await Bun.file(approvedPath).exists()).toBe(false)
+
+    const candidate = JSON.parse(await Bun.file(candidatePath).text())
+    expect(candidate).toMatchObject({
+      schemaVersion: 1,
+      scenarioId: 'scnpurchasebbbbbb',
+      executionTargetProfileId: 'web',
+      applicationRevision: 'app-1',
+    })
+    expect(candidate.steps[0].resolvedActions.length).toBeGreaterThanOrEqual(1)
+    await mkdir(dirname(approvedPath), { recursive: true })
+    await Bun.write(approvedPath, `${JSON.stringify(candidate, null, 2)}\n`)
+    const approved = await Bun.file(approvedPath).text()
+    await Bun.write(candidatePath, 'stale-candidate')
+
+    const replay = Bun.spawnSync({
+      cmd: [pickleCommand, 'run', '--profile', 'web'],
+      cwd: project,
+      env: { ...Bun.env, PICKLE_TEST_OUTCOME: 'passed' },
+    })
+    expect(replay.exitCode).toBe(0)
+    expect(
+      JSON.parse(replay.stdout.toString().trim().split('\n').at(-1) ?? '{}'),
+    ).toMatchObject({
+      kind: 'test-result',
+      result: { state: 'passed', executionMode: 'replay' },
+    })
+    expect(await Bun.file(approvedPath).text()).toBe(approved)
+    expect(await Bun.file(candidatePath).text()).toBe('stale-candidate')
+
+    const otherProfile = Bun.spawnSync({
+      cmd: [pickleCommand, 'run', '--profile', 'android'],
+      cwd: project,
+      env: { ...Bun.env, PICKLE_TEST_OUTCOME: 'passed' },
+    })
+    expect(otherProfile.exitCode).toBe(0)
+    expect(
+      JSON.parse(
+        otherProfile.stdout.toString().trim().split('\n').at(-1) ?? '{}',
+      ),
+    ).toMatchObject({
+      kind: 'test-result',
+      result: {
+        state: 'passed',
+        executionMode: 'adaptive',
+        executionTargetProfile: { id: 'android' },
+      },
+    })
+    expect(await Bun.file(approvedPath).text()).toBe(approved)
+
+    await Bun.write(
+      join(project, 'pickle.config.jsonc'),
+      JSON.stringify({
+        schemaVersion: 1,
+        specifications: 'features/**/*.feature',
+        applicationRevision: 'app-1',
+        executionTargetProfiles: {
+          web: { adapter: 'custom' },
+        },
+        policy: { adaptedResults: 'reject' },
+      }),
+    )
+    const rejected = Bun.spawnSync({
+      cmd: [pickleCommand, 'run', '--profile', 'web'],
+      cwd: project,
+      env: { ...Bun.env, PICKLE_TEST_OUTCOME: 'passed-with-adaptation' },
+    })
+    expect(rejected.exitCode).toBe(1)
+    expect(
+      JSON.parse(rejected.stdout.toString().trim().split('\n').at(-1) ?? '{}'),
+    ).toMatchObject({
+      kind: 'test-result',
+      result: { state: 'passed-with-adaptation' },
+    })
+    expect(await Bun.file(approvedPath).text()).toBe(approved)
+  })
+
+  test('check rejects an unknown adapted-result policy', async () => {
+    const project = await createCheckProject('invalid-adapted-policy', {
+      config: {
+        ...defaultCheckConfig,
+        policy: { adaptedResults: 'ignore' },
+      },
+      specification: validSpecification,
+    })
+
+    const checked = runCheck(project)
+
+    expect(checked.exitCode).toBe(2)
+    expect(checked.stderr.toString()).toContain(
+      'policy.adaptedResults must be accept or reject',
+    )
+    expect(checked.stderr.toString()).toContain(
+      'Correct the value and run pickle check again',
+    )
+  })
 })

--- a/packages/runner/index.ts
+++ b/packages/runner/index.ts
@@ -17,7 +17,6 @@ export type {
 } from './src/execution-plan'
 export {
   createFilePlanStore,
-  createMemoryPlanStore,
   planApplies,
 } from './src/execution-plan'
 export type {

--- a/packages/runner/index.ts
+++ b/packages/runner/index.ts
@@ -10,6 +10,18 @@ export {
   validateRunConfiguration,
 } from './src/configuration'
 export type {
+  ExecutionPlan,
+  ExecutionPlanStep,
+  ExecutionPlanStore,
+  PlanApplicability,
+} from './src/execution-plan'
+export {
+  createFilePlanStore,
+  createMemoryPlanStore,
+  planApplies,
+} from './src/execution-plan'
+export type {
+  ExecutionMode,
   ExecutionPolicy,
   ExecutionTargetAdapter,
   ExecutionTargetProfile,

--- a/packages/runner/src/configuration.test.ts
+++ b/packages/runner/src/configuration.test.ts
@@ -205,3 +205,16 @@ test('binds adapter configuration per execution target profile', () => {
     production,
   ])
 })
+
+test('carries the application revision into the resolved run', () => {
+  const resolved = resolveRunConfiguration(
+    {
+      schemaVersion: 1,
+      executionTargetProfile: { id: 'web' },
+      applicationRevision: 'app-1',
+    },
+    { adapter },
+  )
+
+  expect(resolved.applicationRevision).toBe('app-1')
+})

--- a/packages/runner/src/configuration.ts
+++ b/packages/runner/src/configuration.ts
@@ -158,6 +158,27 @@ function assertProfileCapabilities(
   }
 }
 
+function validateExecution(value: unknown): RunConfiguration['execution'] {
+  const execution = record(value, 'execution')
+  knownFields(
+    execution,
+    ['infrastructureRetries', 'scenarioTimeoutMs', 'stepTimeoutMs'],
+    'execution',
+  )
+  positiveInteger(execution.scenarioTimeoutMs, 'execution.scenarioTimeoutMs')
+  positiveInteger(execution.stepTimeoutMs, 'execution.stepTimeoutMs')
+  const retries = execution.infrastructureRetries
+  if (
+    retries !== undefined &&
+    (!Number.isInteger(retries) || (retries as number) < 0)
+  ) {
+    throw new Error(
+      'execution.infrastructureRetries must be a non-negative integer',
+    )
+  }
+  return execution
+}
+
 export function validateRunConfiguration(value: unknown): RunConfiguration {
   const configuration = record(value, 'run configuration')
   knownFields(
@@ -216,23 +237,7 @@ export function validateRunConfiguration(value: unknown): RunConfiguration {
   }
   positiveInteger(configuration.concurrency, 'concurrency')
   if (configuration.execution !== undefined) {
-    const execution = record(configuration.execution, 'execution')
-    knownFields(
-      execution,
-      ['infrastructureRetries', 'scenarioTimeoutMs', 'stepTimeoutMs'],
-      'execution',
-    )
-    positiveInteger(execution.scenarioTimeoutMs, 'execution.scenarioTimeoutMs')
-    positiveInteger(execution.stepTimeoutMs, 'execution.stepTimeoutMs')
-    const retries = execution.infrastructureRetries
-    if (
-      retries !== undefined &&
-      (!Number.isInteger(retries) || (retries as number) < 0)
-    ) {
-      throw new Error(
-        'execution.infrastructureRetries must be a non-negative integer',
-      )
-    }
+    configuration.execution = validateExecution(configuration.execution)
   }
   return configuration as unknown as RunConfiguration
 }

--- a/packages/runner/src/configuration.ts
+++ b/packages/runner/src/configuration.ts
@@ -9,6 +9,7 @@ export interface RunConfiguration {
   schemaVersion: 1
   executionTargetProfile?: ExecutionTargetProfile
   executionTargetProfiles?: ExecutionTargetProfile[]
+  applicationRevision?: string
   concurrency?: number
   execution?: {
     infrastructureRetries?: number
@@ -32,6 +33,7 @@ export interface ResolvedRunConfiguration extends ExecutionPolicy {
   executionTargetProfile: ExecutionTargetProfile
   targets: RunTarget[]
   concurrency: number
+  applicationRevision?: string
 }
 
 function record(value: unknown, field: string): Record<string, unknown> {
@@ -164,6 +166,7 @@ export function validateRunConfiguration(value: unknown): RunConfiguration {
       'schemaVersion',
       'executionTargetProfile',
       'executionTargetProfiles',
+      'applicationRevision',
       'concurrency',
       'execution',
     ],
@@ -203,6 +206,13 @@ export function validateRunConfiguration(value: unknown): RunConfiguration {
     throw new Error(
       'executionTargetProfile or executionTargetProfiles is required',
     )
+  }
+  if (
+    configuration.applicationRevision !== undefined &&
+    (typeof configuration.applicationRevision !== 'string' ||
+      !configuration.applicationRevision.trim())
+  ) {
+    throw new Error('applicationRevision must not be empty')
   }
   positiveInteger(configuration.concurrency, 'concurrency')
   if (configuration.execution !== undefined) {
@@ -265,5 +275,8 @@ export function resolveRunConfiguration(
       scenarioMs: validatedConfiguration.execution?.scenarioTimeoutMs,
       stepMs: validatedConfiguration.execution?.stepTimeoutMs,
     },
+    ...(validatedConfiguration.applicationRevision
+      ? { applicationRevision: validatedConfiguration.applicationRevision }
+      : {}),
   }
 }

--- a/packages/runner/src/execution-plan.test.ts
+++ b/packages/runner/src/execution-plan.test.ts
@@ -1,0 +1,153 @@
+import { afterAll, describe, expect, test } from 'bun:test'
+import { mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import {
+  createFilePlanStore,
+  createMemoryPlanStore,
+  type ExecutionPlan,
+  planApplies,
+} from '../index'
+
+const applicable: ExecutionPlan = {
+  schemaVersion: 1,
+  scenarioId: 'scnbbbbbbbbbbbb',
+  scenarioRevision: 'rev-a',
+  executionTargetProfileId: 'web',
+  planFormatVersion: 'web.1',
+  applicationRevision: 'app-1',
+  steps: [
+    {
+      resolvedActions: [
+        { description: 'Fill the search field', replay: { selector: '#q' } },
+        { description: 'Submit the search', replay: { selector: '#go' } },
+      ],
+    },
+  ],
+}
+
+describe('planApplies', () => {
+  test('requires Scenario revision, target profile, plan-format version, and application revision', () => {
+    expect(
+      planApplies(applicable, {
+        scenarioId: 'scnbbbbbbbbbbbb',
+        scenarioRevision: 'rev-a',
+        executionTargetProfileId: 'web',
+        planFormatVersion: 'web.1',
+        applicationRevision: 'app-1',
+      }),
+    ).toBe(true)
+    expect(
+      planApplies(applicable, {
+        scenarioId: 'scnbbbbbbbbbbbb',
+        scenarioRevision: 'rev-b',
+        executionTargetProfileId: 'web',
+        planFormatVersion: 'web.1',
+        applicationRevision: 'app-1',
+      }),
+    ).toBe(false)
+    expect(
+      planApplies(applicable, {
+        scenarioId: 'scnbbbbbbbbbbbb',
+        scenarioRevision: 'rev-a',
+        executionTargetProfileId: 'mobile',
+        planFormatVersion: 'web.1',
+        applicationRevision: 'app-1',
+      }),
+    ).toBe(false)
+    expect(
+      planApplies(applicable, {
+        scenarioId: 'scnbbbbbbbbbbbb',
+        scenarioRevision: 'rev-a',
+        executionTargetProfileId: 'web',
+        planFormatVersion: 'web.2',
+        applicationRevision: 'app-1',
+      }),
+    ).toBe(false)
+    expect(
+      planApplies(applicable, {
+        scenarioId: 'scnbbbbbbbbbbbb',
+        scenarioRevision: 'rev-a',
+        executionTargetProfileId: 'web',
+        planFormatVersion: 'web.1',
+        applicationRevision: 'app-2',
+      }),
+    ).toBe(false)
+  })
+})
+
+describe('execution plan store', () => {
+  const directories: string[] = []
+
+  afterAll(async () => {
+    await Promise.all(
+      directories.map((directory) =>
+        rm(directory, { recursive: true, force: true }),
+      ),
+    )
+  })
+
+  test('returns only an approved plan that applies to the current query', async () => {
+    const store = createMemoryPlanStore([applicable])
+    const found = await store.findApproved({
+      scenarioId: 'scnbbbbbbbbbbbb',
+      scenarioRevision: 'rev-a',
+      executionTargetProfileId: 'web',
+      planFormatVersion: 'web.1',
+      applicationRevision: 'app-1',
+    })
+    const otherProfile = await store.findApproved({
+      scenarioId: 'scnbbbbbbbbbbbb',
+      scenarioRevision: 'rev-a',
+      executionTargetProfileId: 'android',
+      planFormatVersion: 'web.1',
+      applicationRevision: 'app-1',
+    })
+
+    expect(found).toEqual(applicable)
+    expect(otherProfile).toBeUndefined()
+  })
+
+  test('writes a candidate plan without changing the approved plan', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'pickle-plans-'))
+    directories.push(root)
+    const approvedPath = join(
+      root,
+      '.pickle',
+      'plans',
+      'web',
+      'scnbbbbbbbbbbbb.json',
+    )
+    await Bun.write(approvedPath, `${JSON.stringify(applicable, null, 2)}\n`)
+    const store = createFilePlanStore(root)
+    const candidate: ExecutionPlan = {
+      ...applicable,
+      steps: [
+        {
+          resolvedActions: [{ description: 'Use the new search field' }],
+        },
+      ],
+    }
+
+    await store.saveCandidate(candidate)
+    const approved = await store.findApproved({
+      scenarioId: 'scnbbbbbbbbbbbb',
+      scenarioRevision: 'rev-a',
+      executionTargetProfileId: 'web',
+      planFormatVersion: 'web.1',
+      applicationRevision: 'app-1',
+    })
+
+    expect(approved).toEqual(applicable)
+    expect(
+      JSON.parse(
+        await Bun.file(
+          join(root, '.pickle', 'candidates', 'web', 'scnbbbbbbbbbbbb.json'),
+        ).text(),
+      ),
+    ).toEqual(candidate)
+    expect(await Bun.file(approvedPath).text()).toBe(
+      `${JSON.stringify(applicable, null, 2)}\n`,
+    )
+  })
+})

--- a/packages/runner/src/execution-plan.test.ts
+++ b/packages/runner/src/execution-plan.test.ts
@@ -4,8 +4,8 @@ import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import {
   createFilePlanStore,
-  createMemoryPlanStore,
   type ExecutionPlan,
+  type ExecutionPlanStore,
   planApplies,
 } from '../index'
 
@@ -88,7 +88,12 @@ describe('execution plan store', () => {
   })
 
   test('returns only an approved plan that applies to the current query', async () => {
-    const store = createMemoryPlanStore([applicable])
+    const store: ExecutionPlanStore = {
+      async findApproved(query) {
+        return planApplies(applicable, query) ? applicable : undefined
+      },
+      async saveCandidate() {},
+    }
     const found = await store.findApproved({
       scenarioId: 'scnbbbbbbbbbbbb',
       scenarioRevision: 'rev-a',

--- a/packages/runner/src/execution-plan.ts
+++ b/packages/runner/src/execution-plan.ts
@@ -71,9 +71,9 @@ function isExecutionPlan(value: unknown): value is ExecutionPlan {
 export function createFilePlanStore(root: string): ExecutionPlanStore {
   return {
     async findApproved(query) {
-      const path = planPath(root, 'plans', query)
-      if (!(await Bun.file(path).exists())) return undefined
-      const parsed: unknown = JSON.parse(await Bun.file(path).text())
+      const file = Bun.file(planPath(root, 'plans', query))
+      if (!(await file.exists())) return undefined
+      const parsed: unknown = JSON.parse(await file.text())
       if (!isExecutionPlan(parsed) || !planApplies(parsed, query)) {
         return undefined
       }

--- a/packages/runner/src/execution-plan.ts
+++ b/packages/runner/src/execution-plan.ts
@@ -1,0 +1,100 @@
+import { mkdir } from 'node:fs/promises'
+import { dirname, join } from 'node:path'
+import type { ResolvedAction } from './run-scenario'
+
+export interface PlanApplicability {
+  scenarioId: string
+  scenarioRevision: string
+  executionTargetProfileId: string
+  planFormatVersion: string
+  applicationRevision?: string
+}
+
+export interface ExecutionPlanStep {
+  resolvedActions: ResolvedAction[]
+}
+
+export interface ExecutionPlan extends PlanApplicability {
+  schemaVersion: 1
+  steps: ExecutionPlanStep[]
+}
+
+export interface ExecutionPlanStore {
+  findApproved(query: PlanApplicability): Promise<ExecutionPlan | undefined>
+  saveCandidate(plan: ExecutionPlan): Promise<void>
+}
+
+export function planApplies(
+  plan: ExecutionPlan,
+  query: PlanApplicability,
+): boolean {
+  return (
+    plan.scenarioId === query.scenarioId &&
+    plan.scenarioRevision === query.scenarioRevision &&
+    plan.executionTargetProfileId === query.executionTargetProfileId &&
+    plan.planFormatVersion === query.planFormatVersion &&
+    plan.applicationRevision === query.applicationRevision
+  )
+}
+
+export function createMemoryPlanStore(
+  approved: readonly ExecutionPlan[] = [],
+): ExecutionPlanStore {
+  const plans = [...approved]
+  return {
+    async findApproved(query) {
+      return plans.find((plan) => planApplies(plan, query))
+    },
+    async saveCandidate() {},
+  }
+}
+
+function planFileName(value: string): string {
+  return value.replace(/[^A-Za-z0-9._-]+/g, '-') || 'plan'
+}
+
+function planPath(
+  root: string,
+  kind: 'plans' | 'candidates',
+  plan: Pick<PlanApplicability, 'executionTargetProfileId' | 'scenarioId'>,
+): string {
+  return join(
+    root,
+    '.pickle',
+    kind,
+    planFileName(plan.executionTargetProfileId),
+    `${planFileName(plan.scenarioId)}.json`,
+  )
+}
+
+function isExecutionPlan(value: unknown): value is ExecutionPlan {
+  if (typeof value !== 'object' || value === null) return false
+  const plan = value as ExecutionPlan
+  return (
+    plan.schemaVersion === 1 &&
+    typeof plan.scenarioId === 'string' &&
+    typeof plan.scenarioRevision === 'string' &&
+    typeof plan.executionTargetProfileId === 'string' &&
+    typeof plan.planFormatVersion === 'string' &&
+    Array.isArray(plan.steps)
+  )
+}
+
+export function createFilePlanStore(root: string): ExecutionPlanStore {
+  return {
+    async findApproved(query) {
+      const path = planPath(root, 'plans', query)
+      if (!(await Bun.file(path).exists())) return undefined
+      const parsed: unknown = JSON.parse(await Bun.file(path).text())
+      if (!isExecutionPlan(parsed) || !planApplies(parsed, query)) {
+        return undefined
+      }
+      return parsed
+    },
+    async saveCandidate(plan) {
+      const path = planPath(root, 'candidates', plan)
+      await mkdir(dirname(path), { recursive: true })
+      await Bun.write(path, `${JSON.stringify(plan, null, 2)}\n`)
+    },
+  }
+}

--- a/packages/runner/src/execution-plan.ts
+++ b/packages/runner/src/execution-plan.ts
@@ -37,18 +37,6 @@ export function planApplies(
   )
 }
 
-export function createMemoryPlanStore(
-  approved: readonly ExecutionPlan[] = [],
-): ExecutionPlanStore {
-  const plans = [...approved]
-  return {
-    async findApproved(query) {
-      return plans.find((plan) => planApplies(plan, query))
-    },
-    async saveCandidate() {},
-  }
-}
-
 function planFileName(value: string): string {
   return value.replace(/[^A-Za-z0-9._-]+/g, '-') || 'plan'
 }

--- a/packages/runner/src/run-scenario.test.ts
+++ b/packages/runner/src/run-scenario.test.ts
@@ -594,37 +594,31 @@ describe('runScenario', () => {
   })
 
   test('refuses Replay in CI when the application revision is missing', async () => {
-    const previous = process.env.CI
-    process.env.CI = 'true'
     const openSession = mock(async () => {
       throw new Error('must not open a logical session')
     })
-    try {
-      await expect(
-        runScenario({
-          specification,
-          scenario: { ...scenario, id: 'purchase' },
-          executionTargetProfile: { id: 'web' },
-          adapter: { planFormatVersion: 'web.1', openSession },
-          plans: {
-            async findApproved() {
-              return {
-                schemaVersion: 1,
-                scenarioId: 'purchase',
-                scenarioRevision: scenarioRevision(scenario),
-                executionTargetProfileId: 'web',
-                planFormatVersion: 'web.1',
-                steps: [{ resolvedActions: [] }],
-              }
-            },
-            async saveCandidate() {},
+    await expect(
+      runScenario({
+        specification,
+        scenario: { ...scenario, id: 'purchase' },
+        executionTargetProfile: { id: 'web' },
+        adapter: { planFormatVersion: 'web.1', openSession },
+        ci: true,
+        plans: {
+          async findApproved() {
+            return {
+              schemaVersion: 1,
+              scenarioId: 'purchase',
+              scenarioRevision: scenarioRevision(scenario),
+              executionTargetProfileId: 'web',
+              planFormatVersion: 'web.1',
+              steps: [{ resolvedActions: [] }],
+            }
           },
-        }),
-      ).rejects.toThrow('CI Replay requires applicationRevision')
-    } finally {
-      if (previous === undefined) delete process.env.CI
-      else process.env.CI = previous
-    }
+          async saveCandidate() {},
+        },
+      }),
+    ).rejects.toThrow('CI Replay requires applicationRevision')
     expect(openSession).not.toHaveBeenCalled()
   })
 })

--- a/packages/runner/src/run-scenario.test.ts
+++ b/packages/runner/src/run-scenario.test.ts
@@ -1,6 +1,16 @@
 import { describe, expect, mock, test } from 'bun:test'
-import type { Scenario, Specification } from '@pickle-spec/spec'
-import { type ExecutionTargetAdapter, runScenario } from '../index'
+import {
+  type Scenario,
+  type Specification,
+  scenarioRevision,
+} from '@pickle-spec/spec'
+import {
+  type ExecutionPlan,
+  type ExecutionPlanStore,
+  type ExecutionTargetAdapter,
+  type OpenSessionInput,
+  runScenario,
+} from '../index'
 
 const scenario: Scenario = {
   name: 'Complete a purchase',
@@ -65,6 +75,7 @@ describe('runScenario', () => {
       scenario: { name: 'Complete a purchase' },
       executionTargetProfile: { id: 'deterministic' },
       state: 'passed',
+      executionMode: 'adaptive',
       steps: [
         {
           step: {
@@ -378,5 +389,242 @@ describe('runScenario', () => {
       message: 'Step exceeded its 5ms deadline',
     })
     expect(close).toHaveBeenCalledTimes(1)
+  })
+
+  test('runs in Adaptive mode and writes a candidate when no approved plan applies', async () => {
+    const candidates: ExecutionPlan[] = []
+    const openSession = mock(async () => ({
+      async executeStep(step: Scenario['steps'][number]) {
+        return {
+          state: 'passed' as const,
+          resolvedActions: [{ description: `Resolved: ${step.text}` }],
+        }
+      },
+      async close() {},
+    }))
+    const plans: ExecutionPlanStore = {
+      async findApproved() {
+        return undefined
+      },
+      async saveCandidate(plan) {
+        candidates.push(plan)
+      },
+    }
+
+    const run = await runScenario({
+      specification,
+      scenario,
+      executionTargetProfile: { id: 'web' },
+      adapter: { planFormatVersion: 'web.1', openSession },
+      plans,
+      applicationRevision: 'app-1',
+    })
+
+    expect(run.result.state).toBe('passed')
+    expect(run.result.executionMode).toBe('adaptive')
+    expect(openSession).toHaveBeenCalledWith(
+      expect.objectContaining({ mode: 'adaptive' }),
+    )
+    expect(candidates).toEqual([
+      {
+        schemaVersion: 1,
+        scenarioId: expect.any(String),
+        scenarioRevision: scenarioRevision(scenario),
+        executionTargetProfileId: 'web',
+        planFormatVersion: 'web.1',
+        applicationRevision: 'app-1',
+        steps: [
+          {
+            resolvedActions: [
+              { description: 'Resolved: a product is in the basket' },
+            ],
+          },
+          {
+            resolvedActions: [
+              { description: 'Resolved: the purchase succeeds' },
+            ],
+          },
+        ],
+      },
+    ])
+  })
+
+  test('runs an applicable approved plan in Replay mode without writing a candidate', async () => {
+    const approved: ExecutionPlan = {
+      schemaVersion: 1,
+      scenarioId: 'purchase',
+      scenarioRevision: scenarioRevision(scenario),
+      executionTargetProfileId: 'web',
+      planFormatVersion: 'web.1',
+      applicationRevision: 'app-1',
+      steps: [
+        {
+          resolvedActions: [
+            { description: 'Open the basket', replay: { selector: '#basket' } },
+            { description: 'Confirm the item', replay: { selector: '#ok' } },
+          ],
+        },
+        {
+          resolvedActions: [{ description: 'See the receipt' }],
+        },
+      ],
+    }
+    const candidates: ExecutionPlan[] = []
+    const openSession = mock(async (input: OpenSessionInput) => ({
+      async executeStep() {
+        return {
+          state: 'passed' as const,
+          resolvedActions: input.plan?.steps[0]?.resolvedActions ?? [],
+        }
+      },
+      async close() {},
+    }))
+
+    const run = await runScenario({
+      specification,
+      scenario: { ...scenario, id: 'purchase' },
+      executionTargetProfile: { id: 'web' },
+      adapter: { planFormatVersion: 'web.1', openSession },
+      applicationRevision: 'app-1',
+      plans: {
+        async findApproved() {
+          return approved
+        },
+        async saveCandidate(plan) {
+          candidates.push(plan)
+        },
+      },
+    })
+
+    expect(run.result.state).toBe('passed')
+    expect(run.result.executionMode).toBe('replay')
+    expect(run.result.steps[0]?.resolvedActions).toEqual([
+      { description: 'Open the basket', replay: { selector: '#basket' } },
+      { description: 'Confirm the item', replay: { selector: '#ok' } },
+    ])
+    expect(openSession).toHaveBeenCalledWith(
+      expect.objectContaining({ mode: 'replay', plan: approved }),
+    )
+    expect(candidates).toEqual([])
+  })
+
+  test('treats a stale or cross-profile plan as Adaptive', async () => {
+    const openSession = mock(async () => ({
+      async executeStep() {
+        return { state: 'passed' as const, resolvedActions: [] }
+      },
+      async close() {},
+    }))
+    const stale: ExecutionPlan = {
+      schemaVersion: 1,
+      scenarioId: 'purchase',
+      scenarioRevision: 'old-revision',
+      executionTargetProfileId: 'web',
+      planFormatVersion: 'web.1',
+      applicationRevision: 'app-1',
+      steps: [{ resolvedActions: [] }],
+    }
+
+    await runScenario({
+      specification,
+      scenario: { ...scenario, id: 'purchase' },
+      executionTargetProfile: { id: 'android' },
+      adapter: { planFormatVersion: 'web.1', openSession },
+      applicationRevision: 'app-1',
+      plans: {
+        async findApproved() {
+          return stale
+        },
+        async saveCandidate() {},
+      },
+    })
+
+    expect(openSession).toHaveBeenCalledWith(
+      expect.objectContaining({ mode: 'adaptive' }),
+    )
+  })
+
+  test('records passed-with-adaptation and a candidate without changing the approved plan', async () => {
+    const approved: ExecutionPlan = {
+      schemaVersion: 1,
+      scenarioId: 'purchase',
+      scenarioRevision: scenarioRevision(scenario),
+      executionTargetProfileId: 'web',
+      planFormatVersion: 'web.1',
+      applicationRevision: 'app-1',
+      steps: [{ resolvedActions: [{ description: 'Old action' }] }],
+    }
+    const approvedCopy = structuredClone(approved)
+    const candidates: ExecutionPlan[] = []
+    const run = await runScenario({
+      specification,
+      scenario: { ...scenario, id: 'purchase' },
+      executionTargetProfile: { id: 'web' },
+      adapter: {
+        planFormatVersion: 'web.1',
+        async openSession() {
+          return {
+            async executeStep() {
+              return {
+                state: 'passed-with-adaptation' as const,
+                resolvedActions: [{ description: 'Adapted action' }],
+              }
+            },
+            async close() {},
+          }
+        },
+      },
+      applicationRevision: 'app-1',
+      plans: {
+        async findApproved() {
+          return approved
+        },
+        async saveCandidate(plan) {
+          candidates.push(plan)
+        },
+      },
+    })
+
+    expect(run.result.state).toBe('passed-with-adaptation')
+    expect(run.result.executionMode).toBe('replay')
+    expect(candidates[0]?.steps[0]?.resolvedActions).toEqual([
+      { description: 'Adapted action' },
+    ])
+    expect(approved).toEqual(approvedCopy)
+  })
+
+  test('refuses Replay in CI when the application revision is missing', async () => {
+    const previous = process.env.CI
+    process.env.CI = 'true'
+    const openSession = mock(async () => {
+      throw new Error('must not open a logical session')
+    })
+    try {
+      await expect(
+        runScenario({
+          specification,
+          scenario: { ...scenario, id: 'purchase' },
+          executionTargetProfile: { id: 'web' },
+          adapter: { planFormatVersion: 'web.1', openSession },
+          plans: {
+            async findApproved() {
+              return {
+                schemaVersion: 1,
+                scenarioId: 'purchase',
+                scenarioRevision: scenarioRevision(scenario),
+                executionTargetProfileId: 'web',
+                planFormatVersion: 'web.1',
+                steps: [{ resolvedActions: [] }],
+              }
+            },
+            async saveCandidate() {},
+          },
+        }),
+      ).rejects.toThrow('CI Replay requires applicationRevision')
+    } finally {
+      if (previous === undefined) delete process.env.CI
+      else process.env.CI = previous
+    }
+    expect(openSession).not.toHaveBeenCalled()
   })
 })

--- a/packages/runner/src/run-scenario.ts
+++ b/packages/runner/src/run-scenario.ts
@@ -155,14 +155,12 @@ function isCancellation(error: unknown, signal?: AbortSignal): boolean {
 }
 
 function executeWithDeadline<T>(
-  operation: (signal: AbortSignal) => Promise<T>,
+  operation: (signal?: AbortSignal) => Promise<T>,
   signal: AbortSignal | undefined,
   timeoutMs: number | undefined,
   timeoutMessage: string,
 ): Promise<T> {
-  if (timeoutMs === undefined) {
-    return operation(signal ?? new AbortController().signal)
-  }
+  if (timeoutMs === undefined) return operation(signal)
 
   const controller = new AbortController()
   const onAbort = () => controller.abort()
@@ -180,6 +178,27 @@ function executeWithDeadline<T>(
         signal?.removeEventListener('abort', onAbort)
       })
   })
+}
+
+function stepDeadline(
+  timeout: ExecutionTimeouts | undefined,
+  scenarioStartedAt: number,
+): { timeoutMs: number | undefined; timeoutMessage: string } {
+  const scenarioRemaining =
+    timeout?.scenarioMs === undefined
+      ? undefined
+      : timeout.scenarioMs - (Date.now() - scenarioStartedAt)
+  const usesScenarioDeadline =
+    scenarioRemaining !== undefined &&
+    (timeout?.stepMs === undefined || scenarioRemaining <= timeout.stepMs)
+  return {
+    timeoutMs: usesScenarioDeadline
+      ? Math.max(0, scenarioRemaining)
+      : timeout?.stepMs,
+    timeoutMessage: usesScenarioDeadline
+      ? `Scenario exceeded its ${timeout?.scenarioMs}ms deadline`
+      : `Step exceeded its ${timeout?.stepMs}ms deadline`,
+  }
 }
 
 interface ScenarioAttemptInput extends RunScenarioInput {
@@ -247,6 +266,16 @@ function shouldSaveCandidate(
   )
 }
 
+function withAttemptMetadata(result: TestResult, attempt: number): TestResult {
+  if (attempt === 1) return result
+  return {
+    ...result,
+    attempts: attempt,
+    flaky:
+      result.state === 'passed' || result.state === 'passed-with-adaptation',
+  }
+}
+
 function createTestResult(
   input: ScenarioAttemptInput,
   state: TestResultState,
@@ -284,31 +313,31 @@ async function runScenarioAttempt(
     await input.onEvent?.(versionedEvent)
   }
 
+  const finish = async (
+    state: TestResultState,
+    steps: TestStepResult[],
+    message?: string,
+  ): Promise<ScenarioRun> => {
+    const result = createTestResult(input, state, steps, message)
+    await emit({ type: 'scenario-finished', result })
+    return { events, result }
+  }
+
   await emit({
     type: 'scenario-started',
     scenario: { name: input.scenario.name },
   })
 
   if (input.scenario.tags.includes('@ignore')) {
-    const result = createTestResult(
-      input,
-      'skipped',
-      [],
-      'Scenario is tagged @ignore',
-    )
-    await emit({ type: 'scenario-finished', result })
-    return { events, result }
+    return finish('skipped', [], 'Scenario is tagged @ignore')
   }
 
   if (input.signal?.aborted) {
-    const result = createTestResult(
-      input,
+    return finish(
       'cancelled',
       [],
       'Scenario cancelled before the logical session started',
     )
-    await emit({ type: 'scenario-finished', result })
-    return { events, result }
   }
 
   let session: TargetSession
@@ -322,18 +351,20 @@ async function runScenarioAttempt(
       signal: input.signal,
     })
   } catch (error) {
-    const result = createTestResult(
-      input,
+    return finish(
       isCancellation(error, input.signal)
         ? 'cancelled'
         : 'infrastructure-error',
       [],
       errorMessage(error),
     )
-    await emit({ type: 'scenario-finished', result })
-    return { events, result }
   }
+
   const steps: TestStepResult[] = []
+  const recordStep = async (result: TestStepResult): Promise<void> => {
+    steps.push(result)
+    await emit({ type: 'step-finished', result })
+  }
   let state: TestResultState = input.signal?.aborted ? 'cancelled' : 'passed'
   let message: string | undefined = input.signal?.aborted
     ? 'Scenario cancelled before step execution started'
@@ -350,57 +381,40 @@ async function runScenarioAttempt(
       await emit({ type: 'step-started', step })
       let execution: StepExecution
       try {
-        const scenarioRemaining =
-          input.timeout?.scenarioMs === undefined
-            ? undefined
-            : input.timeout.scenarioMs - (Date.now() - scenarioStartedAt)
-        const usesScenarioDeadline =
-          scenarioRemaining !== undefined &&
-          (input.timeout?.stepMs === undefined ||
-            scenarioRemaining <= input.timeout.stepMs)
-        const timeoutMs = usesScenarioDeadline
-          ? Math.max(0, scenarioRemaining)
-          : input.timeout?.stepMs
-        const timeoutMessage = usesScenarioDeadline
-          ? `Scenario exceeded its ${input.timeout?.scenarioMs}ms deadline`
-          : `Step exceeded its ${input.timeout?.stepMs}ms deadline`
+        const deadline = stepDeadline(input.timeout, scenarioStartedAt)
         execution = await executeWithDeadline(
           (operationSignal) => session.executeStep(step, operationSignal),
           input.signal,
-          timeoutMs,
-          timeoutMessage,
+          deadline.timeoutMs,
+          deadline.timeoutMessage,
         )
       } catch (error) {
         state = isCancellation(error, input.signal)
           ? 'cancelled'
           : 'infrastructure-error'
         message = errorMessage(error)
-        const result: TestStepResult = {
+        await recordStep({
           step,
           state,
           resolvedActions: [],
           message,
-        }
-        steps.push(result)
-        await emit({ type: 'step-finished', result })
+        })
         break
       }
 
       if (input.signal?.aborted) {
         state = 'cancelled'
         message = 'Scenario cancelled during step execution'
-        const result: TestStepResult = {
+        await recordStep({
           step,
           state,
           resolvedActions: execution.resolvedActions,
           message,
-        }
-        steps.push(result)
-        await emit({ type: 'step-finished', result })
+        })
         break
       }
 
-      const result: TestStepResult = {
+      await recordStep({
         step,
         state: execution.state,
         resolvedActions: execution.resolvedActions,
@@ -408,9 +422,7 @@ async function runScenarioAttempt(
         ...(execution.artifacts?.length
           ? { artifacts: execution.artifacts }
           : {}),
-      }
-      steps.push(result)
-      await emit({ type: 'step-finished', result })
+      })
 
       if (execution.state === 'passed-with-adaptation') {
         state = 'passed-with-adaptation'
@@ -432,11 +444,7 @@ async function runScenarioAttempt(
     }
   }
 
-  const result = createTestResult(input, state, steps, message)
-
-  await emit({ type: 'scenario-finished', result })
-
-  return { events, result }
+  return finish(state, steps, message)
 }
 
 export async function runScenario(
@@ -451,24 +459,16 @@ export async function runScenario(
       ...input,
       mode: selected.mode,
       ...(selected.plan ? { plan: selected.plan } : {}),
+      // Collect attempt events locally so retries can be resequenced.
       onEvent: undefined,
+      // Attempts own one logical session; retries are orchestrated here.
       retry: undefined,
     })
     const shouldRetry =
       run.result.state === 'infrastructure-error' &&
       attempt < maximumAttempts &&
       !input.signal?.aborted
-
-    const result: TestResult =
-      attempt === 1
-        ? run.result
-        : {
-            ...run.result,
-            attempts: attempt,
-            flaky:
-              run.result.state === 'passed' ||
-              run.result.state === 'passed-with-adaptation',
-          }
+    const result = withAttemptMetadata(run.result, attempt)
 
     for (const event of run.events) {
       const versionedEvent = {

--- a/packages/runner/src/run-scenario.ts
+++ b/packages/runner/src/run-scenario.ts
@@ -1,4 +1,16 @@
-import type { Scenario, ScenarioStep, Specification } from '@pickle-spec/spec'
+import {
+  resolveScenarioId,
+  type Scenario,
+  type ScenarioStep,
+  type Specification,
+  scenarioRevision,
+} from '@pickle-spec/spec'
+import {
+  type ExecutionPlan,
+  type ExecutionPlanStore,
+  type PlanApplicability,
+  planApplies,
+} from './execution-plan'
 
 export type TestResultState =
   | 'passed'
@@ -8,6 +20,8 @@ export type TestResultState =
   | 'cancelled'
   | 'infrastructure-error'
 
+export type ExecutionMode = 'adaptive' | 'replay'
+
 export interface ExecutionTargetProfile {
   id: string
   adapter?: string
@@ -16,6 +30,7 @@ export interface ExecutionTargetProfile {
 
 export interface ResolvedAction {
   description: string
+  replay?: Record<string, unknown>
 }
 
 export interface TestArtifact {
@@ -40,11 +55,14 @@ export interface OpenSessionInput {
   executionTargetProfile: ExecutionTargetProfile
   specification: Specification
   scenario: Scenario
+  mode?: ExecutionMode
+  plan?: ExecutionPlan
   signal?: AbortSignal
 }
 
 export interface ExecutionTargetAdapter {
   capabilities?: readonly string[]
+  planFormatVersion?: string
   openSession(input: OpenSessionInput): Promise<TargetSession>
 }
 
@@ -68,6 +86,7 @@ export interface TestResult {
   executionTargetProfile: ExecutionTargetProfile
   state: TestResultState
   steps: TestStepResult[]
+  executionMode?: ExecutionMode
   message?: string
   attempts?: number
   flaky?: boolean
@@ -110,6 +129,8 @@ export interface RunScenarioInput extends ExecutionPolicy {
   scenario: Scenario
   executionTargetProfile: ExecutionTargetProfile
   adapter: ExecutionTargetAdapter
+  plans?: ExecutionPlanStore
+  applicationRevision?: string
   signal?: AbortSignal
   onEvent?: (event: RunEvent) => void | Promise<void>
 }
@@ -160,8 +181,73 @@ function executeWithDeadline<T>(
   })
 }
 
+interface ScenarioAttemptInput extends RunScenarioInput {
+  mode: ExecutionMode
+  plan?: ExecutionPlan
+}
+
+function planQuery(input: RunScenarioInput): PlanApplicability {
+  return {
+    scenarioId:
+      input.scenario.id ??
+      resolveScenarioId(
+        input.specification.source.uri,
+        input.specification.name,
+        input.scenario.name,
+        input.scenario.tags,
+      ),
+    scenarioRevision: scenarioRevision(input.scenario),
+    executionTargetProfileId: input.executionTargetProfile.id,
+    planFormatVersion: input.adapter.planFormatVersion ?? '1',
+    ...(input.applicationRevision !== undefined
+      ? { applicationRevision: input.applicationRevision }
+      : {}),
+  }
+}
+
+async function selectPlan(input: RunScenarioInput): Promise<{
+  mode: ExecutionMode
+  plan?: ExecutionPlan
+  query: PlanApplicability
+}> {
+  const query = planQuery(input)
+  const found = await input.plans?.findApproved(query)
+  const plan = found && planApplies(found, query) ? found : undefined
+  if (plan && input.applicationRevision === undefined && process.env.CI) {
+    throw new Error(
+      'CI Replay requires applicationRevision. Set applicationRevision or --application-revision.',
+    )
+  }
+  return {
+    mode: plan ? 'replay' : 'adaptive',
+    ...(plan ? { plan } : {}),
+    query,
+  }
+}
+
+function candidatePlan(
+  query: PlanApplicability,
+  steps: TestStepResult[],
+): ExecutionPlan {
+  return {
+    schemaVersion: 1,
+    ...query,
+    steps: steps.map((step) => ({ resolvedActions: step.resolvedActions })),
+  }
+}
+
+function shouldSaveCandidate(
+  state: TestResultState,
+  mode: ExecutionMode,
+): boolean {
+  return (
+    state === 'passed-with-adaptation' ||
+    (state === 'passed' && mode === 'adaptive')
+  )
+}
+
 function createTestResult(
-  input: RunScenarioInput,
+  input: ScenarioAttemptInput,
   state: TestResultState,
   steps: TestStepResult[],
   message?: string,
@@ -176,12 +262,13 @@ function createTestResult(
     executionTargetProfile: input.executionTargetProfile,
     state,
     steps,
+    executionMode: input.mode,
     ...(message !== undefined ? { message } : {}),
   }
 }
 
 async function runScenarioAttempt(
-  input: RunScenarioInput,
+  input: ScenarioAttemptInput,
 ): Promise<ScenarioRun> {
   const scenarioStartedAt = Date.now()
   const events: RunEvent[] = []
@@ -229,6 +316,8 @@ async function runScenarioAttempt(
       executionTargetProfile: input.executionTargetProfile,
       specification: input.specification,
       scenario: input.scenario,
+      mode: input.mode,
+      ...(input.plan ? { plan: input.plan } : {}),
       signal: input.signal,
     })
   } catch (error) {
@@ -354,10 +443,13 @@ export async function runScenario(
 ): Promise<ScenarioRun> {
   const events: RunEvent[] = []
   const maximumAttempts = (input.retry?.infrastructureErrors ?? 0) + 1
+  const selected = await selectPlan(input)
 
   for (let attempt = 1; attempt <= maximumAttempts; attempt++) {
     const run = await runScenarioAttempt({
       ...input,
+      mode: selected.mode,
+      ...(selected.plan ? { plan: selected.plan } : {}),
       onEvent: undefined,
       retry: undefined,
     })
@@ -389,7 +481,13 @@ export async function runScenario(
       await input.onEvent?.(versionedEvent)
     }
 
-    if (!shouldRetry) return { events, result }
+    if (shouldRetry) continue
+    if (input.plans && shouldSaveCandidate(result.state, selected.mode)) {
+      await input.plans.saveCandidate(
+        candidatePlan(selected.query, result.steps),
+      )
+    }
+    return { events, result }
   }
 
   throw new Error('Runner exhausted attempts without producing a test result')

--- a/packages/runner/src/run-scenario.ts
+++ b/packages/runner/src/run-scenario.ts
@@ -131,6 +131,7 @@ export interface RunScenarioInput extends ExecutionPolicy {
   adapter: ExecutionTargetAdapter
   plans?: ExecutionPlanStore
   applicationRevision?: string
+  ci?: boolean
   signal?: AbortSignal
   onEvent?: (event: RunEvent) => void | Promise<void>
 }
@@ -213,7 +214,7 @@ async function selectPlan(input: RunScenarioInput): Promise<{
   const query = planQuery(input)
   const found = await input.plans?.findApproved(query)
   const plan = found && planApplies(found, query) ? found : undefined
-  if (plan && input.applicationRevision === undefined && process.env.CI) {
+  if (plan && input.applicationRevision === undefined && input.ci) {
     throw new Error(
       'CI Replay requires applicationRevision. Set applicationRevision or --application-revision.',
     )

--- a/packages/runner/src/run-scenarios.ts
+++ b/packages/runner/src/run-scenarios.ts
@@ -74,9 +74,7 @@ function resolveTargets(input: RunScenariosInput): readonly RunTarget[] {
       },
     ]
   }
-  throw new Error(
-    'A test run must select at least one execution target profile',
-  )
+  return []
 }
 
 export async function runScenarios(
@@ -113,7 +111,7 @@ export async function runScenarios(
         retry: input.retry,
         timeout: input.timeout,
         onEvent: input.onEvent
-          ? (event) => input.onEvent!(event, selection)
+          ? (event) => input.onEvent?.(event, selection)
           : undefined,
       })
     }

--- a/packages/runner/src/run-scenarios.ts
+++ b/packages/runner/src/run-scenarios.ts
@@ -21,6 +21,7 @@ export interface RunScenariosInput extends ExecutionPolicy {
   adapter?: ExecutionTargetAdapter
   plans?: ExecutionPlanStore
   applicationRevision?: string
+  ci?: boolean
   concurrency?: number
   signal?: AbortSignal
   onEvent?: (
@@ -107,6 +108,7 @@ export async function runScenarios(
         adapter: target.adapter,
         plans: input.plans,
         applicationRevision: input.applicationRevision,
+        ci: input.ci,
         signal: input.signal,
         retry: input.retry,
         timeout: input.timeout,

--- a/packages/runner/src/run-scenarios.ts
+++ b/packages/runner/src/run-scenarios.ts
@@ -1,4 +1,5 @@
 import type { ScenarioSelection } from '@pickle-spec/spec'
+import type { ExecutionPlanStore } from './execution-plan'
 import {
   type ExecutionPolicy,
   type ExecutionTargetAdapter,
@@ -18,6 +19,8 @@ export interface RunScenariosInput extends ExecutionPolicy {
   targets?: readonly RunTarget[]
   executionTargetProfile?: ExecutionTargetProfile
   adapter?: ExecutionTargetAdapter
+  plans?: ExecutionPlanStore
+  applicationRevision?: string
   concurrency?: number
   signal?: AbortSignal
   onEvent?: (
@@ -102,6 +105,8 @@ export async function runScenarios(
         scenario: selection.scenario,
         executionTargetProfile: target.executionTargetProfile,
         adapter: target.adapter,
+        plans: input.plans,
+        applicationRevision: input.applicationRevision,
         signal: input.signal,
         retry: input.retry,
         timeout: input.timeout,

--- a/packages/spec/index.ts
+++ b/packages/spec/index.ts
@@ -8,8 +8,10 @@ export type {
 export {
   formatMigrationPreview,
   planSpecificationMigration,
+  resolveScenarioId,
   validateSpecificationMetadata,
 } from './src/identity'
+export { scenarioRevision } from './src/revision'
 export type {
   ScenarioSelection,
   SelectionOptions,

--- a/packages/spec/src/revision.test.ts
+++ b/packages/spec/src/revision.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, test } from 'bun:test'
+import { parseSpecification, scenarioRevision } from '../index'
+
+const checkout = parseSpecification({
+  uri: 'features/checkout.feature',
+  source: `@pickle:id:specaaaaaaaaaaaa @pickle:state:active
+Feature: Checkout
+  @pickle:id:scnbbbbbbbbbbbb
+  Scenario: Complete a purchase
+    Given a product is in the basket
+    Then the purchase succeeds`,
+})
+
+describe('scenarioRevision', () => {
+  test('stays stable when the Scenario name or identifier changes', () => {
+    const renamed = parseSpecification({
+      uri: 'features/checkout.feature',
+      source: `@pickle:id:specaaaaaaaaaaaa @pickle:state:active
+Feature: Checkout
+  @pickle:id:scncccccccccccccccc
+  Scenario: Finish buying
+    Given a product is in the basket
+    Then the purchase succeeds`,
+    })
+
+    expect(scenarioRevision(checkout.scenarios[0]!)).toBe(
+      scenarioRevision(renamed.scenarios[0]!),
+    )
+  })
+
+  test('changes when step text or step arguments change', () => {
+    const editedText = parseSpecification({
+      uri: 'features/checkout.feature',
+      source: `@pickle:id:specaaaaaaaaaaaa @pickle:state:active
+Feature: Checkout
+  @pickle:id:scnbbbbbbbbbbbb
+  Scenario: Complete a purchase
+    Given two products are in the basket
+    Then the purchase succeeds`,
+    })
+    const withArgument = parseSpecification({
+      uri: 'features/checkout.feature',
+      source: `@pickle:id:specaaaaaaaaaaaa @pickle:state:active
+Feature: Checkout
+  @pickle:id:scnbbbbbbbbbbbb
+  Scenario: Complete a purchase
+    Given a product is in the basket
+      | sku |
+      | A1  |
+    Then the purchase succeeds`,
+    })
+
+    const original = scenarioRevision(checkout.scenarios[0]!)
+    expect(scenarioRevision(editedText.scenarios[0]!)).not.toBe(original)
+    expect(scenarioRevision(withArgument.scenarios[0]!)).not.toBe(original)
+    expect(scenarioRevision(editedText.scenarios[0]!)).not.toBe(
+      scenarioRevision(withArgument.scenarios[0]!),
+    )
+  })
+})

--- a/packages/spec/src/revision.ts
+++ b/packages/spec/src/revision.ts
@@ -1,0 +1,17 @@
+import type { Scenario, ScenarioStep } from './specification'
+
+function stepDigest(step: ScenarioStep): string {
+  return JSON.stringify([
+    step.keyword,
+    step.text,
+    step.type,
+    step.argument?.dataTable ?? null,
+    step.argument?.docString ?? null,
+  ])
+}
+
+export function scenarioRevision(scenario: Pick<Scenario, 'steps'>): string {
+  const hasher = new Bun.CryptoHasher('sha256')
+  hasher.update(scenario.steps.map(stepDigest).join('\0'))
+  return hasher.digest('hex')
+}

--- a/packages/web/src/web-adapter.test.ts
+++ b/packages/web/src/web-adapter.test.ts
@@ -271,4 +271,229 @@ describe('createWebAdapter', () => {
       }
     }
   })
+
+  test('replays multiple planned actions without model action resolution', async () => {
+    const observe = mock(async () => [
+      { description: 'Must not resolve', handle: { selector: '#new' } },
+    ])
+    const act = mock(async () => ({ success: true }))
+    const automation: WebAutomation = {
+      async navigate() {},
+      observe,
+      act,
+      async verify() {
+        return { meetsExpectation: true, actualState: 'Ready' }
+      },
+      async screenshot() {
+        return new Uint8Array()
+      },
+      async close() {},
+    }
+    const adapter = createWebAdapter(
+      { baseUrl: 'https://example.test' },
+      {
+        async open() {
+          return automation
+        },
+      },
+    )
+    const session = await adapter.openSession({
+      executionTargetProfile: { id: 'web' },
+      specification,
+      scenario,
+      mode: 'replay',
+      plan: {
+        schemaVersion: 1,
+        scenarioId: 'search',
+        scenarioRevision: 'rev',
+        executionTargetProfileId: 'web',
+        planFormatVersion: 'web.1',
+        steps: [
+          {
+            resolvedActions: [
+              { description: 'Navigate to https://example.test/search' },
+            ],
+          },
+          {
+            resolvedActions: [
+              {
+                description: 'Fill the search field',
+                replay: { selector: '#search' },
+              },
+              {
+                description: 'Submit the search',
+                replay: { selector: '#go' },
+              },
+            ],
+          },
+          {
+            resolvedActions: [
+              { description: 'Verify: pickle results are visible' },
+            ],
+          },
+        ],
+      },
+    })
+
+    await session.executeStep(scenario.steps[0]!)
+    const action = await session.executeStep(scenario.steps[1]!)
+    await session.close()
+
+    expect(action).toMatchObject({
+      state: 'passed',
+      resolvedActions: [
+        {
+          description: 'Fill the search field',
+          replay: { selector: '#search' },
+        },
+        { description: 'Submit the search', replay: { selector: '#go' } },
+      ],
+    })
+    expect(observe).not.toHaveBeenCalled()
+    expect(act).toHaveBeenCalledTimes(2)
+    expect(act).toHaveBeenNthCalledWith(
+      1,
+      { description: 'Fill the search field', handle: { selector: '#search' } },
+      undefined,
+    )
+    expect(act).toHaveBeenNthCalledWith(
+      2,
+      { description: 'Submit the search', handle: { selector: '#go' } },
+      undefined,
+    )
+  })
+
+  test('adapts a failed Replay step without changing the approved plan payload', async () => {
+    const observe = mock(async () => [
+      { description: 'Use the new search field', handle: { selector: '#q' } },
+    ])
+    const act = mock(async (action: { description: string }) => ({
+      success: action.description !== 'Fill the search field',
+      message:
+        action.description === 'Fill the search field'
+          ? 'Selector is stale'
+          : undefined,
+    }))
+    const adapter = createWebAdapter(
+      { baseUrl: 'https://example.test' },
+      {
+        async open() {
+          return {
+            async navigate() {},
+            observe,
+            act,
+            async verify() {
+              return { meetsExpectation: true, actualState: 'Ready' }
+            },
+            async screenshot() {
+              return new Uint8Array()
+            },
+            async close() {},
+          }
+        },
+      },
+    )
+    const plan = {
+      schemaVersion: 1 as const,
+      scenarioId: 'search',
+      scenarioRevision: 'rev',
+      executionTargetProfileId: 'web',
+      planFormatVersion: 'web.1',
+      steps: [
+        {
+          resolvedActions: [
+            { description: 'Navigate to https://example.test/search' },
+          ],
+        },
+        {
+          resolvedActions: [
+            {
+              description: 'Fill the search field',
+              replay: { selector: '#search' },
+            },
+          ],
+        },
+      ],
+    }
+    const session = await adapter.openSession({
+      executionTargetProfile: { id: 'web' },
+      specification,
+      scenario,
+      mode: 'replay',
+      plan,
+    })
+
+    await session.executeStep(scenario.steps[0]!)
+    const action = await session.executeStep(scenario.steps[1]!)
+    await session.close()
+
+    expect(action).toMatchObject({
+      state: 'passed-with-adaptation',
+      resolvedActions: [
+        {
+          description: 'Use the new search field',
+          replay: { selector: '#q' },
+        },
+      ],
+    })
+    expect(observe).toHaveBeenCalledTimes(1)
+    expect(plan.steps[1]?.resolvedActions).toEqual([
+      { description: 'Fill the search field', replay: { selector: '#search' } },
+    ])
+  })
+
+  test('records an adaptation when Replay has no planned actions for a step', async () => {
+    const observe = mock(async () => [
+      { description: 'Fill the search field', handle: { selector: '#search' } },
+    ])
+    const act = mock(async () => ({ success: true }))
+    const adapter = createWebAdapter(
+      { baseUrl: 'https://example.test' },
+      {
+        async open() {
+          return {
+            async navigate() {},
+            observe,
+            act,
+            async verify() {
+              return { meetsExpectation: true, actualState: 'Ready' }
+            },
+            async screenshot() {
+              return new Uint8Array()
+            },
+            async close() {},
+          }
+        },
+      },
+    )
+    const session = await adapter.openSession({
+      executionTargetProfile: { id: 'web' },
+      specification,
+      scenario,
+      mode: 'replay',
+      plan: {
+        schemaVersion: 1,
+        scenarioId: 'search',
+        scenarioRevision: 'rev',
+        executionTargetProfileId: 'web',
+        planFormatVersion: 'web.1',
+        steps: [
+          {
+            resolvedActions: [
+              { description: 'Navigate to https://example.test/search' },
+            ],
+          },
+          { resolvedActions: [] },
+        ],
+      },
+    })
+
+    await session.executeStep(scenario.steps[0]!)
+    const action = await session.executeStep(scenario.steps[1]!)
+    await session.close()
+
+    expect(action.state).toBe('passed-with-adaptation')
+    expect(observe).toHaveBeenCalledTimes(1)
+    expect(act).toHaveBeenCalledTimes(1)
+  })
 })

--- a/packages/web/src/web-adapter.ts
+++ b/packages/web/src/web-adapter.ts
@@ -9,6 +9,7 @@ import {
 } from '@browserbasehq/stagehand'
 import type {
   ExecutionTargetAdapter,
+  ResolvedAction,
   StepExecution,
   TestArtifact,
 } from '@pickle-spec/runner'
@@ -401,6 +402,22 @@ function errorMessage(error: unknown): string {
   return error instanceof Error ? error.message : String(error)
 }
 
+function replayPayload(handle: unknown): Record<string, unknown> | undefined {
+  if (!handle || typeof handle !== 'object') return undefined
+  try {
+    return JSON.parse(JSON.stringify(handle)) as Record<string, unknown>
+  } catch {
+    return undefined
+  }
+}
+
+function plannedAction(action: ResolvedAction): WebObservedAction {
+  return {
+    description: action.description,
+    handle: action.replay ?? {},
+  }
+}
+
 function providerApiKeyEnvNames(modelName: string | undefined): string[] {
   const provider = (modelName ?? 'anthropic/claude-sonnet-4-6').split('/')[0]
   switch (provider) {
@@ -464,10 +481,17 @@ export function createWebAdapter(
   const validatedOptions = validateWebAdapterOptions(options)
   return {
     capabilities: ['web', 'screenshots'],
+    planFormatVersion: 'web.1',
     async openSession(input) {
       const automation = await factory.open({
         browser: stagehandBrowserOptions(
-          validatedOptions.browser,
+          {
+            ...validatedOptions.browser,
+            selfHeal:
+              (input.mode ?? 'adaptive') === 'replay'
+                ? false
+                : (validatedOptions.browser?.selfHeal ?? true),
+          },
           factory === stagehandFactory,
         ),
         signal: input.signal,
@@ -475,6 +499,7 @@ export function createWebAdapter(
       let closed = false
       let navigated = false
       let stepIndex = 0
+      let mode = input.mode ?? 'adaptive'
 
       const close = async () => {
         if (closed) return
@@ -546,6 +571,61 @@ export function createWebAdapter(
         navigated = true
       }
 
+      async function resolveByObservation(
+        prompt: string,
+        signal?: AbortSignal,
+      ): Promise<StepExecution> {
+        let actions = await automation.observe(prompt, signal)
+        if (actions.length === 0)
+          actions = await automation.observe(prompt, signal)
+        if (actions.length === 0) {
+          return {
+            state: 'infrastructure-error',
+            resolvedActions: [],
+            message: 'Observe returned no actions',
+          }
+        }
+
+        const resolvedActions: ResolvedAction[] = []
+        for (const action of actions) {
+          const result = await automation.act(action, signal)
+          const replay = replayPayload(action.handle)
+          resolvedActions.push({
+            description: action.description,
+            ...(replay ? { replay } : {}),
+          })
+          if (!result.success) {
+            return {
+              state: 'infrastructure-error',
+              resolvedActions,
+              message: result.message ?? 'Web action failed',
+            }
+          }
+        }
+        return { state: 'passed', resolvedActions }
+      }
+
+      async function replayOrAdapt(
+        prompt: string,
+        planned: readonly ResolvedAction[],
+        signal?: AbortSignal,
+      ): Promise<StepExecution> {
+        const resolvedActions: ResolvedAction[] = []
+        for (const action of planned) {
+          const result = await automation.act(plannedAction(action), signal)
+          resolvedActions.push(action)
+          if (!result.success) {
+            const adapted = await resolveByObservation(prompt, signal)
+            if (adapted.state === 'passed') {
+              mode = 'adaptive'
+              return { ...adapted, state: 'passed-with-adaptation' }
+            }
+            return adapted
+          }
+        }
+        return { state: 'passed', resolvedActions }
+      }
+
       return {
         async executeStep(step, signal) {
           stepIndex++
@@ -587,30 +667,33 @@ export function createWebAdapter(
               })
             }
 
-            let actions = await automation.observe(prompt, operationSignal)
-            if (actions.length === 0)
-              actions = await automation.observe(prompt, operationSignal)
-            if (actions.length === 0) {
-              return finish(step, {
-                state: 'infrastructure-error',
-                resolvedActions: [],
-                message: 'Observe returned no actions',
-              })
-            }
-
-            const resolvedActions = []
-            for (const action of actions) {
-              const result = await automation.act(action, operationSignal)
-              resolvedActions.push({ description: action.description })
-              if (!result.success) {
+            if (mode === 'replay') {
+              const planned =
+                input.plan?.steps[stepIndex - 1]?.resolvedActions ?? []
+              if (planned.length > 0) {
+                return finish(
+                  step,
+                  await replayOrAdapt(prompt, planned, operationSignal),
+                )
+              }
+              const adapted = await resolveByObservation(
+                prompt,
+                operationSignal,
+              )
+              if (adapted.state === 'passed') {
+                mode = 'adaptive'
                 return finish(step, {
-                  state: 'infrastructure-error',
-                  resolvedActions,
-                  message: result.message ?? 'Web action failed',
+                  ...adapted,
+                  state: 'passed-with-adaptation',
                 })
               }
+              return finish(step, adapted)
             }
-            return finish(step, { state: 'passed', resolvedActions })
+
+            return finish(
+              step,
+              await resolveByObservation(prompt, operationSignal),
+            )
           } catch (error) {
             if (
               operationSignal?.aborted ||

--- a/packages/web/src/web-adapter.ts
+++ b/packages/web/src/web-adapter.ts
@@ -499,7 +499,7 @@ export function createWebAdapter(
       let closed = false
       let navigated = false
       let stepIndex = 0
-      let mode = input.mode ?? 'adaptive'
+      let executionMode = input.mode ?? 'adaptive'
 
       const close = async () => {
         if (closed) return
@@ -605,23 +605,27 @@ export function createWebAdapter(
         return { state: 'passed', resolvedActions }
       }
 
+      async function adapt(
+        prompt: string,
+        signal?: AbortSignal,
+      ): Promise<StepExecution> {
+        const adapted = await resolveByObservation(prompt, signal)
+        if (adapted.state !== 'passed') return adapted
+        executionMode = 'adaptive'
+        return { ...adapted, state: 'passed-with-adaptation' }
+      }
+
       async function replayOrAdapt(
         prompt: string,
         planned: readonly ResolvedAction[],
         signal?: AbortSignal,
       ): Promise<StepExecution> {
+        if (planned.length === 0) return adapt(prompt, signal)
         const resolvedActions: ResolvedAction[] = []
         for (const action of planned) {
           const result = await automation.act(plannedAction(action), signal)
           resolvedActions.push(action)
-          if (!result.success) {
-            const adapted = await resolveByObservation(prompt, signal)
-            if (adapted.state === 'passed') {
-              mode = 'adaptive'
-              return { ...adapted, state: 'passed-with-adaptation' }
-            }
-            return adapted
-          }
+          if (!result.success) return adapt(prompt, signal)
         }
         return { state: 'passed', resolvedActions }
       }
@@ -667,27 +671,15 @@ export function createWebAdapter(
               })
             }
 
-            if (mode === 'replay') {
-              const planned =
-                input.plan?.steps[stepIndex - 1]?.resolvedActions ?? []
-              if (planned.length > 0) {
-                return finish(
-                  step,
-                  await replayOrAdapt(prompt, planned, operationSignal),
-                )
-              }
-              const adapted = await resolveByObservation(
-                prompt,
-                operationSignal,
+            if (executionMode === 'replay') {
+              return finish(
+                step,
+                await replayOrAdapt(
+                  prompt,
+                  input.plan?.steps[stepIndex - 1]?.resolvedActions ?? [],
+                  operationSignal,
+                ),
               )
-              if (adapted.state === 'passed') {
-                mode = 'adaptive'
-                return finish(step, {
-                  ...adapted,
-                  state: 'passed-with-adaptation',
-                })
-              }
-              return finish(step, adapted)
             }
 
             return finish(


### PR DESCRIPTION
## Summary
- New or stale Scenarios run in Adaptive mode and write a candidate plan under `.pickle/candidates/`.
- An applicable approved plan runs in Replay mode without model action resolution, and one step can replay multiple resolved actions.
- Adaptations record `passed-with-adaptation` and never change the approved plan. CI can reject adapted results through `policy.adaptedResults`, and Replay in CI requires `applicationRevision`.

Closes #16

## Test plan
- [ ] `bun run lint && bun run typecheck && bun run test`
- [ ] Run a Scenario with no approved plan and confirm Adaptive mode plus a candidate plan file
- [ ] Promote that candidate into `.pickle/plans/` and confirm Replay mode with no candidate rewrite
- [ ] Change the Scenario steps or use another execution target profile and confirm Adaptive mode
- [ ] Set `policy.adaptedResults` to `reject` and confirm `passed-with-adaptation` exits 1
- [ ] In CI, omit `applicationRevision` when an approved plan exists and confirm Replay is refused


Made with [Cursor](https://cursor.com)