### PR TITLE
Rerun, import, compare, and export test runs

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,48 @@ Set `applicationRevision` in `pickle.config.jsonc` or pass `--application-revisi
 
 `policy.adaptedResults` accepts `accept` or `reject`. The default is `accept`.
 
+## Persist, rerun, compare, and export test runs
+
+Every `pickle run` writes an immutable test run under `.pickle/runs/`.
+
+To create a selective rerun from an earlier test run, use:
+
+```bash
+pickle run --rerun <run-id>
+pickle run --rerun <run-id> --failures
+pickle run --rerun <run-id> --adaptations
+pickle run --rerun <run-id> --failures --scenario "Pay for the order"
+pickle run --rerun <run-id> --profile web
+```
+
+A rerun creates a new test run and records `sourceRunId`. It never changes the source run.
+
+To move a test run between machines, export and import a run archive:
+
+```bash
+pickle export <run-id> --archive run.archive.json
+pickle import run.archive.json
+```
+
+Import preserves the original archive bytes under `.pickle/archives/` and migrates older schemas in memory.
+
+To compare compatible test runs, use:
+
+```bash
+pickle compare <baseline-id> <candidate-id>
+```
+
+Comparison matches results by Scenario identifier and execution target profile identifier. It reports state, duration, flaky, adaptation, plan, and artifact changes.
+
+To create a self-contained HTML export, use:
+
+```bash
+pickle export <run-id> --html report.html
+pickle export <run-id> --html report.html --all-artifacts
+```
+
+HTML export includes failure and adaptation artifacts by default. `--all-artifacts` embeds every available test artifact and prints a size warning when the export exceeds 10 MB.
+
 ## Add a custom adapter
 
 Create `pickle.extensions.ts` when a project needs a custom execution-target adapter:

--- a/apps/example/package.json
+++ b/apps/example/package.json
@@ -5,7 +5,8 @@
   "scripts": {
     "run:example": "pickle run",
     "migrate": "pickle migrate",
-    "smoke": "pickle run --suite google --profile web"
+    "smoke": "pickle run --suite google --profile web",
+    "export": "pickle export 83c9a5e9-0384-466e-ae38-bc623214b9c3 --html report.html"
   },
   "dependencies": {
     "@pickle-spec/cli": "workspace:*"

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -1,24 +1,31 @@
 #!/usr/bin/env bun
 
-import { relative, resolve } from 'node:path'
+import { join, relative, resolve } from 'node:path'
 import { pathToFileURL } from 'node:url'
 import type {
   ExecutionTargetAdapter,
   ExecutionTargetProfile,
   RunExtensions,
+  TestResult,
 } from '@pickle-spec/runner'
 import {
+  compareTestRuns,
   createFilePlanStore,
+  formatHtml,
   formatJson,
   formatJunit,
   formatNdjson,
+  importRunArchive,
   openTestRunStore,
   resolveRunConfiguration,
   runScenarios,
+  selectRerunResults,
   validateTargetSelection,
+  writeRunArchive,
 } from '@pickle-spec/runner'
 import {
   parseSpecification,
+  resolveScenarioId,
   type SelectionOptions,
   type SpecificationState,
   selectScenarios,
@@ -49,6 +56,9 @@ interface RunArguments {
   junitPath?: string
   jsonPath?: string
   ndjsonPath?: string
+  rerunId?: string
+  failures?: boolean
+  adaptations?: boolean
 }
 
 function integer(value: string, flag: string, minimum: number): number {
@@ -157,6 +167,15 @@ function parseRunArguments(argv: string[]): RunArguments {
         break
       case '--ndjson':
         args.ndjsonPath = valueAfter(argv, index++)
+        break
+      case '--rerun':
+        args.rerunId = valueAfter(argv, index++)
+        break
+      case '--failures':
+        args.failures = true
+        break
+      case '--adaptations':
+        args.adaptations = true
         break
       default:
         throw new Error(`Unknown option: ${flag}`)
@@ -283,6 +302,39 @@ function configuredRunExtensions(
   }
 }
 
+function scenarioSelectionId(selection: {
+  specification: { source: { uri: string }; name: string }
+  scenario: { name: string; id?: string; tags: string[] }
+}): string {
+  return (
+    selection.scenario.id ??
+    resolveScenarioId(
+      selection.specification.source.uri,
+      selection.specification.name,
+      selection.scenario.name,
+      selection.scenario.tags,
+    )
+  )
+}
+
+function resultIdentity(result: TestResult): string {
+  return `${result.scenario.id ?? result.scenario.name}::${result.executionTargetProfile.id}`
+}
+
+function selectionMatchesResult(
+  selection: {
+    specification: { source: { uri: string }; name: string }
+    scenario: { name: string; id?: string; tags: string[] }
+  },
+  result: TestResult,
+): boolean {
+  const scenarioId = scenarioSelectionId(selection)
+  return (
+    scenarioId === (result.scenario.id ?? result.scenario.name) ||
+    selection.scenario.name === result.scenario.name
+  )
+}
+
 async function run(argv: string[]): Promise<number> {
   const args = parseRunArguments(argv)
   const config = await loadConfig(args.configPath)
@@ -301,17 +353,73 @@ async function run(argv: string[]): Promise<number> {
       throw new Error(`Unknown test suite "${args.suite}"`)
     }
     const baseSelection = suiteSelection ?? config.selection
-    const selections = selectScenarios(specifications, {
+    const store = openTestRunStore({
+      root: process.cwd(),
+      artifactCapture: config.artifacts?.capture,
+    })
+
+    let selections = selectScenarios(specifications, {
       ...baseSelection,
       ...args.selection,
       shard: args.selection.shard ?? baseSelection?.shard,
     })
+    let profileIds = args.profiles
+    let sourceRunId: string | undefined
+    let selectedResults: TestResult[] | undefined
+
+    if (args.rerunId) {
+      const sourceManifest = await loadManifest(args.rerunId)
+      selectedResults = selectRerunResults(sourceManifest, {
+        failures: args.failures,
+        adaptations: args.adaptations,
+        ...(args.selection.scenarioName
+          ? { scenarioNames: [args.selection.scenarioName] }
+          : {}),
+        ...(args.profiles?.length ? { profileIds: args.profiles } : {}),
+      })
+      if (selectedResults.length === 0) {
+        throw new Error('No results match the current rerun selection')
+      }
+      const selectedScenarioIds = new Set(
+        selectedResults.map(
+          (result) => result.scenario.id ?? result.scenario.name,
+        ),
+      )
+      selections = selectScenarios(specifications, {
+        ...baseSelection,
+        ...args.selection,
+        scenarioName: undefined,
+        shard: args.selection.shard ?? baseSelection?.shard,
+      }).filter(
+        (selection) =>
+          selectedScenarioIds.has(scenarioSelectionId(selection)) ||
+          selectedResults!.some(
+            (result) => result.scenario.name === selection.scenario.name,
+          ),
+      )
+      if (selections.length === 0) {
+        throw new Error('No Scenarios match the current rerun selection')
+      }
+      profileIds = args.profiles?.length
+        ? args.profiles
+        : config.executionTargetProfiles
+          ? [
+              ...new Set(
+                selectedResults.map(
+                  (result) => result.executionTargetProfile.id,
+                ),
+              ),
+            ]
+          : undefined
+      sourceRunId = args.rerunId
+    }
+
     if (selections.length === 0)
       throw new Error('No Scenarios match the current selection')
 
     const extensions = await loadExtensions(args.extensionsPath)
     const runConfiguration = {
-      ...runConfigurationFrom(config, args.profiles),
+      ...runConfigurationFrom(config, profileIds),
       concurrency: args.concurrency ?? config.concurrency,
       applicationRevision:
         args.applicationRevision ?? config.applicationRevision,
@@ -337,25 +445,40 @@ async function run(argv: string[]): Promise<number> {
       ...config.server,
       ...(args.reuseServer ? { reuseExisting: true } : {}),
     })
-    const store = openTestRunStore({
-      root: process.cwd(),
-      artifactCapture: config.artifacts?.capture,
-    })
-    const testRun = await store.create()
-    const runs = await runScenarios({
-      selections,
-      ...resolvedConfiguration,
-      plans: createFilePlanStore(process.cwd()),
-      ci: Boolean(process.env.CI),
-      signal: controller.signal,
-      async onEvent(event) {
-        const persisted = await testRun.append(event)
-        if (event.type === 'scenario-finished') {
-          await testRun.materialize({ finished: false })
-        }
-        console.log(JSON.stringify({ kind: 'run-event', event: persisted }))
-      },
-    })
+    const testRun = await store.create(
+      sourceRunId ? { sourceRunId } : undefined,
+    )
+    const onEvent = async (
+      event: Parameters<
+        NonNullable<Parameters<typeof runScenarios>[0]['onEvent']>
+      >[0],
+    ) => {
+      const persisted = await testRun.append(event)
+      if (event.type === 'scenario-finished') {
+        await testRun.materialize({ finished: false })
+      }
+      console.log(JSON.stringify({ kind: 'run-event', event: persisted }))
+    }
+
+    const planStore = createFilePlanStore(process.cwd())
+    const runs = selectedResults
+      ? await runSelectedResultPairs({
+          selectedResults,
+          selections,
+          resolvedConfiguration,
+          plans: planStore,
+          ci: Boolean(process.env.CI),
+          signal: controller.signal,
+          onEvent,
+        })
+      : await runScenarios({
+          selections,
+          ...resolvedConfiguration,
+          plans: planStore,
+          ci: Boolean(process.env.CI),
+          signal: controller.signal,
+          onEvent,
+        })
     const manifest = await testRun.materialize()
     if (args.junitPath) await Bun.write(args.junitPath, formatJunit(manifest))
     if (args.jsonPath) await Bun.write(args.jsonPath, formatJson(manifest))
@@ -391,6 +514,46 @@ async function run(argv: string[]): Promise<number> {
   }
 }
 
+async function runSelectedResultPairs(input: {
+  selectedResults: readonly TestResult[]
+  selections: ReturnType<typeof selectScenarios>
+  resolvedConfiguration: ReturnType<typeof resolveRunConfiguration>
+  plans: ReturnType<typeof createFilePlanStore>
+  ci: boolean
+  signal: AbortSignal
+  onEvent: NonNullable<Parameters<typeof runScenarios>[0]['onEvent']>
+}) {
+  const wanted = new Set(input.selectedResults.map(resultIdentity))
+  const runs = []
+  for (const target of input.resolvedConfiguration.targets) {
+    const profileId = target.executionTargetProfile.id
+    const profileSelections = input.selections.filter((selection) =>
+      input.selectedResults.some(
+        (result) =>
+          result.executionTargetProfile.id === profileId &&
+          selectionMatchesResult(selection, result) &&
+          wanted.has(resultIdentity(result)),
+      ),
+    )
+    if (profileSelections.length === 0) continue
+    runs.push(
+      ...(await runScenarios({
+        selections: profileSelections,
+        targets: [target],
+        retry: input.resolvedConfiguration.retry,
+        timeout: input.resolvedConfiguration.timeout,
+        concurrency: input.resolvedConfiguration.concurrency,
+        applicationRevision: input.resolvedConfiguration.applicationRevision,
+        plans: input.plans,
+        ci: input.ci,
+        signal: input.signal,
+        onEvent: input.onEvent,
+      })),
+    )
+  }
+  return runs
+}
+
 function projectOptions(argv: string[]): {
   configPath?: string
   extensionsPath?: string
@@ -420,6 +583,102 @@ function migrateOptions(argv: string[]): {
   return options
 }
 
+async function loadManifest(runId: string) {
+  const store = openTestRunStore({ root: process.cwd() })
+  const run = await store.open(runId)
+  const events = await run.events()
+  if (events.length === 0) throw new Error(`Unknown test run "${runId}"`)
+  const manifestPath = join(
+    process.cwd(),
+    '.pickle',
+    'runs',
+    runId,
+    'manifest.json',
+  )
+  if (await Bun.file(manifestPath).exists()) {
+    return (await Bun.file(manifestPath).json()) as Awaited<
+      ReturnType<typeof run.materialize>
+    >
+  }
+  return run.materialize({ finished: false })
+}
+
+async function compare(argv: string[]): Promise<number> {
+  if (argv.length !== 3) {
+    throw new Error('Usage: pickle compare <baseline-id> <candidate-id>')
+  }
+  const baseline = await loadManifest(argv[1]!)
+  const candidate = await loadManifest(argv[2]!)
+  console.log(JSON.stringify(compareTestRuns(baseline, candidate), null, 2))
+  return 0
+}
+
+async function importArchive(argv: string[]): Promise<number> {
+  if (argv.length !== 2) throw new Error('Usage: pickle import <archive>')
+  const imported = await importRunArchive({
+    root: process.cwd(),
+    archivePath: resolve(argv[1]!),
+  })
+  console.log(
+    JSON.stringify({
+      kind: 'imported-run',
+      id: imported.manifest.id,
+      preservedArchivePath: imported.preservedArchivePath,
+    }),
+  )
+  return 0
+}
+
+async function exportRun(argv: string[]): Promise<number> {
+  if (argv[0] !== 'export' || !argv[1]) {
+    throw new Error(
+      'Usage: pickle export <id> (--archive <path> | --html <path>) [--all-artifacts]',
+    )
+  }
+  const runId = argv[1]
+  let archivePath: string | undefined
+  let htmlPath: string | undefined
+  let allArtifacts = false
+  for (let index = 2; index < argv.length; index++) {
+    const flag = argv[index]!
+    if (flag === '--archive') archivePath = valueAfter(argv, index++)
+    else if (flag === '--html') htmlPath = valueAfter(argv, index++)
+    else if (flag === '--all-artifacts') allArtifacts = true
+    else throw new Error(`Unknown option: ${flag}`)
+  }
+  if (!archivePath && !htmlPath) {
+    throw new Error('pickle export requires --archive or --html')
+  }
+  if (archivePath && htmlPath) {
+    throw new Error('pickle export accepts either --archive or --html')
+  }
+  if (archivePath) {
+    await writeRunArchive({
+      root: process.cwd(),
+      runId,
+      outputPath: resolve(archivePath),
+    })
+    return 0
+  }
+
+  const store = openTestRunStore({ root: process.cwd() })
+  const run = await store.open(runId)
+  const events = await run.events()
+  if (events.length === 0) throw new Error(`Unknown test run "${runId}"`)
+  const manifest = await loadManifest(runId)
+  const html = await formatHtml(manifest, events, {
+    artifacts: allArtifacts ? 'all' : 'failures-and-adaptations',
+  })
+  const warningThreshold = 10 * 1024 * 1024
+  if (allArtifacts && Buffer.byteLength(html, 'utf8') > warningThreshold) {
+    console.error(
+      `Warning: HTML export includes every available test artifact and is larger than 10 MB (${Buffer.byteLength(html, 'utf8')} bytes).`,
+    )
+  }
+  await Bun.write(resolve(htmlPath!), html)
+  return 0
+}
+
 async function main(argv: string[]): Promise<number> {
   if (argv[0] === 'init') {
     if (argv.length > 1) throw new Error('Usage: pickle init')
@@ -433,6 +692,15 @@ async function main(argv: string[]): Promise<number> {
   if (argv[0] === 'migrate') {
     await migrateProject({ ...migrateOptions(argv), report: console.log })
     return 0
+  }
+  if (argv[0] === 'compare') {
+    return compare(argv)
+  }
+  if (argv[0] === 'import') {
+    return importArchive(argv)
+  }
+  if (argv[0] === 'export') {
+    return exportRun(argv)
   }
   return run(argv)
 }

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -317,10 +317,6 @@ function scenarioSelectionId(selection: {
   )
 }
 
-function resultIdentity(result: TestResult): string {
-  return `${result.scenario.id ?? result.scenario.name}::${result.executionTargetProfile.id}`
-}
-
 function selectionMatchesResult(
   selection: {
     specification: { source: { uri: string }; name: string }
@@ -328,9 +324,9 @@ function selectionMatchesResult(
   },
   result: TestResult,
 ): boolean {
-  const scenarioId = scenarioSelectionId(selection)
   return (
-    scenarioId === (result.scenario.id ?? result.scenario.name) ||
+    scenarioSelectionId(selection) ===
+      (result.scenario.id ?? result.scenario.name) ||
     selection.scenario.name === result.scenario.name
   )
 }
@@ -368,7 +364,7 @@ async function run(argv: string[]): Promise<number> {
     let selectedResults: TestResult[] | undefined
 
     if (args.rerunId) {
-      const sourceManifest = await loadManifest(args.rerunId)
+      const { manifest: sourceManifest } = await loadPersistedRun(args.rerunId)
       selectedResults = selectRerunResults(sourceManifest, {
         failures: args.failures,
         adaptations: args.adaptations,
@@ -380,22 +376,15 @@ async function run(argv: string[]): Promise<number> {
       if (selectedResults.length === 0) {
         throw new Error('No results match the current rerun selection')
       }
-      const selectedScenarioIds = new Set(
-        selectedResults.map(
-          (result) => result.scenario.id ?? result.scenario.name,
-        ),
-      )
       selections = selectScenarios(specifications, {
         ...baseSelection,
         ...args.selection,
         scenarioName: undefined,
         shard: args.selection.shard ?? baseSelection?.shard,
-      }).filter(
-        (selection) =>
-          selectedScenarioIds.has(scenarioSelectionId(selection)) ||
-          selectedResults!.some(
-            (result) => result.scenario.name === selection.scenario.name,
-          ),
+      }).filter((selection) =>
+        selectedResults!.some((result) =>
+          selectionMatchesResult(selection, result),
+        ),
       )
       if (selections.length === 0) {
         throw new Error('No Scenarios match the current rerun selection')
@@ -461,23 +450,27 @@ async function run(argv: string[]): Promise<number> {
     }
 
     const planStore = createFilePlanStore(process.cwd())
+    const shared = {
+      plans: planStore,
+      ci: Boolean(process.env.CI),
+      signal: controller.signal,
+      onEvent,
+    }
     const runs = selectedResults
       ? await runSelectedResultPairs({
           selectedResults,
           selections,
-          resolvedConfiguration,
-          plans: planStore,
-          ci: Boolean(process.env.CI),
-          signal: controller.signal,
-          onEvent,
+          targets: resolvedConfiguration.targets,
+          retry: resolvedConfiguration.retry,
+          timeout: resolvedConfiguration.timeout,
+          concurrency: resolvedConfiguration.concurrency,
+          applicationRevision: resolvedConfiguration.applicationRevision,
+          ...shared,
         })
       : await runScenarios({
           selections,
           ...resolvedConfiguration,
-          plans: planStore,
-          ci: Boolean(process.env.CI),
-          signal: controller.signal,
-          onEvent,
+          ...shared,
         })
     const manifest = await testRun.materialize()
     if (args.junitPath) await Bun.write(args.junitPath, formatJunit(manifest))
@@ -514,40 +507,29 @@ async function run(argv: string[]): Promise<number> {
   }
 }
 
-async function runSelectedResultPairs(input: {
-  selectedResults: readonly TestResult[]
-  selections: ReturnType<typeof selectScenarios>
-  resolvedConfiguration: ReturnType<typeof resolveRunConfiguration>
-  plans: ReturnType<typeof createFilePlanStore>
-  ci: boolean
-  signal: AbortSignal
-  onEvent: NonNullable<Parameters<typeof runScenarios>[0]['onEvent']>
-}) {
-  const wanted = new Set(input.selectedResults.map(resultIdentity))
+async function runSelectedResultPairs(
+  input: {
+    selectedResults: readonly TestResult[]
+    selections: ReturnType<typeof selectScenarios>
+    targets: ReturnType<typeof resolveRunConfiguration>['targets']
+  } & Omit<Parameters<typeof runScenarios>[0], 'selections' | 'targets'>,
+) {
   const runs = []
-  for (const target of input.resolvedConfiguration.targets) {
+  for (const target of input.targets) {
     const profileId = target.executionTargetProfile.id
     const profileSelections = input.selections.filter((selection) =>
       input.selectedResults.some(
         (result) =>
           result.executionTargetProfile.id === profileId &&
-          selectionMatchesResult(selection, result) &&
-          wanted.has(resultIdentity(result)),
+          selectionMatchesResult(selection, result),
       ),
     )
     if (profileSelections.length === 0) continue
     runs.push(
       ...(await runScenarios({
+        ...input,
         selections: profileSelections,
         targets: [target],
-        retry: input.resolvedConfiguration.retry,
-        timeout: input.resolvedConfiguration.timeout,
-        concurrency: input.resolvedConfiguration.concurrency,
-        applicationRevision: input.resolvedConfiguration.applicationRevision,
-        plans: input.plans,
-        ci: input.ci,
-        signal: input.signal,
-        onEvent: input.onEvent,
       })),
     )
   }
@@ -583,7 +565,7 @@ function migrateOptions(argv: string[]): {
   return options
 }
 
-async function loadManifest(runId: string) {
+async function loadPersistedRun(runId: string) {
   const store = openTestRunStore({ root: process.cwd() })
   const run = await store.open(runId)
   const events = await run.events()
@@ -595,21 +577,27 @@ async function loadManifest(runId: string) {
     runId,
     'manifest.json',
   )
-  if (await Bun.file(manifestPath).exists()) {
-    return (await Bun.file(manifestPath).json()) as Awaited<
-      ReturnType<typeof run.materialize>
-    >
-  }
-  return run.materialize({ finished: false })
+  const manifest = (await Bun.file(manifestPath).exists())
+    ? ((await Bun.file(manifestPath).json()) as Awaited<
+        ReturnType<typeof run.materialize>
+      >)
+    : await run.materialize({ finished: false })
+  return { manifest, events }
 }
 
 async function compare(argv: string[]): Promise<number> {
   if (argv.length !== 3) {
     throw new Error('Usage: pickle compare <baseline-id> <candidate-id>')
   }
-  const baseline = await loadManifest(argv[1]!)
-  const candidate = await loadManifest(argv[2]!)
-  console.log(JSON.stringify(compareTestRuns(baseline, candidate), null, 2))
+  const baseline = await loadPersistedRun(argv[1]!)
+  const candidate = await loadPersistedRun(argv[2]!)
+  console.log(
+    JSON.stringify(
+      compareTestRuns(baseline.manifest, candidate.manifest),
+      null,
+      2,
+    ),
+  )
   return 0
 }
 
@@ -661,18 +649,15 @@ async function exportRun(argv: string[]): Promise<number> {
     return 0
   }
 
-  const store = openTestRunStore({ root: process.cwd() })
-  const run = await store.open(runId)
-  const events = await run.events()
-  if (events.length === 0) throw new Error(`Unknown test run "${runId}"`)
-  const manifest = await loadManifest(runId)
+  const { manifest, events } = await loadPersistedRun(runId)
   const html = await formatHtml(manifest, events, {
     artifacts: allArtifacts ? 'all' : 'failures-and-adaptations',
   })
+  const htmlBytes = Buffer.byteLength(html, 'utf8')
   const warningThreshold = 10 * 1024 * 1024
-  if (allArtifacts && Buffer.byteLength(html, 'utf8') > warningThreshold) {
+  if (allArtifacts && htmlBytes > warningThreshold) {
     console.error(
-      `Warning: HTML export includes every available test artifact and is larger than 10 MB (${Buffer.byteLength(html, 'utf8')} bytes).`,
+      `Warning: HTML export includes every available test artifact and is larger than 10 MB (${htmlBytes} bytes).`,
     )
   }
   await Bun.write(resolve(htmlPath!), html)

--- a/packages/cli/src/workspace.test.ts
+++ b/packages/cli/src/workspace.test.ts
@@ -1454,6 +1454,221 @@ Feature: Purchase
     ).toBe(retainedManifest)
   })
 
+  test('pickle run --rerun creates a new test run linked to its source', async () => {
+    const project = await createCheckProject('rerun-source', {
+      config: {
+        schemaVersion: 1,
+        specifications: 'features/**/*.feature',
+        executionTargetProfile: { id: 'deterministic' },
+      },
+      specification: {
+        path: 'features/purchase.feature',
+        source: `@pickle:id:specpurchaseaaaaaa @pickle:state:active
+Feature: Purchase
+  @pickle:id:scnpurchasebbbbbb
+  Scenario: Complete a purchase
+    Then the purchase succeeds
+  @pickle:id:scnpurchasecccccc
+  Scenario: Pay for the order
+    Then payment succeeds`,
+      },
+      extensions: `
+const outcomes = {
+  'the purchase succeeds': process.env.PICKLE_TEST_PURCHASE ?? 'passed',
+  'payment succeeds': process.env.PICKLE_TEST_PAYMENT ?? 'failed',
+}
+
+export default {
+  adapter: {
+    async openSession() {
+      return {
+        async executeStep(step) {
+          return {
+            state: outcomes[step.text] ?? 'passed',
+            resolvedActions: [{ description: \`Deterministic action: \${step.text}\` }],
+          }
+        },
+        async close() {},
+      }
+    },
+  },
+}
+`,
+    })
+
+    const first = Bun.spawnSync({
+      cmd: [pickleCommand, 'run'],
+      cwd: project,
+      env: {
+        ...Bun.env,
+        PICKLE_TEST_PURCHASE: 'passed',
+        PICKLE_TEST_PAYMENT: 'failed',
+      },
+    })
+    expect(first.exitCode).toBe(1)
+    const sourceManifests = [
+      ...new Bun.Glob('*/manifest.json').scanSync({
+        cwd: join(project, '.pickle', 'runs'),
+      }),
+    ]
+    expect(sourceManifests).toHaveLength(1)
+    const sourceId = dirname(sourceManifests[0]!)
+    const sourceEvents = await Bun.file(
+      join(project, '.pickle', 'runs', sourceId, 'events.ndjson'),
+    ).text()
+
+    const rerun = Bun.spawnSync({
+      cmd: [pickleCommand, 'run', '--rerun', sourceId, '--failures'],
+      cwd: project,
+      env: {
+        ...Bun.env,
+        PICKLE_TEST_PURCHASE: 'passed',
+        PICKLE_TEST_PAYMENT: 'passed',
+      },
+    })
+    expect(rerun.stderr.toString()).toBe('')
+    expect(rerun.exitCode).toBe(0)
+
+    const manifests = [
+      ...new Bun.Glob('*/manifest.json').scanSync({
+        cwd: join(project, '.pickle', 'runs'),
+      }),
+    ]
+    expect(manifests).toHaveLength(2)
+    const rerunManifestPath = manifests.find(
+      (path) => dirname(path) !== sourceId,
+    )!
+    const rerunManifest = (await Bun.file(
+      join(project, '.pickle', 'runs', rerunManifestPath),
+    ).json()) as {
+      sourceRunId?: string
+      results: Array<{ scenario: { name: string }; state: string }>
+    }
+    expect(rerunManifest.sourceRunId).toBe(sourceId)
+    expect(rerunManifest.results).toHaveLength(1)
+    expect(rerunManifest.results[0]).toMatchObject({
+      scenario: { name: 'Pay for the order' },
+      state: 'passed',
+    })
+    expect(
+      await Bun.file(
+        join(project, '.pickle', 'runs', sourceId, 'events.ndjson'),
+      ).text(),
+    ).toBe(sourceEvents)
+  })
+
+  test('pickle export and import move an immutable run archive between projects', async () => {
+    const project = await createCheckProject('export-import', {
+      config: {
+        schemaVersion: 1,
+        specifications: 'features/**/*.feature',
+        executionTargetProfile: { id: 'deterministic' },
+        artifacts: { capture: 'on-failure-or-adaptation' },
+      },
+      specification: {
+        path: 'features/purchase.feature',
+        source: `@pickle:id:specpurchaseaaaaaa @pickle:state:active
+Feature: Purchase
+  @pickle:id:scnpurchasebbbbbb
+  Scenario: Complete a purchase
+    Then the purchase succeeds`,
+      },
+      extensions: `
+export default {
+  adapter: {
+    async openSession() {
+      return {
+        async executeStep(step) {
+          const path = process.env.PICKLE_TEST_ARTIFACT
+          return {
+            state: 'failed',
+            resolvedActions: [{ description: \`Deterministic action: \${step.text}\` }],
+            artifacts: path
+              ? [{ kind: 'screenshot', path, mediaType: 'image/png' }]
+              : [],
+          }
+        },
+        async close() {},
+      }
+    },
+  },
+}
+`,
+    })
+    const artifactPath = join(project, 'failure.png')
+    await Bun.write(artifactPath, 'png-bytes')
+    const run = Bun.spawnSync({
+      cmd: [pickleCommand, 'run'],
+      cwd: project,
+      env: { ...Bun.env, PICKLE_TEST_ARTIFACT: artifactPath },
+    })
+    expect(run.exitCode).toBe(1)
+    const sourceId = dirname(
+      [
+        ...new Bun.Glob('*/manifest.json').scanSync({
+          cwd: join(project, '.pickle', 'runs'),
+        }),
+      ][0]!,
+    )
+    const archivePath = join(project, 'run.archive.json')
+    const exported = Bun.spawnSync({
+      cmd: [pickleCommand, 'export', sourceId, '--archive', archivePath],
+      cwd: project,
+      env: { ...Bun.env },
+    })
+    expect(exported.exitCode).toBe(0)
+    expect(await Bun.file(archivePath).exists()).toBe(true)
+    const originalArchive = await Bun.file(archivePath).text()
+
+    const target = await createCheckProject('import-target', {
+      config: {
+        schemaVersion: 1,
+        specifications: 'features/**/*.feature',
+        executionTargetProfile: { id: 'deterministic' },
+      },
+      specification: validSpecification,
+      extensions: 'export default {}',
+    })
+    await Bun.write(join(target, 'incoming.json'), originalArchive)
+    const imported = Bun.spawnSync({
+      cmd: [pickleCommand, 'import', 'incoming.json'],
+      cwd: target,
+      env: { ...Bun.env },
+    })
+    expect(imported.exitCode).toBe(0)
+    expect(await Bun.file(join(target, 'incoming.json')).text()).toBe(
+      originalArchive,
+    )
+    expect(
+      await Bun.file(
+        join(target, '.pickle', 'archives', `${sourceId}.json`),
+      ).text(),
+    ).toBe(originalArchive)
+    const compare = Bun.spawnSync({
+      cmd: [pickleCommand, 'compare', sourceId, sourceId],
+      cwd: target,
+      env: { ...Bun.env },
+    })
+    expect(compare.exitCode).toBe(0)
+    expect(JSON.parse(compare.stdout.toString())).toMatchObject({
+      schemaVersion: 1,
+      baselineRunId: sourceId,
+      candidateRunId: sourceId,
+      pairs: [],
+      added: [],
+      removed: [],
+    })
+
+    const htmlPath = join(project, 'report.html')
+    const html = Bun.spawnSync({
+      cmd: [pickleCommand, 'export', sourceId, '--html', htmlPath],
+      cwd: project,
+      env: { ...Bun.env },
+    })
+    expect(html.exitCode).toBe(0)
+    expect(await Bun.file(htmlPath).text()).toContain('data:image/png;base64,')
+  })
+
   test('check rejects an unknown artifact capture policy', async () => {
     const project = await createCheckProject('invalid-artifact-policy', {
       config: {

--- a/packages/runner/index.ts
+++ b/packages/runner/index.ts
@@ -1,4 +1,24 @@
 export type {
+  ImportedRunArchive,
+  ImportRunArchiveInput,
+  RunArchive,
+  RunArchiveArtifact,
+  WriteRunArchiveInput,
+} from './src/archive'
+export {
+  importRunArchive,
+  migrateRunArchive,
+  readRunArchive,
+  writeRunArchive,
+} from './src/archive'
+export type {
+  ComparedResultPair,
+  ComparedResultSide,
+  ResultChangeKind,
+  TestRunComparison,
+} from './src/compare'
+export { compareTestRuns } from './src/compare'
+export type {
   ResolvedRunConfiguration,
   RunConfiguration,
   RunExtensionManifest,
@@ -19,7 +39,15 @@ export {
   createFilePlanStore,
   planApplies,
 } from './src/execution-plan'
-export { formatJson, formatJunit, formatNdjson } from './src/outputs'
+export type { FormatHtmlOptions, HtmlArtifactMode } from './src/outputs'
+export {
+  formatHtml,
+  formatJson,
+  formatJunit,
+  formatNdjson,
+} from './src/outputs'
+export type { RerunFilter } from './src/rerun'
+export { selectRerunResults } from './src/rerun'
 export type {
   ExecutionMode,
   ExecutionPolicy,
@@ -43,6 +71,7 @@ export type { RunScenariosInput, RunTarget } from './src/run-scenarios'
 export { runScenarios, validateTargetSelection } from './src/run-scenarios'
 export type {
   ArtifactCapturePolicy,
+  CreateTestRunOptions,
   PersistedTestRun,
   RetentionPolicy,
   RetentionResult,

--- a/packages/runner/index.ts
+++ b/packages/runner/index.ts
@@ -7,7 +7,6 @@ export type {
 } from './src/archive'
 export {
   importRunArchive,
-  migrateRunArchive,
   readRunArchive,
   writeRunArchive,
 } from './src/archive'

--- a/packages/runner/src/archive.test.ts
+++ b/packages/runner/src/archive.test.ts
@@ -1,0 +1,183 @@
+import { expect, test } from 'bun:test'
+import { mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import {
+  importRunArchive,
+  openTestRunStore,
+  readRunArchive,
+  writeRunArchive,
+} from '../index'
+import type { TestResult } from './run-scenario'
+
+async function tempRoot(): Promise<string> {
+  return mkdtemp(join(tmpdir(), 'pickle-archive-'))
+}
+
+function passedResult(): TestResult {
+  return {
+    schemaVersion: 1,
+    specification: {
+      name: 'Checkout',
+      uri: 'features/checkout.feature',
+    },
+    scenario: { name: 'Complete a purchase', id: 'scnpurchasebbbbbb' },
+    executionTargetProfile: { id: 'deterministic' },
+    state: 'passed',
+    steps: [],
+    durationMs: 12,
+  }
+}
+
+test('writeRunArchive preserves events, manifests, and selected test artifacts', async () => {
+  const root = await tempRoot()
+  try {
+    const store = openTestRunStore({
+      root,
+      createId: () => 'run-archive',
+      now: () => new Date('2026-08-15T12:00:00.000Z'),
+    })
+    const artifactSource = join(root, 'source.png')
+    await Bun.write(artifactSource, 'png-bytes')
+    const run = await store.create()
+    await run.append({
+      type: 'scenario-finished',
+      result: {
+        ...passedResult(),
+        state: 'failed',
+        steps: [
+          {
+            step: {
+              keyword: 'Then',
+              text: 'the purchase succeeds',
+              type: 'outcome',
+            },
+            state: 'failed',
+            resolvedActions: [],
+            artifacts: [
+              {
+                kind: 'screenshot',
+                path: artifactSource,
+                mediaType: 'image/png',
+              },
+            ],
+          },
+        ],
+      },
+    })
+    const manifest = await run.materialize()
+    const archivePath = join(root, 'run-archive.json')
+
+    await writeRunArchive({
+      root,
+      runId: run.id,
+      outputPath: archivePath,
+    })
+
+    const archive = await readRunArchive(archivePath)
+    expect(archive).toMatchObject({
+      schemaVersion: 1,
+      kind: 'run-archive',
+      manifest: { id: 'run-archive', state: 'failed' },
+    })
+    expect(archive.events[0]).toMatchObject({
+      type: 'run-started',
+      run: { id: 'run-archive' },
+    })
+    expect(archive.artifacts).toHaveLength(1)
+    expect(archive.artifacts[0]?.mediaType).toBe('image/png')
+    expect(
+      Buffer.from(archive.artifacts[0]!.content, 'base64').toString(),
+    ).toBe('png-bytes')
+    expect(manifest.id).toBe('run-archive')
+  } finally {
+    await rm(root, { recursive: true, force: true })
+  }
+})
+
+test('import preserves the original archive and migrates older schemas in memory', async () => {
+  const root = await tempRoot()
+  try {
+    const archivePath = join(root, 'legacy-archive.json')
+    const legacy = {
+      kind: 'run-archive',
+      manifest: {
+        id: 'run-legacy',
+        startedAt: '2026-08-01T00:00:00.000Z',
+        finishedAt: '2026-08-01T00:00:01.000Z',
+        state: 'passed',
+        results: [
+          {
+            specification: {
+              name: 'Checkout',
+              uri: 'features/checkout.feature',
+            },
+            scenario: { name: 'Complete a purchase' },
+            executionTargetProfile: { id: 'deterministic' },
+            state: 'passed',
+            steps: [],
+          },
+        ],
+      },
+      events: [
+        {
+          sequence: 1,
+          type: 'run-started',
+          run: { id: 'run-legacy', startedAt: '2026-08-01T00:00:00.000Z' },
+        },
+        {
+          sequence: 2,
+          type: 'scenario-finished',
+          result: {
+            specification: {
+              name: 'Checkout',
+              uri: 'features/checkout.feature',
+            },
+            scenario: { name: 'Complete a purchase' },
+            executionTargetProfile: { id: 'deterministic' },
+            state: 'passed',
+            steps: [],
+          },
+        },
+      ],
+      artifacts: [],
+    }
+    const original = `${JSON.stringify(legacy)}\n`
+    await Bun.write(archivePath, original)
+
+    const imported = await importRunArchive({ root, archivePath })
+    const preserved = join(root, '.pickle', 'archives', 'run-legacy.json')
+
+    expect(await Bun.file(preserved).text()).toBe(original)
+    expect(await Bun.file(archivePath).text()).toBe(original)
+    expect(imported.manifest).toMatchObject({
+      schemaVersion: 1,
+      id: 'run-legacy',
+      state: 'passed',
+      results: [
+        {
+          schemaVersion: 1,
+          scenario: { name: 'Complete a purchase' },
+        },
+      ],
+    })
+    expect(imported.events[0]).toMatchObject({
+      schemaVersion: 1,
+      sequence: 1,
+      type: 'run-started',
+    })
+
+    const store = openTestRunStore({ root })
+    expect(await store.list()).toEqual([
+      {
+        id: 'run-legacy',
+        startedAt: '2026-08-01T00:00:00.000Z',
+        finishedAt: '2026-08-01T00:00:01.000Z',
+        state: 'passed',
+        resultCount: 1,
+      },
+    ])
+  } finally {
+    await rm(root, { recursive: true, force: true })
+  }
+})

--- a/packages/runner/src/archive.ts
+++ b/packages/runner/src/archive.ts
@@ -1,0 +1,391 @@
+import { mkdir } from 'node:fs/promises'
+import { dirname, join, relative } from 'node:path'
+import type { RunEvent, TestResult, TestStepResult } from './run-scenario'
+import { openTestRunStore, type TestRunManifest } from './test-run-store'
+
+export interface RunArchiveArtifact {
+  path: string
+  mediaType?: string
+  content: string
+}
+
+export interface RunArchive {
+  schemaVersion: 1
+  kind: 'run-archive'
+  manifest: TestRunManifest
+  events: RunEvent[]
+  artifacts: RunArchiveArtifact[]
+}
+
+export interface WriteRunArchiveInput {
+  root: string
+  runId: string
+  outputPath: string
+}
+
+export interface ImportRunArchiveInput {
+  root: string
+  archivePath: string
+}
+
+export interface ImportedRunArchive {
+  manifest: TestRunManifest
+  events: RunEvent[]
+  preservedArchivePath: string
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function migrateStep(step: unknown): TestStepResult {
+  const value = isRecord(step) ? step : {}
+  return {
+    step: value.step as TestStepResult['step'],
+    state: value.state as TestStepResult['state'],
+    resolvedActions: Array.isArray(value.resolvedActions)
+      ? (value.resolvedActions as TestStepResult['resolvedActions'])
+      : [],
+    ...(typeof value.message === 'string' ? { message: value.message } : {}),
+    ...(Array.isArray(value.artifacts)
+      ? { artifacts: value.artifacts as TestStepResult['artifacts'] }
+      : {}),
+  }
+}
+
+function migrateResult(result: unknown): TestResult {
+  const value = isRecord(result) ? result : {}
+  const scenario = isRecord(value.scenario) ? value.scenario : {}
+  return {
+    schemaVersion: 1,
+    specification: value.specification as TestResult['specification'],
+    scenario: {
+      name: String(scenario.name ?? ''),
+      ...(typeof scenario.id === 'string' ? { id: scenario.id } : {}),
+    },
+    executionTargetProfile:
+      value.executionTargetProfile as TestResult['executionTargetProfile'],
+    state: value.state as TestResult['state'],
+    steps: Array.isArray(value.steps) ? value.steps.map(migrateStep) : [],
+    ...(typeof value.executionMode === 'string'
+      ? { executionMode: value.executionMode as TestResult['executionMode'] }
+      : {}),
+    ...(typeof value.message === 'string' ? { message: value.message } : {}),
+    ...(typeof value.attempts === 'number' ? { attempts: value.attempts } : {}),
+    ...(typeof value.flaky === 'boolean' ? { flaky: value.flaky } : {}),
+    ...(typeof value.durationMs === 'number'
+      ? { durationMs: value.durationMs }
+      : {}),
+  }
+}
+
+function migrateEvent(event: unknown, index: number): RunEvent {
+  const value = isRecord(event) ? event : {}
+  const base = {
+    schemaVersion: 1 as const,
+    sequence: typeof value.sequence === 'number' ? value.sequence : index + 1,
+  }
+  if (value.type === 'scenario-finished') {
+    return {
+      ...base,
+      type: 'scenario-finished',
+      result: migrateResult(value.result),
+    }
+  }
+  if (value.type === 'step-finished') {
+    return {
+      ...base,
+      type: 'step-finished',
+      result: migrateStep(value.result),
+    }
+  }
+  return { ...base, ...(value as object) } as RunEvent
+}
+
+function migrateManifest(manifest: unknown): TestRunManifest {
+  const value = isRecord(manifest) ? manifest : {}
+  return {
+    schemaVersion: 1,
+    id: String(value.id ?? ''),
+    startedAt: String(value.startedAt ?? ''),
+    ...(typeof value.finishedAt === 'string'
+      ? { finishedAt: value.finishedAt }
+      : {}),
+    ...(typeof value.sourceRunId === 'string'
+      ? { sourceRunId: value.sourceRunId }
+      : {}),
+    state: value.state as TestRunManifest['state'],
+    results: Array.isArray(value.results)
+      ? value.results.map(migrateResult)
+      : [],
+  }
+}
+
+export function migrateRunArchive(value: unknown): RunArchive {
+  const archive = isRecord(value) ? value : {}
+  const events = Array.isArray(archive.events) ? archive.events : []
+  return {
+    schemaVersion: 1,
+    kind: 'run-archive',
+    manifest: migrateManifest(archive.manifest),
+    events: events.map(migrateEvent),
+    artifacts: Array.isArray(archive.artifacts)
+      ? (archive.artifacts as RunArchiveArtifact[])
+      : [],
+  }
+}
+
+interface CollectedArtifact {
+  absolutePath: string
+  archivePath: string
+  mediaType?: string
+}
+
+function collectArtifacts(
+  manifest: TestRunManifest,
+  events: RunEvent[],
+  runDirectory: string,
+): CollectedArtifact[] {
+  const byAbsolute = new Map<string, CollectedArtifact>()
+  const consider = (path: string, mediaType: string | undefined): void => {
+    if (byAbsolute.has(path)) return
+    const archivePath = relative(runDirectory, path)
+    byAbsolute.set(path, {
+      absolutePath: path,
+      archivePath: archivePath.startsWith('..')
+        ? join('artifacts', path.split('/').at(-1) ?? 'artifact.bin')
+        : archivePath,
+      ...(mediaType ? { mediaType } : {}),
+    })
+  }
+
+  for (const result of manifest.results) {
+    for (const step of result.steps) {
+      for (const artifact of step.artifacts ?? []) {
+        consider(artifact.path, artifact.mediaType)
+      }
+    }
+  }
+  for (const event of events) {
+    if (event.type === 'scenario-finished') {
+      for (const step of event.result.steps) {
+        for (const artifact of step.artifacts ?? []) {
+          consider(artifact.path, artifact.mediaType)
+        }
+      }
+    }
+    if (event.type === 'step-finished') {
+      for (const artifact of event.result.artifacts ?? []) {
+        consider(artifact.path, artifact.mediaType)
+      }
+    }
+  }
+  return [...byAbsolute.values()]
+}
+
+function remapArtifactPath(
+  path: string,
+  pathMap: Map<string, string>,
+  runDirectory: string,
+): string {
+  return pathMap.get(path) ?? join(runDirectory, path)
+}
+
+function remapResult(
+  result: TestResult,
+  pathMap: Map<string, string>,
+  runDirectory: string,
+): TestResult {
+  return {
+    ...result,
+    steps: result.steps.map((step) => ({
+      ...step,
+      ...(step.artifacts
+        ? {
+            artifacts: step.artifacts.map((artifact) => ({
+              ...artifact,
+              path: remapArtifactPath(artifact.path, pathMap, runDirectory),
+            })),
+          }
+        : {}),
+    })),
+  }
+}
+
+export async function writeRunArchive(
+  input: WriteRunArchiveInput,
+): Promise<RunArchive> {
+  const store = openTestRunStore({ root: input.root })
+  const run = await store.open(input.runId)
+  const events = await run.events()
+  if (events.length === 0) {
+    throw new Error(`Unknown test run "${input.runId}"`)
+  }
+  const runDirectory = join(input.root, '.pickle', 'runs', input.runId)
+  const manifestPath = join(runDirectory, 'manifest.json')
+  const manifest = (await Bun.file(manifestPath).exists())
+    ? ((await Bun.file(manifestPath).json()) as TestRunManifest)
+    : await run.materialize({ finished: false })
+  const collected = collectArtifacts(manifest, events, runDirectory)
+  const artifacts: RunArchiveArtifact[] = []
+  for (const item of collected) {
+    if (!(await Bun.file(item.absolutePath).exists())) continue
+    const bytes = new Uint8Array(
+      await Bun.file(item.absolutePath).arrayBuffer(),
+    )
+    artifacts.push({
+      path: item.archivePath,
+      content: Buffer.from(bytes).toString('base64'),
+      ...(item.mediaType ? { mediaType: item.mediaType } : {}),
+    })
+  }
+
+  const pathMap = new Map(
+    collected.map((item) => [item.absolutePath, item.archivePath]),
+  )
+  const archivedManifest: TestRunManifest = {
+    ...manifest,
+    results: manifest.results.map((result) => ({
+      ...result,
+      steps: result.steps.map((step) => ({
+        ...step,
+        ...(step.artifacts
+          ? {
+              artifacts: step.artifacts.map((artifact) => ({
+                ...artifact,
+                path: pathMap.get(artifact.path) ?? artifact.path,
+              })),
+            }
+          : {}),
+      })),
+    })),
+  }
+  const archivedEvents = events.map((event) => {
+    if (event.type === 'scenario-finished') {
+      return {
+        ...event,
+        result: {
+          ...event.result,
+          steps: event.result.steps.map((step) => ({
+            ...step,
+            ...(step.artifacts
+              ? {
+                  artifacts: step.artifacts.map((artifact) => ({
+                    ...artifact,
+                    path: pathMap.get(artifact.path) ?? artifact.path,
+                  })),
+                }
+              : {}),
+          })),
+        },
+      }
+    }
+    if (event.type === 'step-finished' && event.result.artifacts) {
+      return {
+        ...event,
+        result: {
+          ...event.result,
+          artifacts: event.result.artifacts.map((artifact) => ({
+            ...artifact,
+            path: pathMap.get(artifact.path) ?? artifact.path,
+          })),
+        },
+      }
+    }
+    return event
+  })
+
+  const archive: RunArchive = {
+    schemaVersion: 1,
+    kind: 'run-archive',
+    manifest: archivedManifest,
+    events: archivedEvents,
+    artifacts,
+  }
+  await mkdir(dirname(input.outputPath), { recursive: true })
+  await Bun.write(input.outputPath, `${JSON.stringify(archive, null, 2)}\n`)
+  return archive
+}
+
+export async function readRunArchive(path: string): Promise<RunArchive> {
+  const parsed: unknown = JSON.parse(await Bun.file(path).text())
+  return migrateRunArchive(parsed)
+}
+
+export async function importRunArchive(
+  input: ImportRunArchiveInput,
+): Promise<ImportedRunArchive> {
+  const originalBytes = new Uint8Array(
+    await Bun.file(input.archivePath).arrayBuffer(),
+  )
+  const archive = migrateRunArchive(
+    JSON.parse(new TextDecoder().decode(originalBytes)),
+  )
+  const pickleDirectory = join(input.root, '.pickle')
+  const archivesDirectory = join(pickleDirectory, 'archives')
+  const runDirectory = join(pickleDirectory, 'runs', archive.manifest.id)
+  const preservedArchivePath = join(
+    archivesDirectory,
+    `${archive.manifest.id}.json`,
+  )
+  await mkdir(archivesDirectory, { recursive: true })
+  await mkdir(join(runDirectory, 'artifacts'), { recursive: true })
+  await Bun.write(preservedArchivePath, originalBytes)
+
+  const pathMap = new Map<string, string>()
+  for (const artifact of archive.artifacts) {
+    const target = join(runDirectory, artifact.path)
+    await mkdir(dirname(target), { recursive: true })
+    await Bun.write(target, Buffer.from(artifact.content, 'base64'))
+    pathMap.set(artifact.path, target)
+  }
+
+  const events = archive.events.map((event) => {
+    if (event.type === 'scenario-finished') {
+      return {
+        ...event,
+        result: remapResult(event.result, pathMap, runDirectory),
+      }
+    }
+    if (event.type === 'step-finished') {
+      return {
+        ...event,
+        result: {
+          ...event.result,
+          ...(event.result.artifacts
+            ? {
+                artifacts: event.result.artifacts.map((artifact) => ({
+                  ...artifact,
+                  path: remapArtifactPath(artifact.path, pathMap, runDirectory),
+                })),
+              }
+            : {}),
+        },
+      }
+    }
+    return event
+  })
+  const manifest: TestRunManifest = {
+    ...archive.manifest,
+    results: archive.manifest.results.map((result) =>
+      remapResult(result, pathMap, runDirectory),
+    ),
+  }
+
+  await Bun.write(
+    join(runDirectory, 'events.ndjson'),
+    `${events.map((event) => JSON.stringify(event)).join('\n')}\n`,
+  )
+  await Bun.write(
+    join(runDirectory, 'manifest.json'),
+    `${JSON.stringify(manifest, null, 2)}\n`,
+  )
+
+  await openTestRunStore({ root: input.root }).rebuildIndex()
+
+  return {
+    manifest,
+    events,
+    preservedArchivePath,
+  }
+}

--- a/packages/runner/src/archive.ts
+++ b/packages/runner/src/archive.ts
@@ -1,5 +1,5 @@
 import { mkdir } from 'node:fs/promises'
-import { dirname, join, relative } from 'node:path'
+import { basename, dirname, join, relative } from 'node:path'
 import type { RunEvent, TestResult, TestStepResult } from './run-scenario'
 import { openTestRunStore, type TestRunManifest } from './test-run-store'
 
@@ -142,91 +142,90 @@ interface CollectedArtifact {
 }
 
 function collectArtifacts(
-  manifest: TestRunManifest,
-  events: RunEvent[],
+  results: readonly TestResult[],
   runDirectory: string,
 ): CollectedArtifact[] {
   const byAbsolute = new Map<string, CollectedArtifact>()
-  const consider = (path: string, mediaType: string | undefined): void => {
-    if (byAbsolute.has(path)) return
-    const archivePath = relative(runDirectory, path)
-    byAbsolute.set(path, {
-      absolutePath: path,
-      archivePath: archivePath.startsWith('..')
-        ? join('artifacts', path.split('/').at(-1) ?? 'artifact.bin')
-        : archivePath,
-      ...(mediaType ? { mediaType } : {}),
-    })
-  }
-
-  for (const result of manifest.results) {
+  for (const result of results) {
     for (const step of result.steps) {
       for (const artifact of step.artifacts ?? []) {
-        consider(artifact.path, artifact.mediaType)
-      }
-    }
-  }
-  for (const event of events) {
-    if (event.type === 'scenario-finished') {
-      for (const step of event.result.steps) {
-        for (const artifact of step.artifacts ?? []) {
-          consider(artifact.path, artifact.mediaType)
-        }
-      }
-    }
-    if (event.type === 'step-finished') {
-      for (const artifact of event.result.artifacts ?? []) {
-        consider(artifact.path, artifact.mediaType)
+        if (byAbsolute.has(artifact.path)) continue
+        const archivePath = relative(runDirectory, artifact.path)
+        byAbsolute.set(artifact.path, {
+          absolutePath: artifact.path,
+          archivePath: archivePath.startsWith('..')
+            ? join('artifacts', basename(artifact.path))
+            : archivePath,
+          ...(artifact.mediaType ? { mediaType: artifact.mediaType } : {}),
+        })
       }
     }
   }
   return [...byAbsolute.values()]
 }
 
-function remapArtifactPath(
-  path: string,
-  pathMap: Map<string, string>,
-  runDirectory: string,
-): string {
-  return pathMap.get(path) ?? join(runDirectory, path)
+function mapStepArtifacts(
+  step: TestStepResult,
+  mapPath: (path: string) => string,
+): TestStepResult {
+  if (!step.artifacts) return step
+  return {
+    ...step,
+    artifacts: step.artifacts.map((artifact) => ({
+      ...artifact,
+      path: mapPath(artifact.path),
+    })),
+  }
 }
 
-function remapResult(
+function mapResultArtifacts(
   result: TestResult,
-  pathMap: Map<string, string>,
-  runDirectory: string,
+  mapPath: (path: string) => string,
 ): TestResult {
   return {
     ...result,
-    steps: result.steps.map((step) => ({
-      ...step,
-      ...(step.artifacts
-        ? {
-            artifacts: step.artifacts.map((artifact) => ({
-              ...artifact,
-              path: remapArtifactPath(artifact.path, pathMap, runDirectory),
-            })),
-          }
-        : {}),
-    })),
+    steps: result.steps.map((step) => mapStepArtifacts(step, mapPath)),
   }
+}
+
+function mapEventArtifacts(
+  event: RunEvent,
+  mapPath: (path: string) => string,
+): RunEvent {
+  if (event.type === 'scenario-finished') {
+    return { ...event, result: mapResultArtifacts(event.result, mapPath) }
+  }
+  if (event.type === 'step-finished') {
+    return { ...event, result: mapStepArtifacts(event.result, mapPath) }
+  }
+  return event
+}
+
+async function loadRunFiles(root: string, runId: string) {
+  const store = openTestRunStore({ root })
+  const run = await store.open(runId)
+  const events = await run.events()
+  if (events.length === 0) throw new Error(`Unknown test run "${runId}"`)
+  const runDirectory = join(root, '.pickle', 'runs', runId)
+  const manifestPath = join(runDirectory, 'manifest.json')
+  const manifest = (await Bun.file(manifestPath).exists())
+    ? ((await Bun.file(manifestPath).json()) as TestRunManifest)
+    : await run.materialize({ finished: false })
+  return { runDirectory, manifest, events }
 }
 
 export async function writeRunArchive(
   input: WriteRunArchiveInput,
 ): Promise<RunArchive> {
-  const store = openTestRunStore({ root: input.root })
-  const run = await store.open(input.runId)
-  const events = await run.events()
-  if (events.length === 0) {
-    throw new Error(`Unknown test run "${input.runId}"`)
-  }
-  const runDirectory = join(input.root, '.pickle', 'runs', input.runId)
-  const manifestPath = join(runDirectory, 'manifest.json')
-  const manifest = (await Bun.file(manifestPath).exists())
-    ? ((await Bun.file(manifestPath).json()) as TestRunManifest)
-    : await run.materialize({ finished: false })
-  const collected = collectArtifacts(manifest, events, runDirectory)
+  const { runDirectory, manifest, events } = await loadRunFiles(
+    input.root,
+    input.runId,
+  )
+  const collected = collectArtifacts(manifest.results, runDirectory)
+  const pathMap = new Map(
+    collected.map((item) => [item.absolutePath, item.archivePath]),
+  )
+  const mapPath = (path: string) => pathMap.get(path) ?? path
   const artifacts: RunArchiveArtifact[] = []
   for (const item of collected) {
     if (!(await Bun.file(item.absolutePath).exists())) continue
@@ -240,66 +239,16 @@ export async function writeRunArchive(
     })
   }
 
-  const pathMap = new Map(
-    collected.map((item) => [item.absolutePath, item.archivePath]),
-  )
-  const archivedManifest: TestRunManifest = {
-    ...manifest,
-    results: manifest.results.map((result) => ({
-      ...result,
-      steps: result.steps.map((step) => ({
-        ...step,
-        ...(step.artifacts
-          ? {
-              artifacts: step.artifacts.map((artifact) => ({
-                ...artifact,
-                path: pathMap.get(artifact.path) ?? artifact.path,
-              })),
-            }
-          : {}),
-      })),
-    })),
-  }
-  const archivedEvents = events.map((event) => {
-    if (event.type === 'scenario-finished') {
-      return {
-        ...event,
-        result: {
-          ...event.result,
-          steps: event.result.steps.map((step) => ({
-            ...step,
-            ...(step.artifacts
-              ? {
-                  artifacts: step.artifacts.map((artifact) => ({
-                    ...artifact,
-                    path: pathMap.get(artifact.path) ?? artifact.path,
-                  })),
-                }
-              : {}),
-          })),
-        },
-      }
-    }
-    if (event.type === 'step-finished' && event.result.artifacts) {
-      return {
-        ...event,
-        result: {
-          ...event.result,
-          artifacts: event.result.artifacts.map((artifact) => ({
-            ...artifact,
-            path: pathMap.get(artifact.path) ?? artifact.path,
-          })),
-        },
-      }
-    }
-    return event
-  })
-
   const archive: RunArchive = {
     schemaVersion: 1,
     kind: 'run-archive',
-    manifest: archivedManifest,
-    events: archivedEvents,
+    manifest: {
+      ...manifest,
+      results: manifest.results.map((result) =>
+        mapResultArtifacts(result, mapPath),
+      ),
+    },
+    events: events.map((event) => mapEventArtifacts(event, mapPath)),
     artifacts,
   }
   await mkdir(dirname(input.outputPath), { recursive: true })
@@ -339,36 +288,15 @@ export async function importRunArchive(
     await Bun.write(target, Buffer.from(artifact.content, 'base64'))
     pathMap.set(artifact.path, target)
   }
-
-  const events = archive.events.map((event) => {
-    if (event.type === 'scenario-finished') {
-      return {
-        ...event,
-        result: remapResult(event.result, pathMap, runDirectory),
-      }
-    }
-    if (event.type === 'step-finished') {
-      return {
-        ...event,
-        result: {
-          ...event.result,
-          ...(event.result.artifacts
-            ? {
-                artifacts: event.result.artifacts.map((artifact) => ({
-                  ...artifact,
-                  path: remapArtifactPath(artifact.path, pathMap, runDirectory),
-                })),
-              }
-            : {}),
-        },
-      }
-    }
-    return event
-  })
+  const mapPath = (path: string) =>
+    pathMap.get(path) ?? join(runDirectory, path)
+  const events = archive.events.map((event) =>
+    mapEventArtifacts(event, mapPath),
+  )
   const manifest: TestRunManifest = {
     ...archive.manifest,
     results: archive.manifest.results.map((result) =>
-      remapResult(result, pathMap, runDirectory),
+      mapResultArtifacts(result, mapPath),
     ),
   }
 
@@ -380,12 +308,7 @@ export async function importRunArchive(
     join(runDirectory, 'manifest.json'),
     `${JSON.stringify(manifest, null, 2)}\n`,
   )
-
   await openTestRunStore({ root: input.root }).rebuildIndex()
 
-  return {
-    manifest,
-    events,
-    preservedArchivePath,
-  }
+  return { manifest, events, preservedArchivePath }
 }

--- a/packages/runner/src/compare.test.ts
+++ b/packages/runner/src/compare.test.ts
@@ -1,0 +1,152 @@
+import { expect, test } from 'bun:test'
+import { compareTestRuns } from '../index'
+import type { TestResult } from './run-scenario'
+import type { TestRunManifest } from './test-run-store'
+
+function result(
+  name: string,
+  state: TestResult['state'],
+  extras: Partial<TestResult> = {},
+): TestResult {
+  return {
+    schemaVersion: 1,
+    specification: {
+      name: 'Checkout',
+      uri: 'features/checkout.feature',
+    },
+    scenario: { name, id: `scn-${name.replace(/\s+/g, '-').toLowerCase()}` },
+    executionTargetProfile: { id: 'web' },
+    state,
+    steps: [
+      {
+        step: {
+          keyword: 'Then',
+          text: 'the purchase succeeds',
+          type: 'outcome',
+        },
+        state,
+        resolvedActions: [{ description: 'Click purchase' }],
+      },
+    ],
+    durationMs: 100,
+    executionMode: 'replay',
+    ...extras,
+  }
+}
+
+const baseline: TestRunManifest = {
+  schemaVersion: 1,
+  id: 'run-baseline',
+  startedAt: '2026-08-15T12:00:00.000Z',
+  finishedAt: '2026-08-15T12:01:00.000Z',
+  state: 'failed',
+  results: [
+    result('Complete a purchase', 'passed'),
+    result('Pay for the order', 'failed', { durationMs: 200 }),
+    result('Skip the purchase', 'skipped'),
+  ],
+}
+
+test('compareTestRuns matches results by Scenario and execution target profile identifiers', () => {
+  const candidate: TestRunManifest = {
+    ...baseline,
+    id: 'run-candidate',
+    results: [
+      result('Complete a purchase', 'passed', { durationMs: 150, flaky: true }),
+      result('Pay for the order', 'passed-with-adaptation', {
+        durationMs: 200,
+        executionMode: 'adaptive',
+        steps: [
+          {
+            step: {
+              keyword: 'Then',
+              text: 'the purchase succeeds',
+              type: 'outcome',
+            },
+            state: 'passed-with-adaptation',
+            resolvedActions: [{ description: 'Click buy now' }],
+            artifacts: [
+              {
+                kind: 'screenshot',
+                path: '.pickle/runs/run-candidate/artifacts/pay.png',
+                mediaType: 'image/png',
+              },
+            ],
+          },
+        ],
+      }),
+      result('Mobile purchase', 'passed', {
+        executionTargetProfile: { id: 'android' },
+      }),
+    ],
+  }
+
+  expect(compareTestRuns(baseline, candidate)).toEqual({
+    schemaVersion: 1,
+    baselineRunId: 'run-baseline',
+    candidateRunId: 'run-candidate',
+    pairs: [
+      {
+        scenarioId: 'scn-complete-a-purchase',
+        executionTargetProfileId: 'web',
+        baseline: baseline.results[0]!,
+        candidate: candidate.results[0]!,
+        changes: ['duration', 'flaky'],
+      },
+      {
+        scenarioId: 'scn-pay-for-the-order',
+        executionTargetProfileId: 'web',
+        baseline: baseline.results[1]!,
+        candidate: candidate.results[1]!,
+        changes: ['state', 'adaptation', 'plan', 'artifacts'],
+      },
+    ],
+    removed: [
+      {
+        scenarioId: 'scn-skip-the-purchase',
+        executionTargetProfileId: 'web',
+        result: baseline.results[2]!,
+      },
+    ],
+    added: [
+      {
+        scenarioId: 'scn-mobile-purchase',
+        executionTargetProfileId: 'android',
+        result: candidate.results[2]!,
+      },
+    ],
+  })
+})
+
+test('compareTestRuns falls back to Scenario name when identifiers are absent', () => {
+  const olderBaseline: TestRunManifest = {
+    schemaVersion: 1,
+    id: 'run-old',
+    startedAt: '2026-08-15T12:00:00.000Z',
+    state: 'passed',
+    results: [
+      {
+        ...result('Complete a purchase', 'passed'),
+        scenario: { name: 'Complete a purchase' },
+        durationMs: undefined,
+      },
+    ],
+  }
+  const candidate: TestRunManifest = {
+    schemaVersion: 1,
+    id: 'run-new',
+    startedAt: '2026-08-15T12:00:00.000Z',
+    state: 'failed',
+    results: [result('Complete a purchase', 'failed')],
+  }
+
+  expect(compareTestRuns(olderBaseline, candidate)).toMatchObject({
+    pairs: [
+      {
+        scenarioId: 'Complete a purchase',
+        executionTargetProfileId: 'web',
+        changes: ['state'],
+      },
+    ],
+  })
+})

--- a/packages/runner/src/compare.ts
+++ b/packages/runner/src/compare.ts
@@ -1,0 +1,154 @@
+import type { TestResult } from './run-scenario'
+import type { TestRunManifest } from './test-run-store'
+
+export type ResultChangeKind =
+  | 'state'
+  | 'duration'
+  | 'flaky'
+  | 'adaptation'
+  | 'plan'
+  | 'artifacts'
+
+export interface ComparedResultPair {
+  scenarioId: string
+  executionTargetProfileId: string
+  baseline: TestResult
+  candidate: TestResult
+  changes: ResultChangeKind[]
+}
+
+export interface ComparedResultSide {
+  scenarioId: string
+  executionTargetProfileId: string
+  result: TestResult
+}
+
+export interface TestRunComparison {
+  schemaVersion: 1
+  baselineRunId: string
+  candidateRunId: string
+  pairs: ComparedResultPair[]
+  removed: ComparedResultSide[]
+  added: ComparedResultSide[]
+}
+
+function scenarioIdOf(result: TestResult): string {
+  return result.scenario.id ?? result.scenario.name
+}
+
+function identityKeys(result: TestResult): string[] {
+  const profileId = result.executionTargetProfile.id
+  const keys = [`name:${result.scenario.name}::${profileId}`]
+  if (result.scenario.id) {
+    keys.unshift(`id:${result.scenario.id}::${profileId}`)
+  }
+  return keys
+}
+
+function artifactSignature(result: TestResult): string {
+  return JSON.stringify(
+    result.steps.flatMap((step) =>
+      (step.artifacts ?? []).map((artifact) => ({
+        kind: artifact.kind,
+        path: artifact.path,
+      })),
+    ),
+  )
+}
+
+function planSignature(result: TestResult): string {
+  return JSON.stringify({
+    executionMode: result.executionMode,
+    steps: result.steps.map((step) => step.resolvedActions),
+  })
+}
+
+function changesBetween(
+  baseline: TestResult,
+  candidate: TestResult,
+): ResultChangeKind[] {
+  const changes: ResultChangeKind[] = []
+  if (baseline.state !== candidate.state) changes.push('state')
+  if (
+    baseline.durationMs !== undefined &&
+    candidate.durationMs !== undefined &&
+    baseline.durationMs !== candidate.durationMs
+  ) {
+    changes.push('duration')
+  }
+  if (Boolean(baseline.flaky) !== Boolean(candidate.flaky)) {
+    changes.push('flaky')
+  }
+  const baselineAdapted = baseline.state === 'passed-with-adaptation'
+  const candidateAdapted = candidate.state === 'passed-with-adaptation'
+  if (baselineAdapted !== candidateAdapted) changes.push('adaptation')
+  if (planSignature(baseline) !== planSignature(candidate)) {
+    changes.push('plan')
+  }
+  if (artifactSignature(baseline) !== artifactSignature(candidate)) {
+    changes.push('artifacts')
+  }
+  return changes
+}
+
+function findMatch(
+  available: Map<TestResult, string[]>,
+  candidate: TestResult,
+): TestResult | undefined {
+  const candidateKeys = new Set(identityKeys(candidate))
+  for (const [baseline, keys] of available) {
+    if (keys.some((key) => candidateKeys.has(key))) {
+      available.delete(baseline)
+      return baseline
+    }
+  }
+  return undefined
+}
+
+export function compareTestRuns(
+  baseline: TestRunManifest,
+  candidate: TestRunManifest,
+): TestRunComparison {
+  const available = new Map(
+    baseline.results.map((result) => [result, identityKeys(result)] as const),
+  )
+  const pairs: ComparedResultPair[] = []
+  const added: ComparedResultSide[] = []
+
+  for (const candidateResult of candidate.results) {
+    const baselineResult = findMatch(available, candidateResult)
+    if (!baselineResult) {
+      added.push({
+        scenarioId: scenarioIdOf(candidateResult),
+        executionTargetProfileId: candidateResult.executionTargetProfile.id,
+        result: candidateResult,
+      })
+      continue
+    }
+    const changes = changesBetween(baselineResult, candidateResult)
+    if (changes.length > 0) {
+      pairs.push({
+        scenarioId: scenarioIdOf(baselineResult),
+        executionTargetProfileId: baselineResult.executionTargetProfile.id,
+        baseline: baselineResult,
+        candidate: candidateResult,
+        changes,
+      })
+    }
+  }
+
+  const removed: ComparedResultSide[] = [...available.keys()].map((result) => ({
+    scenarioId: scenarioIdOf(result),
+    executionTargetProfileId: result.executionTargetProfile.id,
+    result,
+  }))
+
+  return {
+    schemaVersion: 1,
+    baselineRunId: baseline.id,
+    candidateRunId: candidate.id,
+    pairs,
+    removed,
+    added,
+  }
+}

--- a/packages/runner/src/outputs-html.test.ts
+++ b/packages/runner/src/outputs-html.test.ts
@@ -1,0 +1,168 @@
+import { expect, test } from 'bun:test'
+import { mkdir, mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { dirname, join } from 'node:path'
+import { formatHtml } from '../index'
+import type { RunEvent, TestResult } from './run-scenario'
+import type { TestRunManifest } from './test-run-store'
+
+async function withArtifact(
+  use: (path: string) => Promise<void>,
+): Promise<void> {
+  const root = await mkdtemp(join(tmpdir(), 'pickle-html-'))
+  try {
+    await mkdir(join(root, 'artifacts'), { recursive: true })
+    const path = join(root, 'artifacts', 'failure.png')
+    await Bun.write(path, 'png-bytes')
+    await use(path)
+  } finally {
+    await rm(root, { recursive: true, force: true })
+  }
+}
+
+function result(
+  name: string,
+  state: TestResult['state'],
+  extras: Partial<TestResult> = {},
+): TestResult {
+  return {
+    schemaVersion: 1,
+    specification: {
+      name: 'Checkout',
+      uri: 'features/checkout.feature',
+    },
+    scenario: { name, id: `scn-${name}` },
+    executionTargetProfile: { id: 'web' },
+    state,
+    steps: [],
+    ...extras,
+  }
+}
+
+test('formatHtml includes failure and adaptation artifacts by default', async () => {
+  await withArtifact(async (failurePath) => {
+    const passedPath = join(dirname(failurePath), 'passed.png')
+    await Bun.write(passedPath, 'passed-bytes')
+    const manifest: TestRunManifest = {
+      schemaVersion: 1,
+      id: 'run-html',
+      startedAt: '2026-08-15T12:00:00.000Z',
+      finishedAt: '2026-08-15T12:01:00.000Z',
+      state: 'failed',
+      results: [
+        result('Complete a purchase', 'passed', {
+          steps: [
+            {
+              step: {
+                keyword: 'Then',
+                text: 'ok',
+                type: 'outcome',
+              },
+              state: 'passed',
+              resolvedActions: [],
+              artifacts: [
+                {
+                  kind: 'screenshot',
+                  path: passedPath,
+                  mediaType: 'image/png',
+                },
+              ],
+            },
+          ],
+        }),
+        result('Pay for the order', 'failed', {
+          steps: [
+            {
+              step: {
+                keyword: 'Then',
+                text: 'pay',
+                type: 'outcome',
+              },
+              state: 'failed',
+              resolvedActions: [],
+              artifacts: [
+                {
+                  kind: 'screenshot',
+                  path: failurePath,
+                  mediaType: 'image/png',
+                },
+              ],
+            },
+          ],
+        }),
+        result('Adapt the purchase', 'passed-with-adaptation'),
+      ],
+    }
+    const events: RunEvent[] = []
+    const html = await formatHtml(manifest, events)
+
+    expect(html).toContain('<!DOCTYPE html>')
+    expect(html).toContain('Pay for the order')
+    expect(html).toContain('Adapt the purchase')
+    expect(html.indexOf('Pay for the order')).toBeLessThan(
+      html.indexOf('Complete a purchase'),
+    )
+    expect(html).toContain('data:image/png;base64,')
+    expect(html).toContain(Buffer.from('png-bytes').toString('base64'))
+    expect(html).not.toContain(Buffer.from('passed-bytes').toString('base64'))
+  })
+})
+
+test('formatHtml can include every available test artifact', async () => {
+  await withArtifact(async (failurePath) => {
+    const passedPath = join(dirname(failurePath), 'passed.png')
+    await Bun.write(passedPath, 'passed-bytes')
+    const manifest: TestRunManifest = {
+      schemaVersion: 1,
+      id: 'run-html-all',
+      startedAt: '2026-08-15T12:00:00.000Z',
+      state: 'failed',
+      results: [
+        result('Complete a purchase', 'passed', {
+          steps: [
+            {
+              step: {
+                keyword: 'Then',
+                text: 'ok',
+                type: 'outcome',
+              },
+              state: 'passed',
+              resolvedActions: [],
+              artifacts: [
+                {
+                  kind: 'screenshot',
+                  path: passedPath,
+                  mediaType: 'image/png',
+                },
+              ],
+            },
+          ],
+        }),
+        result('Pay for the order', 'failed', {
+          steps: [
+            {
+              step: {
+                keyword: 'Then',
+                text: 'pay',
+                type: 'outcome',
+              },
+              state: 'failed',
+              resolvedActions: [],
+              artifacts: [
+                {
+                  kind: 'screenshot',
+                  path: failurePath,
+                  mediaType: 'image/png',
+                },
+              ],
+            },
+          ],
+        }),
+      ],
+    }
+
+    const html = await formatHtml(manifest, [], { artifacts: 'all' })
+    expect(html).toContain(Buffer.from('png-bytes').toString('base64'))
+    expect(html).toContain(Buffer.from('passed-bytes').toString('base64'))
+  })
+})

--- a/packages/runner/src/outputs.ts
+++ b/packages/runner/src/outputs.ts
@@ -9,6 +9,111 @@ export function formatNdjson(events: readonly RunEvent[]): string {
   return `${events.map((event) => JSON.stringify(event)).join('\n')}\n`
 }
 
+export type HtmlArtifactMode = 'failures-and-adaptations' | 'all'
+
+export interface FormatHtmlOptions {
+  artifacts?: HtmlArtifactMode
+}
+
+const priorityStates = new Set<TestResultState>([
+  'failed',
+  'infrastructure-error',
+  'passed-with-adaptation',
+  'cancelled',
+])
+
+function shouldEmbedArtifacts(
+  state: TestResultState,
+  mode: HtmlArtifactMode,
+): boolean {
+  if (mode === 'all') return true
+  return (
+    state === 'failed' ||
+    state === 'passed-with-adaptation' ||
+    state === 'infrastructure-error'
+  )
+}
+
+function resultPriority(state: TestResultState): number {
+  if (state === 'failed' || state === 'infrastructure-error') return 0
+  if (state === 'passed-with-adaptation') return 1
+  if (state === 'cancelled') return 2
+  if (state === 'skipped') return 4
+  return 3
+}
+
+async function embedArtifacts(
+  result: TestResult,
+  mode: HtmlArtifactMode,
+): Promise<string> {
+  if (!shouldEmbedArtifacts(result.state, mode)) return ''
+  const parts: string[] = []
+  for (const step of result.steps) {
+    for (const artifact of step.artifacts ?? []) {
+      if (!(await Bun.file(artifact.path).exists())) continue
+      const bytes = Buffer.from(await Bun.file(artifact.path).arrayBuffer())
+      const mediaType = artifact.mediaType ?? 'application/octet-stream'
+      const href = `data:${mediaType};base64,${bytes.toString('base64')}`
+      if (mediaType.startsWith('image/')) {
+        parts.push(
+          `<figure><img alt="${escapeXml(artifact.kind)}" src="${href}"/></figure>`,
+        )
+      } else {
+        parts.push(`<p><a href="${href}">${escapeXml(artifact.kind)}</a></p>`)
+      }
+    }
+  }
+  return parts.join('\n')
+}
+
+export async function formatHtml(
+  manifest: TestRunManifest,
+  _events: readonly RunEvent[],
+  options: FormatHtmlOptions = {},
+): Promise<string> {
+  const mode = options.artifacts ?? 'failures-and-adaptations'
+  const results = [...manifest.results].sort(
+    (left, right) =>
+      resultPriority(left.state) - resultPriority(right.state) ||
+      left.scenario.name.localeCompare(right.scenario.name),
+  )
+  const sections = await Promise.all(
+    results.map(async (result) => {
+      const artifacts = await embedArtifacts(result, mode)
+      const highlight = priorityStates.has(result.state)
+        ? ' class="priority"'
+        : ''
+      return `<section${highlight}>
+  <h2>${escapeXml(result.scenario.name)}</h2>
+  <p>State: ${escapeXml(result.state)}</p>
+  <p>Profile: ${escapeXml(result.executionTargetProfile.id)}</p>
+  ${result.message ? `<p>${escapeXml(result.message)}</p>` : ''}
+  ${artifacts}
+</section>`
+    }),
+  )
+
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8"/>
+  <title>Test run ${escapeXml(manifest.id)}</title>
+  <style>
+    body { font-family: sans-serif; margin: 2rem; }
+    section { border: 1px solid #ddd; padding: 1rem; margin-bottom: 1rem; }
+    section.priority { border-color: #b00; }
+    img { max-width: 100%; }
+  </style>
+</head>
+<body>
+  <h1>Test run ${escapeXml(manifest.id)}</h1>
+  <p>State: ${escapeXml(manifest.state)}</p>
+  ${sections.join('\n')}
+</body>
+</html>
+`
+}
+
 export function formatJunit(manifest: TestRunManifest): string {
   const suites = new Map<string, TestResult[]>()
   for (const result of manifest.results) {

--- a/packages/runner/src/rerun.test.ts
+++ b/packages/runner/src/rerun.test.ts
@@ -1,0 +1,93 @@
+import { expect, test } from 'bun:test'
+import { selectRerunResults } from '../index'
+import type { TestResult } from './run-scenario'
+import type { TestRunManifest } from './test-run-store'
+
+function result(
+  name: string,
+  state: TestResult['state'],
+  extras: Partial<TestResult> = {},
+): TestResult {
+  return {
+    schemaVersion: 1,
+    specification: {
+      name: 'Checkout',
+      uri: 'features/checkout.feature',
+    },
+    scenario: { name, id: `scn-${name.replace(/\s+/g, '-').toLowerCase()}` },
+    executionTargetProfile: { id: 'web' },
+    state,
+    steps: [],
+    durationMs: 100,
+    ...extras,
+  }
+}
+
+const manifest: TestRunManifest = {
+  schemaVersion: 1,
+  id: 'run-source',
+  startedAt: '2026-08-15T12:00:00.000Z',
+  finishedAt: '2026-08-15T12:01:00.000Z',
+  state: 'failed',
+  results: [
+    result('Complete a purchase', 'passed'),
+    result('Adapt the purchase', 'passed-with-adaptation'),
+    result('Pay for the order', 'failed'),
+    result('Retry the purchase', 'infrastructure-error'),
+    result('Mobile purchase', 'failed', {
+      executionTargetProfile: { id: 'android' },
+    }),
+  ],
+}
+
+test('selectRerunResults returns every result when no filter is provided', () => {
+  expect(selectRerunResults(manifest, {})).toEqual(manifest.results)
+})
+
+test('selectRerunResults selects failures and adaptations', () => {
+  expect(
+    selectRerunResults(manifest, { failures: true }).map(
+      (item) => item.scenario.name,
+    ),
+  ).toEqual(['Pay for the order', 'Retry the purchase', 'Mobile purchase'])
+
+  expect(
+    selectRerunResults(manifest, { adaptations: true }).map(
+      (item) => item.scenario.name,
+    ),
+  ).toEqual(['Adapt the purchase'])
+
+  expect(
+    selectRerunResults(manifest, { failures: true, adaptations: true }).map(
+      (item) => item.scenario.name,
+    ),
+  ).toEqual([
+    'Adapt the purchase',
+    'Pay for the order',
+    'Retry the purchase',
+    'Mobile purchase',
+  ])
+})
+
+test('selectRerunResults intersects state filters with Scenario and profile identifiers', () => {
+  expect(
+    selectRerunResults(manifest, {
+      failures: true,
+      scenarioIds: ['scn-pay-for-the-order'],
+    }).map((item) => item.scenario.name),
+  ).toEqual(['Pay for the order'])
+
+  expect(
+    selectRerunResults(manifest, {
+      failures: true,
+      profileIds: ['android'],
+    }).map((item) => item.scenario.name),
+  ).toEqual(['Mobile purchase'])
+
+  expect(
+    selectRerunResults(manifest, {
+      scenarioNames: ['Complete a purchase'],
+      profileIds: ['web'],
+    }).map((item) => item.scenario.name),
+  ).toEqual(['Complete a purchase'])
+})

--- a/packages/runner/src/rerun.ts
+++ b/packages/runner/src/rerun.ts
@@ -1,0 +1,52 @@
+import type { TestResult, TestResultState } from './run-scenario'
+import type { TestRunManifest } from './test-run-store'
+
+export interface RerunFilter {
+  failures?: boolean
+  adaptations?: boolean
+  scenarioIds?: readonly string[]
+  scenarioNames?: readonly string[]
+  profileIds?: readonly string[]
+}
+
+const failureStates = new Set<TestResultState>([
+  'failed',
+  'infrastructure-error',
+])
+
+export function selectRerunResults(
+  manifest: TestRunManifest,
+  filter: RerunFilter,
+): TestResult[] {
+  const hasStateFilter = Boolean(filter.failures || filter.adaptations)
+  const scenarioIds = filter.scenarioIds
+    ? new Set(filter.scenarioIds)
+    : undefined
+  const scenarioNames = filter.scenarioNames
+    ? new Set(filter.scenarioNames)
+    : undefined
+  const profileIds = filter.profileIds ? new Set(filter.profileIds) : undefined
+
+  return manifest.results.filter((result) => {
+    if (hasStateFilter) {
+      const matchesFailure =
+        filter.failures === true && failureStates.has(result.state)
+      const matchesAdaptation =
+        filter.adaptations === true && result.state === 'passed-with-adaptation'
+      if (!matchesFailure && !matchesAdaptation) return false
+    }
+    if (
+      scenarioIds &&
+      (!result.scenario.id || !scenarioIds.has(result.scenario.id))
+    ) {
+      return false
+    }
+    if (scenarioNames && !scenarioNames.has(result.scenario.name)) {
+      return false
+    }
+    if (profileIds && !profileIds.has(result.executionTargetProfile.id)) {
+      return false
+    }
+    return true
+  })
+}

--- a/packages/runner/src/run-scenario.test.ts
+++ b/packages/runner/src/run-scenario.test.ts
@@ -66,7 +66,7 @@ describe('runScenario', () => {
       [1, 5, 'step-finished'],
       [1, 6, 'scenario-finished'],
     ])
-    expect(run.result).toEqual({
+    expect(run.result).toMatchObject({
       schemaVersion: 1,
       specification: {
         name: 'Checkout',
@@ -101,6 +101,8 @@ describe('runScenario', () => {
         },
       ],
     })
+    expect(run.result.scenario.id).toBeString()
+    expect(run.result.durationMs).toBeGreaterThanOrEqual(0)
     expect(close).toHaveBeenCalledTimes(1)
   })
 

--- a/packages/runner/src/run-scenario.ts
+++ b/packages/runner/src/run-scenario.ts
@@ -82,6 +82,7 @@ export interface TestResult {
   }
   scenario: {
     name: string
+    id?: string
   }
   executionTargetProfile: ExecutionTargetProfile
   state: TestResultState
@@ -90,6 +91,7 @@ export interface TestResult {
   message?: string
   attempts?: number
   flaky?: boolean
+  durationMs?: number
 }
 
 interface RunEventEnvelope {
@@ -98,7 +100,10 @@ interface RunEventEnvelope {
 }
 
 export type RunEventPayload =
-  | { type: 'run-started'; run: { id: string; startedAt: string } }
+  | {
+      type: 'run-started'
+      run: { id: string; startedAt: string; sourceRunId?: string }
+    }
   | { type: 'scenario-started'; scenario: TestResult['scenario'] }
   | { type: 'step-started'; step: ScenarioStep }
   | { type: 'step-finished'; result: TestStepResult }
@@ -281,19 +286,22 @@ function createTestResult(
   input: ScenarioAttemptInput,
   state: TestResultState,
   steps: TestStepResult[],
+  durationMs: number,
   message?: string,
 ): TestResult {
+  const scenarioId = planQuery(input).scenarioId
   return {
     schemaVersion: 1,
     specification: {
       name: input.specification.name,
       uri: input.specification.source.uri,
     },
-    scenario: { name: input.scenario.name },
+    scenario: { name: input.scenario.name, id: scenarioId },
     executionTargetProfile: input.executionTargetProfile,
     state,
     steps,
     executionMode: input.mode,
+    durationMs,
     ...(message !== undefined ? { message } : {}),
   }
 }
@@ -319,14 +327,23 @@ async function runScenarioAttempt(
     steps: TestStepResult[],
     message?: string,
   ): Promise<ScenarioRun> => {
-    const result = createTestResult(input, state, steps, message)
+    const result = createTestResult(
+      input,
+      state,
+      steps,
+      Math.max(0, Date.now() - scenarioStartedAt),
+      message,
+    )
     await emit({ type: 'scenario-finished', result })
     return { events, result }
   }
 
   await emit({
     type: 'scenario-started',
-    scenario: { name: input.scenario.name },
+    scenario: {
+      name: input.scenario.name,
+      id: planQuery(input).scenarioId,
+    },
   })
 
   if (input.scenario.tags.includes('@ignore')) {

--- a/packages/runner/src/test-run-store.test.ts
+++ b/packages/runner/src/test-run-store.test.ts
@@ -463,6 +463,52 @@ test('retention removes eligible local data without changing retained test runs'
   ])
 })
 
+test('a rerun creates a new test run with a source-run reference', async () => {
+  const root = await tempRoot()
+  let nextId = 1
+  const store = openTestRunStore({
+    root,
+    createId: () => `run-${nextId++}`,
+    now: () => new Date('2026-08-15T12:00:00.000Z'),
+  })
+  const source = await store.create()
+  await source.append({
+    type: 'scenario-finished',
+    result: passedResult(),
+  })
+  const sourceManifest = await source.materialize()
+  const sourceEvents = await Bun.file(
+    join(root, '.pickle', 'runs', source.id, 'events.ndjson'),
+  ).text()
+
+  const rerun = await store.create({ sourceRunId: source.id })
+  await rerun.append({
+    type: 'scenario-finished',
+    result: passedResult(),
+  })
+  const rerunManifest = await rerun.materialize()
+
+  expect(rerun.id).toBe('run-2')
+  expect(rerun.id).not.toBe(source.id)
+  expect(rerunManifest.sourceRunId).toBe(source.id)
+  expect(
+    (await rerun.events()).find((event) => event.type === 'run-started'),
+  ).toMatchObject({
+    type: 'run-started',
+    run: { id: 'run-2', sourceRunId: source.id },
+  })
+  expect(
+    await Bun.file(
+      join(root, '.pickle', 'runs', source.id, 'events.ndjson'),
+    ).text(),
+  ).toBe(sourceEvents)
+  expect(
+    await Bun.file(
+      join(root, '.pickle', 'runs', source.id, 'manifest.json'),
+    ).json(),
+  ).toEqual(sourceManifest)
+})
+
 test('retention evicts the oldest runs when stored bytes exceed the limit', async () => {
   const root = await tempRoot()
   let nextId = 1

--- a/packages/runner/src/test-run-store.ts
+++ b/packages/runner/src/test-run-store.ts
@@ -26,8 +26,13 @@ export interface TestRunManifest {
   id: string
   startedAt: string
   finishedAt?: string
+  sourceRunId?: string
   state: TestResultState
   results: TestResult[]
+}
+
+export interface CreateTestRunOptions {
+  sourceRunId?: string
 }
 
 export interface TestRunSummary {
@@ -55,7 +60,7 @@ export interface RetentionResult {
 }
 
 export interface TestRunStore {
-  create(): Promise<PersistedTestRun>
+  create(options?: CreateTestRunOptions): Promise<PersistedTestRun>
   open(id: string): Promise<PersistedTestRun>
   list(): Promise<TestRunSummary[]>
   rebuildIndex(): Promise<void>
@@ -91,7 +96,11 @@ export function openTestRunStore(options: TestRunStoreOptions): TestRunStore {
     withIndex(indexPath, (db) => upsertRun(db, manifest))
   }
 
-  function persistedRunFor(id: string, startedAt: string): PersistedTestRun {
+  function persistedRunFor(
+    id: string,
+    startedAt: string,
+    sourceRunId?: string,
+  ): PersistedTestRun {
     return persistedTestRun(
       id,
       join(runsDirectory, id),
@@ -99,12 +108,20 @@ export function openTestRunStore(options: TestRunStoreOptions): TestRunStore {
       now,
       artifactCapture,
       upsertManifest,
+      sourceRunId,
     )
   }
 
   async function openRun(id: string): Promise<PersistedTestRun> {
     const events = await readEvents(join(runsDirectory, id, 'events.ndjson'))
-    return persistedRunFor(id, startedAtFrom(events, now().toISOString()))
+    const started = events.find((event) => event.type === 'run-started')
+    const sourceRunId =
+      started?.type === 'run-started' ? started.run.sourceRunId : undefined
+    return persistedRunFor(
+      id,
+      startedAtFrom(events, now().toISOString()),
+      sourceRunId,
+    )
   }
 
   async function manifestFor(id: string): Promise<TestRunManifest> {
@@ -141,12 +158,19 @@ export function openTestRunStore(options: TestRunStoreOptions): TestRunStore {
   }
 
   return {
-    async create() {
+    async create(options: CreateTestRunOptions = {}) {
       const id = createId()
       const startedAt = now().toISOString()
       await mkdir(join(runsDirectory, id), { recursive: true })
-      const run = persistedRunFor(id, startedAt)
-      await run.append({ type: 'run-started', run: { id, startedAt } })
+      const run = persistedRunFor(id, startedAt, options.sourceRunId)
+      await run.append({
+        type: 'run-started',
+        run: {
+          id,
+          startedAt,
+          ...(options.sourceRunId ? { sourceRunId: options.sourceRunId } : {}),
+        },
+      })
       return run
     },
     open: openRun,
@@ -193,6 +217,7 @@ function persistedTestRun(
   now: () => Date,
   artifactCapture: ArtifactCapturePolicy,
   onMaterialize: (manifest: TestRunManifest) => Promise<void>,
+  sourceRunId?: string,
 ): PersistedTestRun {
   const eventsPath = join(directory, 'events.ndjson')
   const manifestPath = join(directory, 'manifest.json')
@@ -229,6 +254,7 @@ function persistedTestRun(
         ...(input?.finished === false
           ? {}
           : { finishedAt: now().toISOString() }),
+        ...(sourceRunId ? { sourceRunId } : {}),
         state: aggregateState(results),
         results,
       }


### PR DESCRIPTION
## Summary
- Add selective `pickle run --rerun` that creates a new immutable test run with `sourceRunId`, filtered by failures, adaptations, Scenarios, or profiles.
- Add portable run archives (`pickle export --archive` / `pickle import`) that preserve original bytes and migrate older schemas in memory.
- Add `pickle compare` and self-contained `pickle export --html` (failure/adaptation artifacts by default, `--all-artifacts` with a 10 MB size warning).

Closes #18

## Test plan
- [x] `bun run lint`
- [x] `bun run typecheck`
- [x] `bun run test`
- [ ] `pickle run --rerun <id> --failures` on a multi-scenario project
- [ ] `pickle export <id> --archive` then `pickle import` in another project
- [ ] `pickle compare` between baseline and candidate runs
- [ ] `pickle export <id> --html` and `--all-artifacts`


Made with [Cursor](https://cursor.com)