### PR TITLE
Pool isolated web sessions and schedule globally

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -29,6 +29,7 @@
         "@pickle-spec/web": "workspace:*",
         "@types/bun": "catalog:",
         "@typescript/typescript6": "catalog:",
+        "zod": "catalog:",
       },
       "devDependencies": {
         "typescript": "catalog:",
@@ -39,6 +40,7 @@
       "version": "1.0.2",
       "dependencies": {
         "@pickle-spec/spec": "workspace:*",
+        "zod": "catalog:",
       },
       "devDependencies": {
         "@types/bun": "catalog:",
@@ -51,6 +53,7 @@
       "dependencies": {
         "@cucumber/gherkin": "catalog:",
         "@cucumber/messages": "catalog:",
+        "zod": "catalog:",
       },
       "devDependencies": {
         "@types/bun": "catalog:",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -22,7 +22,8 @@
     "@pickle-spec/spec": "workspace:*",
     "@pickle-spec/web": "workspace:*",
     "@types/bun": "catalog:",
-    "@typescript/typescript6": "catalog:"
+    "@typescript/typescript6": "catalog:",
+    "zod": "catalog:"
   },
   "devDependencies": {
     "typescript": "catalog:"

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -302,6 +302,17 @@ function configuredRunExtensions(
   }
 }
 
+async function disposeAdapters(
+  targets: ReturnType<typeof resolveRunConfiguration>['targets'],
+): Promise<void> {
+  const seen = new Set<ExecutionTargetAdapter>()
+  for (const target of targets) {
+    if (seen.has(target.adapter)) continue
+    seen.add(target.adapter)
+    await target.adapter.dispose?.()
+  }
+}
+
 function scenarioSelectionId(selection: {
   specification: { source: { uri: string }; name: string }
   scenario: { name: string; id?: string; tags: string[] }
@@ -338,6 +349,9 @@ async function run(argv: string[]): Promise<number> {
   const onSigint = () => controller.abort()
   process.on('SIGINT', onSigint)
   let server: Awaited<ReturnType<typeof startServer>>
+  let resolvedConfiguration:
+    | ReturnType<typeof resolveRunConfiguration>
+    | undefined
 
   try {
     const specifications = await discoverSpecifications(
@@ -415,12 +429,13 @@ async function run(argv: string[]): Promise<number> {
       execution: {
         infrastructureRetries:
           args.retries ?? config.execution?.infrastructureRetries,
+        functionalRetries: config.execution?.functionalRetries,
         stepTimeoutMs: args.stepTimeoutMs ?? config.execution?.stepTimeoutMs,
         scenarioTimeoutMs:
           args.scenarioTimeoutMs ?? config.execution?.scenarioTimeoutMs,
       },
     }
-    const resolvedConfiguration = resolveRunConfiguration(
+    resolvedConfiguration = resolveRunConfiguration(
       runConfiguration,
       configuredRunExtensions(
         extensions,
@@ -504,6 +519,9 @@ async function run(argv: string[]): Promise<number> {
   } finally {
     process.off('SIGINT', onSigint)
     server?.stop()
+    if (resolvedConfiguration) {
+      await disposeAdapters(resolvedConfiguration.targets)
+    }
   }
 }
 

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -31,8 +31,18 @@ import {
   selectScenarios,
   validateSpecificationMetadata,
 } from '@pickle-spec/spec'
-import { createWebAdapter, type WebAdapterOptions } from '@pickle-spec/web'
-import { loadConfig, type PickleConfig, runConfigurationFrom } from './config'
+import {
+  createWebAdapter,
+  screenshotModes,
+  type WebAdapterOptions,
+} from '@pickle-spec/web'
+import {
+  defaultExtensionsFile,
+  defaultSpecificationGlob,
+  loadConfig,
+  type PickleConfig,
+  runConfigurationFrom,
+} from './config'
 import type { Extensions } from './extensions'
 import { checkProject, initializeProject, migrateProject } from './project'
 import { startServer } from './server'
@@ -60,6 +70,8 @@ interface RunArguments {
   failures?: boolean
   adaptations?: boolean
 }
+
+const dayMs = 24 * 60 * 60 * 1000
 
 function integer(value: string, flag: string, minimum: number): number {
   const parsed = Number(value)
@@ -150,7 +162,9 @@ function parseRunArguments(argv: string[]): RunArguments {
         break
       case '--screenshot': {
         const mode = valueAfter(argv, index++)
-        if (!['off', 'on-failure', 'on-step'].includes(mode)) {
+        if (
+          !screenshotModes.includes(mode as (typeof screenshotModes)[number])
+        ) {
           throw new Error('--screenshot requires off, on-failure, or on-step')
         }
         args.screenshotMode = mode as RunArguments['screenshotMode']
@@ -186,7 +200,7 @@ function parseRunArguments(argv: string[]): RunArguments {
 }
 
 async function loadExtensions(path?: string): Promise<Extensions> {
-  const selectedPath = path ?? 'pickle.extensions.ts'
+  const selectedPath = path ?? defaultExtensionsFile
   const absolutePath = resolve(selectedPath)
   if (!(await Bun.file(absolutePath).exists())) {
     if (!path) return {}
@@ -216,11 +230,7 @@ async function discoverSpecifications(
       source: await Bun.file(path).text(),
     })),
   )
-  try {
-    validateSpecificationMetadata(files, language)
-  } catch (error) {
-    console.error(error instanceof Error ? error.message : String(error))
-  }
+  validateSpecificationMetadata(files, language)
   return files.map((file) =>
     parseSpecification({
       source: file.source,
@@ -355,7 +365,7 @@ async function run(argv: string[]): Promise<number> {
 
   try {
     const specifications = await discoverSpecifications(
-      args.pattern ?? config.specifications ?? 'features/**/*.feature',
+      args.pattern ?? config.specifications ?? defaultSpecificationGlob,
       args.language ?? config.language,
     )
     const suiteSelection = args.suite ? config.suites?.[args.suite] : undefined
@@ -495,7 +505,7 @@ async function run(argv: string[]): Promise<number> {
     }
     await store.applyRetention({
       maxAgeMs: config.retention?.days
-        ? config.retention.days * 24 * 60 * 60 * 1000
+        ? config.retention.days * dayMs
         : undefined,
       maxBytes: config.retention?.maxBytes,
     })
@@ -667,8 +677,8 @@ async function exportRun(argv: string[]): Promise<number> {
     return 0
   }
 
-  const { manifest, events } = await loadPersistedRun(runId)
-  const html = await formatHtml(manifest, events, {
+  const { manifest } = await loadPersistedRun(runId)
+  const html = await formatHtml(manifest, {
     artifacts: allArtifacts ? 'all' : 'failures-and-adaptations',
   })
   const htmlBytes = Buffer.byteLength(html, 'utf8')

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -56,6 +56,7 @@ export interface PickleConfig {
   selection?: SelectionOptions
   execution?: {
     infrastructureRetries?: number
+    functionalRetries?: number
     scenarioTimeoutMs?: number
     stepTimeoutMs?: number
   }

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -1,18 +1,24 @@
-import { resolve } from 'node:path'
+import { join, resolve } from 'node:path'
 import {
   type ArtifactCapturePolicy,
+  type ExecutionSettings,
   type ExecutionTargetProfile,
+  executionSettingsSchema,
   type RunConfiguration,
-  validateRunConfiguration,
 } from '@pickle-spec/runner'
 import {
   type SelectionOptions,
-  validateSelectionOptions,
+  selectionOptionsSchema,
 } from '@pickle-spec/spec'
 import {
-  validateWebAdapterOptions,
   type WebAdapterOptions,
+  webAdapterOptionsSchema,
 } from '@pickle-spec/web'
+import { z } from 'zod'
+
+export const defaultConfigFile = 'pickle.config.jsonc'
+export const defaultExtensionsFile = 'pickle.extensions.ts'
+export const defaultSpecificationGlob = 'features/**/*.feature'
 
 export interface ServerConfig {
   command?: string
@@ -54,12 +60,7 @@ export interface PickleConfig {
   policy?: ProjectPolicy
   web?: WebAdapterOptions
   selection?: SelectionOptions
-  execution?: {
-    infrastructureRetries?: number
-    functionalRetries?: number
-    scenarioTimeoutMs?: number
-    stepTimeoutMs?: number
-  }
+  execution?: ExecutionSettings
   concurrency?: number
   server?: ServerConfig
   retention?: ProjectRetention
@@ -75,8 +76,8 @@ function toExecutionTargetProfile(
 ): ExecutionTargetProfile {
   return {
     id,
-    ...(profile.adapter ? { adapter: profile.adapter } : {}),
-    ...(profile.capabilities ? { capabilities: profile.capabilities } : {}),
+    adapter: profile.adapter,
+    capabilities: profile.capabilities,
   }
 }
 
@@ -120,247 +121,190 @@ export function runConfigurationFrom(
     executionTargetProfiles,
     concurrency: config.concurrency,
     execution: config.execution,
-    ...(config.applicationRevision
-      ? { applicationRevision: config.applicationRevision }
-      : {}),
+    applicationRevision: config.applicationRevision,
   }
 }
 
-function record(value: unknown, field: string): Record<string, unknown> {
-  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
-    throw new Error(`${field} must be an object`)
-  }
-  return value as Record<string, unknown>
+function parsed<T>(schema: z.ZodType<T>, value: unknown): T {
+  const result = schema.safeParse(value)
+  if (result.success) return result.data
+  throw new Error(result.error.issues[0]?.message ?? 'Invalid configuration')
 }
 
-function knownFields(
-  value: Record<string, unknown>,
-  fields: readonly string[],
-  parent: string,
-): void {
-  for (const field of Object.keys(value)) {
-    if (!fields.includes(field))
-      throw new Error(`${parent}.${field} is not supported`)
-  }
-}
-
-function optionalString(value: unknown, field: string): void {
-  if (value !== undefined && typeof value !== 'string') {
-    throw new Error(`${field} must be a string`)
-  }
-}
-
-function optionalPositiveInteger(value: unknown, field: string): void {
-  if (
-    value !== undefined &&
-    (!Number.isInteger(value) || (value as number) < 1)
-  ) {
-    throw new Error(`${field} must be an integer greater than or equal to 1`)
-  }
-}
-
-function validateCapabilities(
-  value: unknown,
+function strictObject<Shape extends z.ZodRawShape>(
   field: string,
-): readonly string[] {
-  if (!Array.isArray(value) || value.length === 0) {
-    throw new Error(`${field} must contain at least one capability`)
-  }
-  if (!value.every((item) => typeof item === 'string' && item.trim())) {
-    throw new Error(`${field} must not contain an empty capability`)
-  }
-  return value
+  shape: Shape,
+) {
+  return z.strictObject(shape, {
+    error: (issue) => {
+      if (issue.code === 'unrecognized_keys') {
+        const keys = 'keys' in issue ? (issue.keys as string[]) : []
+        return keys.map((key) => `${field}.${key} is not supported`).join('\n')
+      }
+      return `${field} must be an object`
+    },
+  })
 }
 
-function validateSuites(value: unknown): Record<string, SelectionOptions> {
-  const suites = record(value, 'suites')
-  const result: Record<string, SelectionOptions> = {}
-  for (const [name, query] of Object.entries(suites)) {
-    if (!name.trim()) throw new Error('suites keys must not be empty')
-    const options = validateSelectionOptions(query)
-    if (options.shard) {
-      throw new Error(`suites.${name}.shard is not supported`)
-    }
-    result[name] = options
-  }
-  return result
+function optionalString(field: string) {
+  return z.string({ error: `${field} must be a string` }).optional()
 }
 
-function validateProjectProfiles(
-  value: unknown,
-): Record<string, ProjectExecutionTargetProfile> {
-  const profiles = record(value, 'executionTargetProfiles')
-  const ids = Object.keys(profiles)
-  if (ids.length === 0) {
-    throw new Error(
-      'executionTargetProfiles must contain at least one execution target profile',
+function optionalPositiveInteger(field: string) {
+  return z
+    .number({
+      error: `${field} must be an integer greater than or equal to 1`,
+    })
+    .int({
+      error: `${field} must be an integer greater than or equal to 1`,
+    })
+    .min(1, {
+      error: `${field} must be an integer greater than or equal to 1`,
+    })
+    .optional()
+}
+
+function nonemptyKey(field: string) {
+  return z.string().refine((value) => value.trim().length > 0, {
+    error: `${field} keys must not be empty`,
+  })
+}
+
+const nonemptyPath = z.string().refine((value) => value.trim().length > 0, {
+  error: 'specifications paths must not be empty',
+})
+
+const projectProfileSchema = strictObject('executionTargetProfiles', {
+  adapter: z
+    .string({ error: 'executionTargetProfiles adapter must not be empty' })
+    .refine((value) => value.trim().length > 0, {
+      error: 'executionTargetProfiles adapter must not be empty',
+    }),
+  capabilities: z
+    .array(
+      z.string().refine((item) => item.trim().length > 0, {
+        error: 'capabilities must not contain an empty capability',
+      }),
     )
-  }
-  const result: Record<string, ProjectExecutionTargetProfile> = {}
-  for (const id of ids) {
-    if (!id.trim()) {
-      throw new Error('executionTargetProfiles keys must not be empty')
-    }
-    const field = `executionTargetProfiles.${id}`
-    const profile = record(profiles[id], field)
-    knownFields(profile, ['adapter', 'capabilities', 'web'], field)
-    if (typeof profile.adapter !== 'string' || !profile.adapter.trim()) {
-      throw new Error(`${field}.adapter must not be empty`)
-    }
-    if (profile.capabilities !== undefined) {
-      profile.capabilities = validateCapabilities(
-        profile.capabilities,
-        `${field}.capabilities`,
-      )
-    }
-    if (profile.web !== undefined) {
-      profile.web = validateWebAdapterOptions(profile.web)
-    }
-    result[id] = profile as unknown as ProjectExecutionTargetProfile
-  }
-  return result
-}
+    .min(1, { error: 'capabilities must contain at least one capability' })
+    .optional(),
+  web: webAdapterOptionsSchema.optional(),
+})
+
+const pickleConfigSchema = strictObject('configuration', {
+  schemaVersion: z.number().superRefine((value, context) => {
+    if (value === 1) return
+    context.addIssue({
+      code: 'custom',
+      message: `Unsupported configuration schemaVersion: ${String(value)}`,
+    })
+  }),
+  language: optionalString('language'),
+  specifications: z
+    .union([
+      nonemptyPath,
+      z
+        .array(nonemptyPath, {
+          error: 'specifications must be a string or an array of strings',
+        })
+        .min(1, { error: 'specifications must contain at least one path' }),
+    ])
+    .optional(),
+  suites: z
+    .record(nonemptyKey('suites'), selectionOptionsSchema)
+    .superRefine((suites, context) => {
+      for (const [name, query] of Object.entries(suites)) {
+        if (!query.shard) continue
+        context.addIssue({
+          code: 'custom',
+          message: `suites.${name}.shard is not supported`,
+        })
+      }
+    })
+    .optional(),
+  executionTargetProfiles: z
+    .record(nonemptyKey('executionTargetProfiles'), projectProfileSchema)
+    .refine((profiles) => Object.keys(profiles).length > 0, {
+      error:
+        'executionTargetProfiles must contain at least one execution target profile',
+    })
+    .optional(),
+  executionTargetProfile: z
+    .object({
+      id: z.string(),
+      adapter: z.string().optional(),
+      capabilities: z.array(z.string()).optional(),
+    })
+    .optional(),
+  applicationRevision: z
+    .string()
+    .refine((value) => value.trim().length > 0, {
+      error: 'applicationRevision must not be empty',
+    })
+    .optional(),
+  policy: strictObject('policy', {
+    adaptedResults: z
+      .enum(['accept', 'reject'], {
+        error: 'policy.adaptedResults must be accept or reject',
+      })
+      .optional(),
+  }).optional(),
+  web: webAdapterOptionsSchema.optional(),
+  selection: selectionOptionsSchema.optional(),
+  execution: executionSettingsSchema.optional(),
+  concurrency: optionalPositiveInteger('concurrency'),
+  server: strictObject('server', {
+    command: optionalString('server.command'),
+    url: optionalString('server.url'),
+    port: optionalPositiveInteger('server.port'),
+    startupTimeoutMs: optionalPositiveInteger('server.startupTimeoutMs'),
+    pollIntervalMs: optionalPositiveInteger('server.pollIntervalMs'),
+    readinessPath: optionalString('server.readinessPath'),
+    reuseExisting: z
+      .boolean({ error: 'server.reuseExisting must be a boolean' })
+      .optional(),
+  })
+    .superRefine((server, context) => {
+      if (server.command && !server.url && !server.port) {
+        context.addIssue({
+          code: 'custom',
+          message: 'server.command requires server.url or server.port',
+        })
+      }
+      if (server.url !== undefined) {
+        try {
+          new URL(server.url)
+        } catch {
+          context.addIssue({
+            code: 'custom',
+            message: 'server.url must be a valid URL',
+          })
+        }
+      }
+      if (typeof server.port === 'number' && server.port > 65_535) {
+        context.addIssue({
+          code: 'custom',
+          message: 'server.port must be less than or equal to 65535',
+        })
+      }
+    })
+    .optional(),
+  retention: strictObject('retention', {
+    days: optionalPositiveInteger('retention.days'),
+    maxBytes: optionalPositiveInteger('retention.maxBytes'),
+  }).optional(),
+  artifacts: strictObject('artifacts', {
+    capture: z
+      .enum(['off', 'on-failure-or-adaptation', 'always'], {
+        error:
+          'artifacts.capture must be off, on-failure-or-adaptation, or always',
+      })
+      .optional(),
+  }).optional(),
+}).transform((config) => config as PickleConfig)
 
 function validateConfig(value: unknown): PickleConfig {
-  const config = record(value, 'configuration')
-  knownFields(
-    config,
-    [
-      'schemaVersion',
-      'language',
-      'specifications',
-      'suites',
-      'executionTargetProfiles',
-      'executionTargetProfile',
-      'applicationRevision',
-      'policy',
-      'web',
-      'selection',
-      'execution',
-      'concurrency',
-      'server',
-      'retention',
-      'artifacts',
-    ],
-    'configuration',
-  )
-  optionalString(config.language, 'language')
-  if (
-    typeof config.specifications === 'string' &&
-    !config.specifications.trim()
-  ) {
-    throw new Error('specifications paths must not be empty')
-  }
-  if (
-    Array.isArray(config.specifications) &&
-    config.specifications.length === 0
-  ) {
-    throw new Error('specifications must contain at least one path')
-  }
-  if (
-    config.specifications !== undefined &&
-    typeof config.specifications !== 'string' &&
-    !(
-      Array.isArray(config.specifications) &&
-      config.specifications.every(
-        (item) => typeof item === 'string' && item.trim(),
-      )
-    )
-  ) {
-    throw new Error('specifications must be a string or an array of strings')
-  }
-  if (config.web !== undefined) {
-    validateWebAdapterOptions(config.web)
-  }
-  if (config.server !== undefined) {
-    const server = record(config.server, 'server')
-    knownFields(
-      server,
-      [
-        'command',
-        'url',
-        'port',
-        'startupTimeoutMs',
-        'pollIntervalMs',
-        'readinessPath',
-        'reuseExisting',
-      ],
-      'server',
-    )
-    optionalString(server.command, 'server.command')
-    optionalString(server.url, 'server.url')
-    optionalString(server.readinessPath, 'server.readinessPath')
-    optionalPositiveInteger(server.port, 'server.port')
-    optionalPositiveInteger(server.startupTimeoutMs, 'server.startupTimeoutMs')
-    optionalPositiveInteger(server.pollIntervalMs, 'server.pollIntervalMs')
-    if (
-      server.reuseExisting !== undefined &&
-      typeof server.reuseExisting !== 'boolean'
-    ) {
-      throw new Error('server.reuseExisting must be a boolean')
-    }
-    if (server.command && !server.url && !server.port) {
-      throw new Error('server.command requires server.url or server.port')
-    }
-    if (server.url !== undefined) {
-      try {
-        new URL(server.url as string)
-      } catch {
-        throw new Error('server.url must be a valid URL')
-      }
-    }
-    if (typeof server.port === 'number' && server.port > 65_535) {
-      throw new Error('server.port must be less than or equal to 65535')
-    }
-  }
-  if (
-    config.applicationRevision !== undefined &&
-    (typeof config.applicationRevision !== 'string' ||
-      !config.applicationRevision.trim())
-  ) {
-    throw new Error('applicationRevision must not be empty')
-  }
-  if (config.policy !== undefined) {
-    const policy = record(config.policy, 'policy')
-    knownFields(policy, ['adaptedResults'], 'policy')
-    if (
-      policy.adaptedResults !== undefined &&
-      policy.adaptedResults !== 'accept' &&
-      policy.adaptedResults !== 'reject'
-    ) {
-      throw new Error('policy.adaptedResults must be accept or reject')
-    }
-  }
-  if (config.selection !== undefined) validateSelectionOptions(config.selection)
-  if (config.suites !== undefined) config.suites = validateSuites(config.suites)
-  if (config.retention !== undefined) {
-    const retention = record(config.retention, 'retention')
-    knownFields(retention, ['days', 'maxBytes'], 'retention')
-    optionalPositiveInteger(retention.days, 'retention.days')
-    optionalPositiveInteger(retention.maxBytes, 'retention.maxBytes')
-  }
-  if (config.artifacts !== undefined) {
-    const artifacts = record(config.artifacts, 'artifacts')
-    knownFields(artifacts, ['capture'], 'artifacts')
-    if (
-      artifacts.capture !== undefined &&
-      artifacts.capture !== 'off' &&
-      artifacts.capture !== 'on-failure-or-adaptation' &&
-      artifacts.capture !== 'always'
-    ) {
-      throw new Error(
-        'artifacts.capture must be off, on-failure-or-adaptation, or always',
-      )
-    }
-  }
-  if (config.executionTargetProfiles !== undefined) {
-    config.executionTargetProfiles = validateProjectProfiles(
-      config.executionTargetProfiles,
-    )
-  }
-  const validatedConfig = config as unknown as PickleConfig
-  validateRunConfiguration(runConfigurationFrom(validatedConfig))
-  return validatedConfig
+  return parsed(pickleConfigSchema, value)
 }
 
 function removeJsonComments(source: string): string {
@@ -404,27 +348,30 @@ function removeJsonComments(source: string): string {
   return result
 }
 
-async function defaultConfigPath(): Promise<string | undefined> {
-  return (await Bun.file('pickle.config.jsonc').exists())
-    ? 'pickle.config.jsonc'
-    : undefined
+function parseJsonc(source: string): unknown {
+  return JSON.parse(removeJsonComments(source).replaceAll(/,(\s*[}\]])/g, '$1'))
 }
 
-export async function loadConfig(configPath?: string): Promise<PickleConfig> {
-  const selectedPath = configPath ?? (await defaultConfigPath())
+export async function loadConfig(
+  configPath?: string,
+  root = process.cwd(),
+): Promise<PickleConfig> {
+  const selectedPath =
+    configPath ??
+    ((await Bun.file(join(root, defaultConfigFile)).exists())
+      ? defaultConfigFile
+      : undefined)
   if (!selectedPath) return { schemaVersion: 1 }
   if (!selectedPath.endsWith('.jsonc') && !selectedPath.endsWith('.json')) {
     throw new Error('Configuration must use pickle.config.jsonc')
   }
-  const absolutePath = resolve(selectedPath)
+  const absolutePath = resolve(root, selectedPath)
   if (!(await Bun.file(absolutePath).exists())) {
     throw new Error(`Configuration file not found: ${selectedPath}`)
   }
 
   try {
-    return validateConfig(
-      JSON.parse(removeJsonComments(await Bun.file(absolutePath).text())),
-    )
+    return validateConfig(parseJsonc(await Bun.file(absolutePath).text()))
   } catch (error) {
     const reason = error instanceof Error ? error.message : String(error)
     throw new Error(

--- a/packages/cli/src/project.ts
+++ b/packages/cli/src/project.ts
@@ -7,16 +7,20 @@ import {
   type SpecificationSourceFile,
   validateSpecificationMetadata,
 } from '@pickle-spec/spec'
-import { loadConfig, type PickleConfig, runConfigurationFrom } from './config'
+import {
+  defaultConfigFile,
+  defaultExtensionsFile,
+  defaultSpecificationGlob,
+  loadConfig,
+  type PickleConfig,
+  runConfigurationFrom,
+} from './config'
 import { validateExtensions } from './extension-validation'
-
-const defaultConfigPath = 'pickle.config.jsonc'
-const defaultExtensionsPath = 'pickle.extensions.ts'
 
 const initialConfig = `{
   // Pickle Spec project configuration.
   "schemaVersion": 1,
-  "specifications": "features/**/*.feature",
+  "specifications": "${defaultSpecificationGlob}",
   "executionTargetProfile": { "id": "custom" }
 }
 `
@@ -45,8 +49,8 @@ export async function initializeProject(
   const cwd = resolve(options.cwd ?? process.cwd())
   const report = options.report ?? console.log
   for (const [path, contents] of [
-    [defaultConfigPath, initialConfig],
-    [defaultExtensionsPath, initialExtensions],
+    [defaultConfigFile, initialConfig],
+    [defaultExtensionsFile, initialExtensions],
   ] as const) {
     const absolutePath = resolve(cwd, path)
     if (await Bun.file(absolutePath).exists()) {
@@ -62,7 +66,7 @@ async function discoverSpecificationPaths(
   config: PickleConfig,
   cwd: string,
 ): Promise<string[]> {
-  const patterns = config.specifications ?? 'features/**/*.feature'
+  const patterns = config.specifications ?? defaultSpecificationGlob
   const specificationPaths = new Set<string>()
   for (const pattern of Array.isArray(patterns) ? patterns : [patterns]) {
     let found = false
@@ -108,7 +112,7 @@ export async function migrateProject(
   options: ProjectCommandOptions = {},
 ): Promise<void> {
   const cwd = resolve(options.cwd ?? process.cwd())
-  const configPath = resolve(cwd, options.configPath ?? defaultConfigPath)
+  const configPath = resolve(cwd, options.configPath ?? defaultConfigFile)
   const report = options.report ?? console.log
   if (!(await Bun.file(configPath).exists())) {
     throw new Error(
@@ -116,46 +120,40 @@ export async function migrateProject(
     )
   }
 
-  const previousCwd = process.cwd()
-  try {
-    process.chdir(cwd)
-    const config = await loadConfig(configPath)
-    const files = await readSpecificationFiles(config, cwd)
-    const plan = planSpecificationMigration(files, config.language)
-    report(formatMigrationPreview(plan))
-    if (plan.changes.length === 0) return
-    if (!options.yes) {
-      if (!process.stdin.isTTY) {
-        report(
-          'No files were changed. Re-run pickle migrate --yes after reviewing the preview.',
-        )
-        return
-      }
-      if (!/^[yY]/.test((prompt('Apply these changes? [y/N]') ?? '').trim())) {
-        report('No files were changed')
-        return
-      }
+  const config = await loadConfig(configPath, cwd)
+  const files = await readSpecificationFiles(config, cwd)
+  const plan = planSpecificationMigration(files, config.language)
+  report(formatMigrationPreview(plan))
+  if (plan.changes.length === 0) return
+  if (!options.yes) {
+    if (!process.stdin.isTTY) {
+      report(
+        'No files were changed. Re-run pickle migrate --yes after reviewing the preview.',
+      )
+      return
     }
-    let updated = 0
-    for (const file of plan.files) {
-      if (file.source === file.nextSource) continue
-      await Bun.write(resolve(cwd, file.uri), file.nextSource)
-      updated++
+    if (!/^[yY]/.test((prompt('Apply these changes? [y/N]') ?? '').trim())) {
+      report('No files were changed')
+      return
     }
-    report(`Updated ${updated} Specification file(s)`)
-  } finally {
-    process.chdir(previousCwd)
   }
+  let updated = 0
+  for (const file of plan.files) {
+    if (file.source === file.nextSource) continue
+    await Bun.write(resolve(cwd, file.uri), file.nextSource)
+    updated++
+  }
+  report(`Updated ${updated} Specification file(s)`)
 }
 
 export async function checkProject(
   options: ProjectCommandOptions = {},
 ): Promise<void> {
   const cwd = resolve(options.cwd ?? process.cwd())
-  const configPath = resolve(cwd, options.configPath ?? defaultConfigPath)
+  const configPath = resolve(cwd, options.configPath ?? defaultConfigFile)
   const extensionsPath = resolve(
     cwd,
-    options.extensionsPath ?? defaultExtensionsPath,
+    options.extensionsPath ?? defaultExtensionsFile,
   )
   if (!(await Bun.file(configPath).exists())) {
     throw new Error(
@@ -168,23 +166,17 @@ export async function checkProject(
     )
   }
 
-  const previousCwd = process.cwd()
-  try {
-    process.chdir(cwd)
-    const config = await loadConfig(configPath)
-    const extensions = validateExtensions(extensionsPath)
-    validateProjectRunConfiguration(runConfigurationFrom(config), {
-      ...extensions,
-      fallbackAdapterAvailable: Boolean(config.web),
-    })
-    validateSpecificationMetadata(
-      await readSpecificationFiles(config, cwd),
-      config.language,
-    )
-    options.report?.(
-      `Project is valid (${relative(cwd, configPath)}, ${relative(cwd, extensionsPath)})`,
-    )
-  } finally {
-    process.chdir(previousCwd)
-  }
+  const config = await loadConfig(configPath, cwd)
+  const extensions = validateExtensions(extensionsPath)
+  validateProjectRunConfiguration(runConfigurationFrom(config), {
+    ...extensions,
+    fallbackAdapterAvailable: Boolean(config.web),
+  })
+  validateSpecificationMetadata(
+    await readSpecificationFiles(config, cwd),
+    config.language,
+  )
+  options.report?.(
+    `Project is valid (${relative(cwd, configPath)}, ${relative(cwd, extensionsPath)})`,
+  )
 }

--- a/packages/cli/src/workspace.test.ts
+++ b/packages/cli/src/workspace.test.ts
@@ -610,7 +610,7 @@ Feature: Checkout
     })
     expect(run.exitCode).toBe(0)
     expect(await Bun.file(purchasePath).text()).toBe(purchaseSource)
-  })
+  }, 15_000)
 
   test('run reports missing Specification metadata without modifying source', async () => {
     const source = `Feature: Unreported
@@ -635,7 +635,7 @@ Feature: Checkout
       env: { ...Bun.env, PICKLE_TEST_OUTCOME: 'passed' },
     })
 
-    expect(run.exitCode).toBe(0)
+    expect(run.exitCode).toBe(2)
     expect(run.stderr.toString()).toContain('missing a Specification state')
     expect(run.stderr.toString()).toContain(
       'Run pickle migrate to add missing metadata',

--- a/packages/cli/src/workspace.test.ts
+++ b/packages/cli/src/workspace.test.ts
@@ -783,24 +783,32 @@ Feature: Web search
       `
 export default {
   webAutomationFactory: {
-    async open() {
+    async launch() {
       let page = ''
       return {
-        async navigate(url) { page = await (await fetch(url)).text() },
-        async observe() {
-          return [{ description: 'Search for pickles', handle: 'search' }]
-        },
-        async act() {
-          page += '<div>Pickle results</div>'
-          return { success: true }
-        },
-        async verify() {
+        async openContext() {
           return {
-            meetsExpectation: page.includes('Pickle results'),
-            actualState: page,
+            async navigate(url) { page = await (await fetch(url)).text() },
+            async observe() {
+              return [{ description: 'Search for pickles', handle: 'search' }]
+            },
+            async act() {
+              page += '<div>Pickle results</div>'
+              return { success: true }
+            },
+            async verify() {
+              return {
+                meetsExpectation: page.includes('Pickle results'),
+                actualState: page,
+              }
+            },
+            async readIsolationState() {
+              return { cookieCount: 0, storageKeyCount: 0 }
+            },
+            async screenshot() { return new Uint8Array([137, 80, 78, 71]) },
+            async close() {},
           }
         },
-        async screenshot() { return new Uint8Array([137, 80, 78, 71]) },
         async close() {},
       }
     },

--- a/packages/runner/index.ts
+++ b/packages/runner/index.ts
@@ -18,13 +18,16 @@ export type {
 } from './src/compare'
 export { compareTestRuns } from './src/compare'
 export type {
+  ExecutionSettings,
   ResolvedRunConfiguration,
   RunConfiguration,
   RunExtensionManifest,
   RunExtensions,
 } from './src/configuration'
 export {
+  executionSettingsSchema,
   resolveRunConfiguration,
+  runConfigurationSchema,
   validateProjectRunConfiguration,
   validateRunConfiguration,
 } from './src/configuration'
@@ -65,7 +68,7 @@ export type {
   TestResult,
   TestResultState,
 } from './src/run-scenario'
-export { runScenario } from './src/run-scenario'
+export { isEvidenceState, runScenario } from './src/run-scenario'
 export type { RunScenariosInput, RunTarget } from './src/run-scenarios'
 export { runScenarios, validateTargetSelection } from './src/run-scenarios'
 export type {
@@ -79,4 +82,4 @@ export type {
   TestRunStoreOptions,
   TestRunSummary,
 } from './src/test-run-store'
-export { defaultRetention, openTestRunStore } from './src/test-run-store'
+export { defaultRetention, openTestRunStore, slug } from './src/test-run-store'

--- a/packages/runner/package.json
+++ b/packages/runner/package.json
@@ -15,7 +15,8 @@
     "test": "bun test"
   },
   "dependencies": {
-    "@pickle-spec/spec": "workspace:*"
+    "@pickle-spec/spec": "workspace:*",
+    "zod": "catalog:"
   },
   "devDependencies": {
     "@types/bun": "catalog:",

--- a/packages/runner/src/archive.ts
+++ b/packages/runner/src/archive.ts
@@ -1,5 +1,6 @@
 import { mkdir } from 'node:fs/promises'
 import { basename, dirname, join, relative } from 'node:path'
+import { z } from 'zod'
 import type { RunEvent, TestResult, TestStepResult } from './run-scenario'
 import { openTestRunStore, type TestRunManifest } from './test-run-store'
 
@@ -34,12 +35,16 @@ export interface ImportedRunArchive {
   preservedArchivePath: string
 }
 
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === 'object' && value !== null && !Array.isArray(value)
+const objectSchema = z.record(z.string(), z.unknown())
+
+function asObject(value: unknown, field: string): Record<string, unknown> {
+  const result = objectSchema.safeParse(value)
+  if (!result.success) throw new Error(`${field} must be an object`)
+  return result.data
 }
 
 function migrateStep(step: unknown): TestStepResult {
-  const value = isRecord(step) ? step : {}
+  const value = asObject(step, 'archive step')
   return {
     step: value.step as TestStepResult['step'],
     state: value.state as TestStepResult['state'],
@@ -54,8 +59,8 @@ function migrateStep(step: unknown): TestStepResult {
 }
 
 function migrateResult(result: unknown): TestResult {
-  const value = isRecord(result) ? result : {}
-  const scenario = isRecord(value.scenario) ? value.scenario : {}
+  const value = asObject(result, 'archive result')
+  const scenario = asObject(value.scenario, 'archive result.scenario')
   return {
     schemaVersion: 1,
     specification: value.specification as TestResult['specification'],
@@ -80,7 +85,7 @@ function migrateResult(result: unknown): TestResult {
 }
 
 function migrateEvent(event: unknown, index: number): RunEvent {
-  const value = isRecord(event) ? event : {}
+  const value = asObject(event, 'archive event')
   const base = {
     schemaVersion: 1 as const,
     sequence: typeof value.sequence === 'number' ? value.sequence : index + 1,
@@ -103,7 +108,7 @@ function migrateEvent(event: unknown, index: number): RunEvent {
 }
 
 function migrateManifest(manifest: unknown): TestRunManifest {
-  const value = isRecord(manifest) ? manifest : {}
+  const value = asObject(manifest, 'archive manifest')
   return {
     schemaVersion: 1,
     id: String(value.id ?? ''),
@@ -122,7 +127,7 @@ function migrateManifest(manifest: unknown): TestRunManifest {
 }
 
 export function migrateRunArchive(value: unknown): RunArchive {
-  const archive = isRecord(value) ? value : {}
+  const archive = asObject(value, 'run archive')
   const events = Array.isArray(archive.events) ? archive.events : []
   return {
     schemaVersion: 1,

--- a/packages/runner/src/configuration.test.ts
+++ b/packages/runner/src/configuration.test.ts
@@ -51,13 +51,10 @@ test('combines versioned configuration and extensions into validated runner inpu
 
 test('rejects an unsupported configuration schema before execution', () => {
   expect(() =>
-    resolveRunConfiguration(
-      {
-        schemaVersion: 2 as 1,
-        executionTargetProfile: { id: 'web' },
-      },
-      { adapter },
-    ),
+    validateRunConfiguration({
+      schemaVersion: 2,
+      executionTargetProfile: { id: 'web' },
+    }),
   ).toThrow('Unsupported configuration schemaVersion: 2')
 })
 

--- a/packages/runner/src/configuration.test.ts
+++ b/packages/runner/src/configuration.test.ts
@@ -44,7 +44,7 @@ test('combines versioned configuration and extensions into validated runner inpu
       },
     ],
     concurrency: 3,
-    retry: { infrastructureErrors: 2 },
+    retry: { infrastructureErrors: 2, functionalFailures: 0 },
     timeout: { scenarioMs: 30_000, stepMs: 5_000 },
   })
 })
@@ -217,4 +217,35 @@ test('carries the application revision into the resolved run', () => {
   )
 
   expect(resolved.applicationRevision).toBe('app-1')
+})
+
+test('defaults infrastructure retries to one when execution policy is omitted', () => {
+  const resolved = resolveRunConfiguration(
+    {
+      schemaVersion: 1,
+      executionTargetProfile: { id: 'web' },
+    },
+    { adapter },
+  )
+
+  expect(resolved.retry).toEqual({
+    infrastructureErrors: 1,
+    functionalFailures: 0,
+  })
+})
+
+test('disables infrastructure retries when execution.infrastructureRetries is zero', () => {
+  const resolved = resolveRunConfiguration(
+    {
+      schemaVersion: 1,
+      executionTargetProfile: { id: 'web' },
+      execution: { infrastructureRetries: 0 },
+    },
+    { adapter },
+  )
+
+  expect(resolved.retry).toEqual({
+    infrastructureErrors: 0,
+    functionalFailures: 0,
+  })
 })

--- a/packages/runner/src/configuration.ts
+++ b/packages/runner/src/configuration.ts
@@ -13,6 +13,7 @@ export interface RunConfiguration {
   concurrency?: number
   execution?: {
     infrastructureRetries?: number
+    functionalRetries?: number
     scenarioTimeoutMs?: number
     stepTimeoutMs?: number
   }
@@ -162,7 +163,12 @@ function validateExecution(value: unknown): RunConfiguration['execution'] {
   const execution = record(value, 'execution')
   knownFields(
     execution,
-    ['infrastructureRetries', 'scenarioTimeoutMs', 'stepTimeoutMs'],
+    [
+      'infrastructureRetries',
+      'functionalRetries',
+      'scenarioTimeoutMs',
+      'stepTimeoutMs',
+    ],
     'execution',
   )
   positiveInteger(execution.scenarioTimeoutMs, 'execution.scenarioTimeoutMs')
@@ -174,6 +180,15 @@ function validateExecution(value: unknown): RunConfiguration['execution'] {
   ) {
     throw new Error(
       'execution.infrastructureRetries must be a non-negative integer',
+    )
+  }
+  const functionalRetries = execution.functionalRetries
+  if (
+    functionalRetries !== undefined &&
+    (!Number.isInteger(functionalRetries) || (functionalRetries as number) < 0)
+  ) {
+    throw new Error(
+      'execution.functionalRetries must be a non-negative integer',
     )
   }
   return execution
@@ -268,14 +283,19 @@ export function resolveRunConfiguration(
     return { executionTargetProfile, adapter }
   })
   const first = targets[0]!
-  const retries = validatedConfiguration.execution?.infrastructureRetries
+  const infrastructureRetries =
+    validatedConfiguration.execution?.infrastructureRetries
+  const functionalRetries = validatedConfiguration.execution?.functionalRetries
 
   return {
     adapter: first.adapter,
     executionTargetProfile: first.executionTargetProfile,
     targets,
     concurrency: validatedConfiguration.concurrency ?? 1,
-    retry: { infrastructureErrors: retries ?? 0 },
+    retry: {
+      infrastructureErrors: infrastructureRetries ?? 1,
+      functionalFailures: functionalRetries ?? 0,
+    },
     timeout: {
       scenarioMs: validatedConfiguration.execution?.scenarioTimeoutMs,
       stepMs: validatedConfiguration.execution?.stepTimeoutMs,

--- a/packages/runner/src/configuration.ts
+++ b/packages/runner/src/configuration.ts
@@ -1,3 +1,4 @@
+import { z } from 'zod'
 import type {
   ExecutionPolicy,
   ExecutionTargetAdapter,
@@ -5,18 +6,20 @@ import type {
 } from './run-scenario'
 import type { RunTarget } from './run-scenarios'
 
+export interface ExecutionSettings {
+  infrastructureRetries?: number
+  functionalRetries?: number
+  scenarioTimeoutMs?: number
+  stepTimeoutMs?: number
+}
+
 export interface RunConfiguration {
   schemaVersion: 1
   executionTargetProfile?: ExecutionTargetProfile
   executionTargetProfiles?: ExecutionTargetProfile[]
   applicationRevision?: string
   concurrency?: number
-  execution?: {
-    infrastructureRetries?: number
-    functionalRetries?: number
-    scenarioTimeoutMs?: number
-    stepTimeoutMs?: number
-  }
+  execution?: ExecutionSettings
 }
 
 export interface RunExtensions {
@@ -37,68 +40,128 @@ export interface ResolvedRunConfiguration extends ExecutionPolicy {
   applicationRevision?: string
 }
 
-function record(value: unknown, field: string): Record<string, unknown> {
-  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
-    throw new Error(`${field} must be an object`)
-  }
-  return value as Record<string, unknown>
+function parsed<T>(schema: z.ZodType<T>, value: unknown): T {
+  const result = schema.safeParse(value)
+  if (result.success) return result.data
+  throw new Error(
+    result.error.issues[0]?.message ?? 'Invalid run configuration',
+  )
 }
 
-function knownFields(
-  value: Record<string, unknown>,
-  fields: readonly string[],
-  parent: string,
-): void {
-  for (const field of Object.keys(value)) {
-    if (!fields.includes(field))
-      throw new Error(`${parent}.${field} is not supported`)
-  }
-}
-
-function positiveInteger(value: unknown, field: string): void {
-  if (
-    value !== undefined &&
-    (!Number.isInteger(value) || (value as number) < 1)
-  ) {
-    throw new Error(`${field} must be an integer greater than or equal to 1`)
-  }
-}
-
-function validateCapabilities(
-  value: unknown,
+function strictObject<Shape extends z.ZodRawShape>(
   field: string,
-): readonly string[] {
-  if (!Array.isArray(value) || value.length === 0) {
-    throw new Error(`${field} must contain at least one capability`)
-  }
-  if (!value.every((item) => typeof item === 'string' && item.trim())) {
-    throw new Error(`${field} must not contain an empty capability`)
-  }
-  return value
+  shape: Shape,
+) {
+  return z.strictObject(shape, {
+    error: (issue) => {
+      if (issue.code === 'unrecognized_keys') {
+        const keys = 'keys' in issue ? (issue.keys as string[]) : []
+        return keys.map((key) => `${field}.${key} is not supported`).join('\n')
+      }
+      return `${field} must be an object`
+    },
+  })
 }
 
-function validateExecutionTargetProfile(
-  value: unknown,
-  field = 'executionTargetProfile',
-): ExecutionTargetProfile {
-  const profile = record(value, field)
-  knownFields(profile, ['id', 'adapter', 'capabilities'], field)
-  if (typeof profile.id !== 'string' || !profile.id.trim()) {
-    throw new Error(`${field}.id must not be empty`)
-  }
-  if (
-    profile.adapter !== undefined &&
-    (typeof profile.adapter !== 'string' || !profile.adapter.trim())
-  ) {
-    throw new Error(`${field}.adapter must not be empty`)
-  }
-  if (profile.capabilities !== undefined) {
-    profile.capabilities = validateCapabilities(
-      profile.capabilities,
-      `${field}.capabilities`,
+function nonemptyString(field: string) {
+  return z
+    .string({ error: `${field} must not be empty` })
+    .refine((value) => value.trim().length > 0, {
+      error: `${field} must not be empty`,
+    })
+}
+
+function optionalPositiveInteger(field: string) {
+  return z
+    .number({
+      error: `${field} must be an integer greater than or equal to 1`,
+    })
+    .int({
+      error: `${field} must be an integer greater than or equal to 1`,
+    })
+    .min(1, {
+      error: `${field} must be an integer greater than or equal to 1`,
+    })
+    .optional()
+}
+
+function optionalNonNegativeInteger(field: string) {
+  return z
+    .number({ error: `${field} must be a non-negative integer` })
+    .int({ error: `${field} must be a non-negative integer` })
+    .min(0, { error: `${field} must be a non-negative integer` })
+    .optional()
+}
+
+function capabilitiesSchema(field: string) {
+  return z
+    .array(
+      z.string().refine((item) => item.trim().length > 0, {
+        error: `${field} must not contain an empty capability`,
+      }),
+      { error: `${field} must contain at least one capability` },
     )
-  }
-  return profile as unknown as ExecutionTargetProfile
+    .min(1, { error: `${field} must contain at least one capability` })
+}
+
+function executionTargetProfileSchema(field: string) {
+  return strictObject(field, {
+    id: nonemptyString(`${field}.id`),
+    adapter: nonemptyString(`${field}.adapter`).optional(),
+    capabilities: capabilitiesSchema(`${field}.capabilities`).optional(),
+  })
+}
+
+export const executionSettingsSchema = strictObject('execution', {
+  infrastructureRetries: optionalNonNegativeInteger(
+    'execution.infrastructureRetries',
+  ),
+  functionalRetries: optionalNonNegativeInteger('execution.functionalRetries'),
+  scenarioTimeoutMs: optionalPositiveInteger('execution.scenarioTimeoutMs'),
+  stepTimeoutMs: optionalPositiveInteger('execution.stepTimeoutMs'),
+})
+
+export const runConfigurationSchema = strictObject('run configuration', {
+  schemaVersion: z.number(),
+  executionTargetProfile: executionTargetProfileSchema(
+    'executionTargetProfile',
+  ).optional(),
+  executionTargetProfiles: z
+    .array(executionTargetProfileSchema('executionTargetProfiles'), {
+      error:
+        'executionTargetProfiles must contain at least one execution target profile',
+    })
+    .min(1, {
+      error:
+        'executionTargetProfiles must contain at least one execution target profile',
+    })
+    .optional(),
+  applicationRevision: nonemptyString('applicationRevision').optional(),
+  concurrency: optionalPositiveInteger('concurrency'),
+  execution: executionSettingsSchema.optional(),
+})
+  .refine(
+    (configuration) =>
+      configuration.executionTargetProfile !== undefined ||
+      configuration.executionTargetProfiles !== undefined,
+    {
+      error: 'executionTargetProfile or executionTargetProfiles is required',
+    },
+  )
+  .superRefine((configuration, context) => {
+    if (configuration.schemaVersion === 1) return
+    context.addIssue({
+      code: 'custom',
+      message: `Unsupported configuration schemaVersion: ${String(configuration.schemaVersion)}`,
+    })
+  })
+  .transform((configuration) => ({
+    ...configuration,
+    schemaVersion: 1 as const,
+  }))
+
+export function validateRunConfiguration(value: unknown): RunConfiguration {
+  return parsed(runConfigurationSchema, value)
 }
 
 function configuredProfiles(
@@ -159,104 +222,6 @@ function assertProfileCapabilities(
   }
 }
 
-function validateExecution(value: unknown): RunConfiguration['execution'] {
-  const execution = record(value, 'execution')
-  knownFields(
-    execution,
-    [
-      'infrastructureRetries',
-      'functionalRetries',
-      'scenarioTimeoutMs',
-      'stepTimeoutMs',
-    ],
-    'execution',
-  )
-  positiveInteger(execution.scenarioTimeoutMs, 'execution.scenarioTimeoutMs')
-  positiveInteger(execution.stepTimeoutMs, 'execution.stepTimeoutMs')
-  const retries = execution.infrastructureRetries
-  if (
-    retries !== undefined &&
-    (!Number.isInteger(retries) || (retries as number) < 0)
-  ) {
-    throw new Error(
-      'execution.infrastructureRetries must be a non-negative integer',
-    )
-  }
-  const functionalRetries = execution.functionalRetries
-  if (
-    functionalRetries !== undefined &&
-    (!Number.isInteger(functionalRetries) || (functionalRetries as number) < 0)
-  ) {
-    throw new Error(
-      'execution.functionalRetries must be a non-negative integer',
-    )
-  }
-  return execution
-}
-
-export function validateRunConfiguration(value: unknown): RunConfiguration {
-  const configuration = record(value, 'run configuration')
-  knownFields(
-    configuration,
-    [
-      'schemaVersion',
-      'executionTargetProfile',
-      'executionTargetProfiles',
-      'applicationRevision',
-      'concurrency',
-      'execution',
-    ],
-    'run configuration',
-  )
-  if (configuration.schemaVersion !== 1) {
-    throw new Error(
-      `Unsupported configuration schemaVersion: ${String(configuration.schemaVersion)}`,
-    )
-  }
-  if (configuration.executionTargetProfile !== undefined) {
-    configuration.executionTargetProfile = validateExecutionTargetProfile(
-      configuration.executionTargetProfile,
-    )
-  }
-  if (configuration.executionTargetProfiles !== undefined) {
-    if (
-      !Array.isArray(configuration.executionTargetProfiles) ||
-      configuration.executionTargetProfiles.length === 0
-    ) {
-      throw new Error(
-        'executionTargetProfiles must contain at least one execution target profile',
-      )
-    }
-    configuration.executionTargetProfiles =
-      configuration.executionTargetProfiles.map((profile, index) =>
-        validateExecutionTargetProfile(
-          profile,
-          `executionTargetProfiles[${index}]`,
-        ),
-      )
-  }
-  if (
-    configuration.executionTargetProfile === undefined &&
-    configuration.executionTargetProfiles === undefined
-  ) {
-    throw new Error(
-      'executionTargetProfile or executionTargetProfiles is required',
-    )
-  }
-  if (
-    configuration.applicationRevision !== undefined &&
-    (typeof configuration.applicationRevision !== 'string' ||
-      !configuration.applicationRevision.trim())
-  ) {
-    throw new Error('applicationRevision must not be empty')
-  }
-  positiveInteger(configuration.concurrency, 'concurrency')
-  if (configuration.execution !== undefined) {
-    configuration.execution = validateExecution(configuration.execution)
-  }
-  return configuration as unknown as RunConfiguration
-}
-
 export function validateProjectRunConfiguration(
   configuration: unknown,
   extensions: RunExtensionManifest,
@@ -275,33 +240,34 @@ export function resolveRunConfiguration(
   configuration: RunConfiguration,
   extensions: RunExtensions,
 ): ResolvedRunConfiguration {
-  const validatedConfiguration = validateRunConfiguration(configuration)
-  const profiles = configuredProfiles(validatedConfiguration)
+  const profiles = configuredProfiles(configuration)
   const targets = profiles.map((executionTargetProfile) => {
     const adapter = adapterForProfile(executionTargetProfile, extensions)
     assertProfileCapabilities(executionTargetProfile, adapter)
     return { executionTargetProfile, adapter }
   })
-  const first = targets[0]!
-  const infrastructureRetries =
-    validatedConfiguration.execution?.infrastructureRetries
-  const functionalRetries = validatedConfiguration.execution?.functionalRetries
+  const first = targets[0]
+  if (!first) {
+    throw new Error(
+      'executionTargetProfile or executionTargetProfiles is required',
+    )
+  }
+  const infrastructureRetries = configuration.execution?.infrastructureRetries
+  const functionalRetries = configuration.execution?.functionalRetries
 
   return {
     adapter: first.adapter,
     executionTargetProfile: first.executionTargetProfile,
     targets,
-    concurrency: validatedConfiguration.concurrency ?? 1,
+    concurrency: configuration.concurrency ?? 1,
     retry: {
       infrastructureErrors: infrastructureRetries ?? 1,
       functionalFailures: functionalRetries ?? 0,
     },
     timeout: {
-      scenarioMs: validatedConfiguration.execution?.scenarioTimeoutMs,
-      stepMs: validatedConfiguration.execution?.stepTimeoutMs,
+      scenarioMs: configuration.execution?.scenarioTimeoutMs,
+      stepMs: configuration.execution?.stepTimeoutMs,
     },
-    ...(validatedConfiguration.applicationRevision
-      ? { applicationRevision: validatedConfiguration.applicationRevision }
-      : {}),
+    applicationRevision: configuration.applicationRevision,
   }
 }

--- a/packages/runner/src/execution-plan.ts
+++ b/packages/runner/src/execution-plan.ts
@@ -1,5 +1,6 @@
 import { mkdir } from 'node:fs/promises'
 import { dirname, join } from 'node:path'
+import { z } from 'zod'
 import type { ResolvedAction } from './run-scenario'
 
 export interface PlanApplicability {
@@ -55,17 +56,18 @@ function planPath(
   )
 }
 
+const executionPlanSchema = z.object({
+  schemaVersion: z.literal(1),
+  scenarioId: z.string(),
+  scenarioRevision: z.string(),
+  executionTargetProfileId: z.string(),
+  planFormatVersion: z.string(),
+  applicationRevision: z.string().optional(),
+  steps: z.array(z.object({ resolvedActions: z.array(z.unknown()) })),
+})
+
 function isExecutionPlan(value: unknown): value is ExecutionPlan {
-  if (typeof value !== 'object' || value === null) return false
-  const plan = value as ExecutionPlan
-  return (
-    plan.schemaVersion === 1 &&
-    typeof plan.scenarioId === 'string' &&
-    typeof plan.scenarioRevision === 'string' &&
-    typeof plan.executionTargetProfileId === 'string' &&
-    typeof plan.planFormatVersion === 'string' &&
-    Array.isArray(plan.steps)
-  )
+  return executionPlanSchema.safeParse(value).success
 }
 
 export function createFilePlanStore(root: string): ExecutionPlanStore {

--- a/packages/runner/src/outputs-html.test.ts
+++ b/packages/runner/src/outputs-html.test.ts
@@ -3,7 +3,7 @@ import { mkdir, mkdtemp, rm } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { dirname, join } from 'node:path'
 import { formatHtml } from '../index'
-import type { RunEvent, TestResult } from './run-scenario'
+import type { TestResult } from './run-scenario'
 import type { TestRunManifest } from './test-run-store'
 
 async function withArtifact(
@@ -93,8 +93,7 @@ test('formatHtml includes failure and adaptation artifacts by default', async ()
         result('Adapt the purchase', 'passed-with-adaptation'),
       ],
     }
-    const events: RunEvent[] = []
-    const html = await formatHtml(manifest, events)
+    const html = await formatHtml(manifest)
 
     expect(html).toContain('<!DOCTYPE html>')
     expect(html).toContain('Pay for the order')
@@ -161,7 +160,7 @@ test('formatHtml can include every available test artifact', async () => {
       ],
     }
 
-    const html = await formatHtml(manifest, [], { artifacts: 'all' })
+    const html = await formatHtml(manifest, { artifacts: 'all' })
     expect(html).toContain(Buffer.from('png-bytes').toString('base64'))
     expect(html).toContain(Buffer.from('passed-bytes').toString('base64'))
   })

--- a/packages/runner/src/outputs.ts
+++ b/packages/runner/src/outputs.ts
@@ -1,4 +1,5 @@
 import type { RunEvent, TestResult, TestResultState } from './run-scenario'
+import { isEvidenceState } from './run-scenario'
 import type { TestRunManifest } from './test-run-store'
 
 export function formatJson(manifest: TestRunManifest): string {
@@ -27,11 +28,7 @@ function shouldEmbedArtifacts(
   mode: HtmlArtifactMode,
 ): boolean {
   if (mode === 'all') return true
-  return (
-    state === 'failed' ||
-    state === 'passed-with-adaptation' ||
-    state === 'infrastructure-error'
-  )
+  return isEvidenceState(state)
 }
 
 function resultPriority(state: TestResultState): number {
@@ -68,7 +65,6 @@ async function embedArtifacts(
 
 export async function formatHtml(
   manifest: TestRunManifest,
-  _events: readonly RunEvent[],
   options: FormatHtmlOptions = {},
 ): Promise<string> {
   const mode = options.artifacts ?? 'failures-and-adaptations'

--- a/packages/runner/src/run-scenario.test.ts
+++ b/packages/runner/src/run-scenario.test.ts
@@ -230,6 +230,25 @@ describe('runScenario', () => {
     ])
   })
 
+  test('materializes isolation verification failure as an infrastructure error', async () => {
+    const run = await runScenario({
+      specification,
+      scenario,
+      executionTargetProfile: { id: 'web' },
+      adapter: {
+        async openSession() {
+          throw new Error('Logical session isolation verification failed')
+        },
+      },
+      retry: { infrastructureErrors: 0 },
+    })
+
+    expect(run.result).toMatchObject({
+      state: 'infrastructure-error',
+      message: 'Logical session isolation verification failed',
+    })
+  })
+
   test('preserves a successful adaptation as the final result state', async () => {
     let step = 0
     const run = await runScenario({
@@ -350,6 +369,56 @@ describe('runScenario', () => {
     })
 
     expect(run.result).toMatchObject({
+      state: 'passed',
+      attempts: 2,
+      flaky: true,
+    })
+    expect(openSession).toHaveBeenCalledTimes(2)
+    expect(close).toHaveBeenCalledTimes(2)
+  })
+
+  test('retries functional failures only when explicit policy allows it', async () => {
+    let attempt = 0
+    const close = mock(async () => {})
+    const openSession = mock(async () => {
+      attempt++
+      return {
+        async executeStep() {
+          if (attempt === 1) {
+            return {
+              state: 'failed' as const,
+              resolvedActions: [],
+              message: 'Product behavior failed',
+            }
+          }
+          return { state: 'passed' as const, resolvedActions: [] }
+        },
+        close,
+      }
+    })
+
+    const withoutPolicy = await runScenario({
+      specification,
+      scenario: { ...scenario, steps: scenario.steps.slice(0, 1) },
+      executionTargetProfile: { id: 'web' },
+      adapter: { openSession },
+      retry: { infrastructureErrors: 0, functionalFailures: 0 },
+    })
+    expect(withoutPolicy.result.state).toBe('failed')
+    expect(openSession).toHaveBeenCalledTimes(1)
+
+    attempt = 0
+    openSession.mockClear()
+    close.mockClear()
+
+    const withPolicy = await runScenario({
+      specification,
+      scenario: { ...scenario, steps: scenario.steps.slice(0, 1) },
+      executionTargetProfile: { id: 'web' },
+      adapter: { openSession },
+      retry: { infrastructureErrors: 0, functionalFailures: 1 },
+    })
+    expect(withPolicy.result).toMatchObject({
       state: 'passed',
       attempts: 2,
       flaky: true,

--- a/packages/runner/src/run-scenario.ts
+++ b/packages/runner/src/run-scenario.ts
@@ -64,6 +64,7 @@ export interface ExecutionTargetAdapter {
   capabilities?: readonly string[]
   planFormatVersion?: string
   openSession(input: OpenSessionInput): Promise<TargetSession>
+  dispose?(): Promise<void>
 }
 
 export interface TestStepResult {
@@ -107,7 +108,7 @@ export type RunEventPayload =
   | { type: 'scenario-started'; scenario: TestResult['scenario'] }
   | { type: 'step-started'; step: ScenarioStep }
   | { type: 'step-finished'; result: TestStepResult }
-  | { type: 'scenario-finished'; result: TestResult }
+  | { type: 'scenario-finished'; result: TestResult; scheduleIndex?: number }
 
 export type RunEvent = RunEventEnvelope & RunEventPayload
 
@@ -118,6 +119,7 @@ export interface ScenarioRun {
 
 export interface RetryPolicy {
   infrastructureErrors: number
+  functionalFailures?: number
 }
 
 export interface ExecutionTimeouts {
@@ -469,10 +471,13 @@ export async function runScenario(
   input: RunScenarioInput,
 ): Promise<ScenarioRun> {
   const events: RunEvent[] = []
-  const maximumAttempts = (input.retry?.infrastructureErrors ?? 0) + 1
+  const infrastructureRetries = input.retry?.infrastructureErrors ?? 0
+  const functionalRetries = input.retry?.functionalFailures ?? 0
+  let infrastructureFailures = 0
+  let functionalFailures = 0
   const selected = await selectPlan(input)
 
-  for (let attempt = 1; attempt <= maximumAttempts; attempt++) {
+  for (let attempt = 1; ; attempt++) {
     const run = await runScenarioAttempt({
       ...input,
       mode: selected.mode,
@@ -482,10 +487,15 @@ export async function runScenario(
       // Attempts own one logical session; retries are orchestrated here.
       retry: undefined,
     })
-    const shouldRetry =
+    const shouldRetryInfrastructure =
       run.result.state === 'infrastructure-error' &&
-      attempt < maximumAttempts &&
+      infrastructureFailures < infrastructureRetries &&
       !input.signal?.aborted
+    const shouldRetryFunctional =
+      run.result.state === 'failed' &&
+      functionalFailures < functionalRetries &&
+      !input.signal?.aborted
+    const shouldRetry = shouldRetryInfrastructure || shouldRetryFunctional
     const result = withAttemptMetadata(run.result, attempt)
 
     for (const event of run.events) {
@@ -500,7 +510,14 @@ export async function runScenario(
       await input.onEvent?.(versionedEvent)
     }
 
-    if (shouldRetry) continue
+    if (shouldRetryInfrastructure) {
+      infrastructureFailures++
+      continue
+    }
+    if (shouldRetryFunctional) {
+      functionalFailures++
+      continue
+    }
     if (input.plans && shouldSaveCandidate(result.state, selected.mode)) {
       await input.plans.saveCandidate(
         candidatePlan(selected.query, result.steps),
@@ -508,6 +525,4 @@ export async function runScenario(
     }
     return { events, result }
   }
-
-  throw new Error('Runner exhausted attempts without producing a test result')
 }

--- a/packages/runner/src/run-scenario.ts
+++ b/packages/runner/src/run-scenario.ts
@@ -1,4 +1,5 @@
 import {
+  ignoreTag,
   resolveScenarioId,
   type Scenario,
   type ScenarioStep,
@@ -19,6 +20,14 @@ export type TestResultState =
   | 'skipped'
   | 'cancelled'
   | 'infrastructure-error'
+
+export function isEvidenceState(state: TestResultState): boolean {
+  return (
+    state === 'failed' ||
+    state === 'infrastructure-error' ||
+    state === 'passed-with-adaptation'
+  )
+}
 
 export type ExecutionMode = 'adaptive' | 'replay'
 
@@ -348,7 +357,7 @@ async function runScenarioAttempt(
     },
   })
 
-  if (input.scenario.tags.includes('@ignore')) {
+  if (input.scenario.tags.includes(ignoreTag)) {
     return finish('skipped', [], 'Scenario is tagged @ignore')
   }
 

--- a/packages/runner/src/run-scenarios.test.ts
+++ b/packages/runner/src/run-scenarios.test.ts
@@ -89,6 +89,106 @@ test('rejects a target that lacks a Scenario capability requirement before openi
   expect(openSession).not.toHaveBeenCalled()
 })
 
+test('applies one global concurrency limit across Scenarios from multiple feature files', async () => {
+  let active = 0
+  let maximumActive = 0
+  const openSession = mock(async () => {
+    active++
+    maximumActive = Math.max(maximumActive, active)
+    return {
+      async executeStep(step: { text: string }) {
+        await Bun.sleep(step.text.includes('slow') ? 30 : 1)
+        return { state: 'passed' as const, resolvedActions: [] }
+      },
+      async close() {
+        active--
+      },
+    }
+  })
+  const adapter: ExecutionTargetAdapter = { openSession }
+
+  const crossFileSelections: ScenarioSelection[] = [
+    {
+      specification: {
+        name: 'Checkout',
+        source: { uri: 'features/checkout.feature', language: 'en' },
+        tags: [],
+        scenarios: [],
+      },
+      scenario: {
+        name: 'slow checkout',
+        tags: [],
+        steps: [
+          {
+            keyword: 'Then',
+            text: 'slow checkout completes',
+            type: 'outcome' as const,
+          },
+        ],
+      },
+    },
+    {
+      specification: {
+        name: 'Search',
+        source: { uri: 'features/search.feature', language: 'en' },
+        tags: [],
+        scenarios: [],
+      },
+      scenario: {
+        name: 'fast search',
+        tags: [],
+        steps: [
+          {
+            keyword: 'Then',
+            text: 'fast search completes',
+            type: 'outcome' as const,
+          },
+        ],
+      },
+    },
+    {
+      specification: {
+        name: 'Account',
+        source: { uri: 'features/account.feature', language: 'en' },
+        tags: [],
+        scenarios: [],
+      },
+      scenario: {
+        name: 'slow account',
+        tags: [],
+        steps: [
+          {
+            keyword: 'Then',
+            text: 'slow account completes',
+            type: 'outcome' as const,
+          },
+        ],
+      },
+    },
+  ]
+
+  const runs = await runScenarios({
+    selections: crossFileSelections,
+    executionTargetProfile: { id: 'web' },
+    adapter,
+    concurrency: 2,
+  })
+
+  expect(
+    runs.map((run) => [
+      run.result.specification.uri,
+      run.result.scenario.name,
+      run.result.state,
+    ]),
+  ).toEqual([
+    ['features/checkout.feature', 'slow checkout', 'passed'],
+    ['features/search.feature', 'fast search', 'passed'],
+    ['features/account.feature', 'slow account', 'passed'],
+  ])
+  expect(maximumActive).toBe(2)
+  expect(openSession).toHaveBeenCalledTimes(3)
+})
+
 test('produces one test result per Scenario and execution target profile', async () => {
   const webOpen = mock(async () => ({
     async executeStep() {

--- a/packages/runner/src/run-scenarios.ts
+++ b/packages/runner/src/run-scenarios.ts
@@ -111,7 +111,13 @@ export async function runScenarios(
         retry: input.retry,
         timeout: input.timeout,
         onEvent: input.onEvent
-          ? (event) => input.onEvent?.(event, selection)
+          ? (event) =>
+              input.onEvent?.(
+                event.type === 'scenario-finished'
+                  ? { ...event, scheduleIndex: index }
+                  : event,
+                selection,
+              )
           : undefined,
       })
     }

--- a/packages/runner/src/test-run-store.test.ts
+++ b/packages/runner/src/test-run-store.test.ts
@@ -182,6 +182,38 @@ test('an in-progress manifest omits finishedAt until the test run finishes', asy
   expect(finished.finishedAt).toBe('2026-08-15T12:00:00.000Z')
 })
 
+test('orders manifest results by schedule index instead of finish order', async () => {
+  const root = await tempRoot()
+  const store = openTestRunStore({
+    root,
+    createId: () => 'run-order',
+    now: () => new Date('2026-08-15T12:00:00.000Z'),
+  })
+  const run = await store.create()
+  await run.append({
+    type: 'scenario-finished',
+    scheduleIndex: 1,
+    result: {
+      ...passedResult('Second scenario'),
+      specification: {
+        name: 'Search',
+        uri: 'features/search.feature',
+      },
+    },
+  })
+  await run.append({
+    type: 'scenario-finished',
+    scheduleIndex: 0,
+    result: passedResult('First scenario'),
+  })
+
+  const manifest = await run.materialize()
+  expect(manifest.results.map((result) => result.scenario.name)).toEqual([
+    'First scenario',
+    'Second scenario',
+  ])
+})
+
 test('rebuilds the query index from persisted test runs after it is deleted', async () => {
   const root = await tempRoot()
   let nextId = 1

--- a/packages/runner/src/test-run-store.ts
+++ b/packages/runner/src/test-run-store.ts
@@ -8,6 +8,7 @@ import type {
   TestResultState,
   TestStepResult,
 } from './run-scenario'
+import { isEvidenceState } from './run-scenario'
 
 export type ArtifactCapturePolicy =
   | 'off'
@@ -477,7 +478,7 @@ function shouldCapture(
 ): boolean {
   if (policy === 'always') return true
   if (policy === 'off') return false
-  return state === 'failed' || state === 'passed-with-adaptation'
+  return isEvidenceState(state)
 }
 
 async function removeRun(
@@ -502,7 +503,7 @@ async function directorySize(directory: string): Promise<number> {
   return total
 }
 
-function slug(value: string): string {
+export function slug(value: string): string {
   return value
     .toLowerCase()
     .replace(/[^a-z0-9]+/g, '-')

--- a/packages/runner/src/test-run-store.ts
+++ b/packages/runner/src/test-run-store.ts
@@ -244,9 +244,18 @@ function persistedTestRun(
     },
     async materialize(input) {
       const recorded = await readEvents(eventsPath)
-      const results = recorded.flatMap((event) =>
-        event.type === 'scenario-finished' ? [event.result] : [],
+      const finished = recorded.flatMap((event) =>
+        event.type === 'scenario-finished'
+          ? [{ result: event.result, scheduleIndex: event.scheduleIndex }]
+          : [],
       )
+      const results = [...finished]
+        .sort(
+          (left, right) =>
+            (left.scheduleIndex ?? Number.MAX_SAFE_INTEGER) -
+            (right.scheduleIndex ?? Number.MAX_SAFE_INTEGER),
+        )
+        .map(({ result }) => result)
       const manifest: TestRunManifest = {
         schemaVersion: 1,
         id,

--- a/packages/spec/index.ts
+++ b/packages/spec/index.ts
@@ -9,6 +9,7 @@ export {
   formatMigrationPreview,
   planSpecificationMigration,
   resolveScenarioId,
+  specificationStates,
   validateSpecificationMetadata,
 } from './src/identity'
 export { scenarioRevision } from './src/revision'
@@ -17,7 +18,12 @@ export type {
   SelectionOptions,
   Shard,
 } from './src/selection'
-export { selectScenarios, validateSelectionOptions } from './src/selection'
+export {
+  ignoreTag,
+  selectionOptionsSchema,
+  selectScenarios,
+  validateSelectionOptions,
+} from './src/selection'
 export type {
   ParseSpecificationInput,
   Scenario,
@@ -25,4 +31,4 @@ export type {
   Specification,
   SpecificationSource,
 } from './src/specification'
-export { parseSpecification, parseSpecificationFile } from './src/specification'
+export { parseSpecification } from './src/specification'

--- a/packages/spec/package.json
+++ b/packages/spec/package.json
@@ -16,7 +16,8 @@
   },
   "dependencies": {
     "@cucumber/gherkin": "catalog:",
-    "@cucumber/messages": "catalog:"
+    "@cucumber/messages": "catalog:",
+    "zod": "catalog:"
   },
   "devDependencies": {
     "@types/bun": "catalog:",

--- a/packages/spec/src/identity.ts
+++ b/packages/spec/src/identity.ts
@@ -13,7 +13,8 @@ import type {
 } from '@cucumber/messages'
 import { IdGenerator } from '@cucumber/messages'
 
-export type SpecificationState = 'draft' | 'active' | 'deprecated'
+export const specificationStates = ['draft', 'active', 'deprecated'] as const
+export type SpecificationState = (typeof specificationStates)[number]
 
 export interface SpecificationSourceFile {
   uri: string
@@ -39,7 +40,6 @@ export interface SpecificationMigrationPlan {
 const idTagPrefix = '@pickle:id:'
 const stateTagPrefix = '@pickle:state:'
 const rowIdColumn = 'pickle_id'
-const validStates = ['draft', 'active', 'deprecated'] as const
 const idPattern = /^[A-Za-z0-9_-]+$/
 
 interface IdentityNode {
@@ -80,7 +80,7 @@ function stateValues(tags: readonly string[]): string[] {
 function specificationState(
   value: string | undefined,
 ): SpecificationState | undefined {
-  return validStates.find((state) => state === value)
+  return specificationStates.find((state) => state === value)
 }
 
 export function identityFromTags(tags: readonly string[]): {

--- a/packages/spec/src/selection.ts
+++ b/packages/spec/src/selection.ts
@@ -1,4 +1,5 @@
-import type { SpecificationState } from './identity'
+import { z } from 'zod'
+import { type SpecificationState, specificationStates } from './identity'
 import type { Scenario, Specification } from './specification'
 
 export interface Shard {
@@ -14,17 +15,55 @@ export interface SelectionOptions {
   shard?: Shard
 }
 
-const specificationStates = ['draft', 'active', 'deprecated'] as const
-
 export interface ScenarioSelection {
   specification: Specification
   scenario: Scenario
 }
 
+export const ignoreTag = '@ignore'
+
 type TagExpressionNode =
   | { type: 'tag'; value: string }
   | { type: 'not'; child: TagExpressionNode }
   | { type: 'and' | 'or'; left: TagExpressionNode; right: TagExpressionNode }
+
+function parsed<T>(schema: z.ZodType<T>, value: unknown): T {
+  const result = schema.safeParse(value)
+  if (result.success) return result.data
+  throw new Error(result.error.issues[0]?.message ?? 'Invalid selection')
+}
+
+function strictObject<Shape extends z.ZodRawShape>(
+  field: string,
+  shape: Shape,
+) {
+  return z.strictObject(shape, {
+    error: (issue) => {
+      if (issue.code === 'unrecognized_keys') {
+        const keys = 'keys' in issue ? (issue.keys as string[]) : []
+        return keys.map((key) => `${field}.${key} is not supported`).join('\n')
+      }
+      return `${field} must be an object`
+    },
+  })
+}
+
+function optionalString(field: string) {
+  return z.string({ error: `${field} must be a string` }).optional()
+}
+
+function positiveInteger(field: string) {
+  return z
+    .number({
+      error: `${field} must be an integer greater than or equal to 1`,
+    })
+    .int({
+      error: `${field} must be an integer greater than or equal to 1`,
+    })
+    .min(1, {
+      error: `${field} must be an integer greater than or equal to 1`,
+    })
+}
 
 function normalizedTag(tag: string): string {
   return tag.startsWith('@') ? tag : `@${tag}`
@@ -120,143 +159,89 @@ function matchesTagExpression(
   }
 }
 
-function record(value: unknown, field: string): Record<string, unknown> {
-  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
-    throw new Error(`${field} must be an object`)
-  }
-  return value as Record<string, unknown>
-}
+const selectionPathsSchema = z.union(
+  [
+    z.string().refine((value) => value.trim().length > 0, {
+      error: 'selection.paths must contain at least one path',
+    }),
+    z
+      .array(
+        z.string().refine((value) => value.trim().length > 0, {
+          error: 'selection.paths must not contain an empty path',
+        }),
+        { error: 'selection.paths must contain at least one path' },
+      )
+      .min(1, { error: 'selection.paths must contain at least one path' }),
+  ],
+  { error: 'selection.paths must contain at least one path' },
+)
 
-function knownFields(
-  value: Record<string, unknown>,
-  fields: readonly string[],
-  parent: string,
-): void {
-  for (const field of Object.keys(value)) {
-    if (!fields.includes(field))
-      throw new Error(`${parent}.${field} is not supported`)
-  }
-}
+const shardSchema = strictObject('selection.shard', {
+  index: positiveInteger('selection.shard.index'),
+  total: positiveInteger('selection.shard.total'),
+}).refine((shard) => shard.index <= shard.total, {
+  error:
+    'selection.shard.index must be less than or equal to selection.shard.total',
+})
 
-function optionalString(value: unknown, field: string): void {
-  if (value !== undefined && typeof value !== 'string') {
-    throw new Error(`${field} must be a string`)
-  }
-}
-
-function validateShard(value: unknown): void {
-  const shard = record(value, 'selection.shard')
-  knownFields(shard, ['index', 'total'], 'selection.shard')
-  if (!Number.isInteger(shard.index) || (shard.index as number) < 1) {
-    throw new Error(
-      'selection.shard.index must be an integer greater than or equal to 1',
+export const selectionOptionsSchema = strictObject('selection', {
+  paths: selectionPathsSchema.optional(),
+  scenarioName: optionalString('selection.scenarioName'),
+  tagExpression: optionalString('selection.tagExpression'),
+  states: z
+    .array(
+      z.enum(specificationStates, {
+        error: 'selection.states must be draft, active, or deprecated',
+      }),
+      { error: 'selection.states must be draft, active, or deprecated' },
     )
+    .min(1, {
+      error: 'selection.states must contain at least one Specification state',
+    })
+    .optional(),
+  shard: shardSchema.optional(),
+}).superRefine((options, context) => {
+  if (!options.tagExpression) return
+  try {
+    parseTagExpression(options.tagExpression)
+  } catch (error) {
+    context.addIssue({
+      code: 'custom',
+      message: error instanceof Error ? error.message : String(error),
+    })
   }
-  if (!Number.isInteger(shard.total) || (shard.total as number) < 1) {
-    throw new Error(
-      'selection.shard.total must be an integer greater than or equal to 1',
-    )
-  }
-  if ((shard.index as number) > (shard.total as number)) {
+})
+
+function matchesPath(uri: string, pattern: string): boolean {
+  return new Bun.Glob(pattern.replaceAll('\\', '/')).match(
+    uri.replaceAll('\\', '/'),
+  )
+}
+
+function assertShard(shard: Shard): void {
+  if (shard.index > shard.total) {
     throw new Error(
       'selection.shard.index must be less than or equal to selection.shard.total',
     )
   }
 }
 
-function globToRegExp(pattern: string): RegExp {
-  let regex = '^'
-  for (let index = 0; index < pattern.length; index++) {
-    const character = pattern[index]!
-    if (character === '*') {
-      if (pattern[index + 1] === '*') {
-        regex += '.*'
-        index++
-        continue
-      }
-      regex += '[^/]*'
-      continue
-    }
-    if ('\\^$+{}()|[]?.'.includes(character)) {
-      regex += `\\${character}`
-      continue
-    }
-    regex += character
-  }
-  return new RegExp(`${regex}$`)
-}
-
-function normalizePaths(value: unknown): string[] {
-  if (typeof value === 'string') {
-    if (!value.trim()) {
-      throw new Error('selection.paths must contain at least one path')
-    }
-    return [value]
-  }
-  if (!Array.isArray(value) || value.length === 0) {
-    throw new Error('selection.paths must contain at least one path')
-  }
-  if (!value.every((path) => typeof path === 'string' && path.trim())) {
-    throw new Error('selection.paths must not contain an empty path')
-  }
-  return value
-}
-
-function matchesPath(uri: string, pattern: string): boolean {
-  return globToRegExp(pattern.replaceAll('\\', '/')).test(
-    uri.replaceAll('\\', '/'),
-  )
-}
-
-function validateStates(value: unknown): SpecificationState[] {
-  if (!Array.isArray(value) || value.length === 0) {
-    throw new Error(
-      'selection.states must contain at least one Specification state',
-    )
-  }
-  if (
-    !value.every(
-      (state) =>
-        typeof state === 'string' &&
-        specificationStates.includes(state as SpecificationState),
-    )
-  ) {
-    throw new Error('selection.states must be draft, active, or deprecated')
-  }
-  return value as SpecificationState[]
-}
-
 export function validateSelectionOptions(value: unknown): SelectionOptions {
-  const options = record(value, 'selection')
-  knownFields(
-    options,
-    ['paths', 'scenarioName', 'tagExpression', 'states', 'shard'],
-    'selection',
-  )
-  optionalString(options.scenarioName, 'selection.scenarioName')
-  optionalString(options.tagExpression, 'selection.tagExpression')
-  if (options.paths !== undefined) options.paths = normalizePaths(options.paths)
-  if (options.states !== undefined)
-    options.states = validateStates(options.states)
-  if (options.tagExpression) parseTagExpression(options.tagExpression as string)
-  if (options.shard !== undefined) validateShard(options.shard)
-  return options as unknown as SelectionOptions
+  return parsed(selectionOptionsSchema, value)
 }
 
 export function selectScenarios(
   specifications: readonly Specification[],
   options: SelectionOptions = {},
 ): ScenarioSelection[] {
-  const validatedOptions = validateSelectionOptions(options)
-  const name = validatedOptions.scenarioName?.trim().toLowerCase()
-  const tagExpression = validatedOptions.tagExpression
-    ? parseTagExpression(validatedOptions.tagExpression)
+  if (options.shard) assertShard(options.shard)
+  const name = options.scenarioName?.trim().toLowerCase()
+  const tagExpression = options.tagExpression
+    ? parseTagExpression(options.tagExpression)
     : undefined
 
-  const paths = validatedOptions.paths ? [validatedOptions.paths].flat() : []
-  const states = new Set<SpecificationState>(
-    validatedOptions.states ?? ['active'],
-  )
+  const paths = options.paths ? [options.paths].flat() : []
+  const states = new Set<SpecificationState>(options.states ?? ['active'])
 
   const selected = [...specifications]
     .sort((left, right) => left.source.uri.localeCompare(right.source.uri))
@@ -277,13 +262,11 @@ export function selectScenarios(
         !tagExpression || matchesTagExpression(tagExpression, scenario.tags),
     )
 
-  if (!validatedOptions.shard) return selected
+  if (!options.shard) return selected
 
   return selected
-    .filter(({ scenario }) => !scenario.tags.includes('@ignore'))
+    .filter(({ scenario }) => !scenario.tags.includes(ignoreTag))
     .filter(
-      (_, index) =>
-        index % validatedOptions.shard!.total ===
-        validatedOptions.shard!.index - 1,
+      (_, index) => index % options.shard!.total === options.shard!.index - 1,
     )
 }

--- a/packages/spec/src/specification.ts
+++ b/packages/spec/src/specification.ts
@@ -276,14 +276,3 @@ function collectIdentityNodes(
 
   for (const child of document.feature?.children ?? []) visitChild(child)
 }
-
-export async function parseSpecificationFile(
-  filePath: string,
-  language?: string,
-): Promise<Specification> {
-  return parseSpecification({
-    source: await Bun.file(filePath).text(),
-    uri: filePath,
-    language,
-  })
-}

--- a/packages/web/index.ts
+++ b/packages/web/index.ts
@@ -8,5 +8,11 @@ export type {
   WebIsolationState,
   WebObservedAction,
 } from './src/web-adapter'
-export { createWebAdapter, validateWebAdapterOptions } from './src/web-adapter'
+export {
+  createWebAdapter,
+  screenshotModes,
+  validateWebAdapterOptions,
+  webAdapterOptionsSchema,
+} from './src/web-adapter'
+export type { WebLogicalSession } from './src/web-pool'
 export { IsolationVerificationError, WebProcessPool } from './src/web-pool'

--- a/packages/web/index.ts
+++ b/packages/web/index.ts
@@ -4,6 +4,9 @@ export type {
   WebAdapterOptions,
   WebAutomation,
   WebAutomationFactory,
+  WebBrowserProcess,
+  WebIsolationState,
   WebObservedAction,
 } from './src/web-adapter'
 export { createWebAdapter, validateWebAdapterOptions } from './src/web-adapter'
+export { IsolationVerificationError, WebProcessPool } from './src/web-pool'

--- a/packages/web/src/abort.ts
+++ b/packages/web/src/abort.ts
@@ -1,0 +1,3 @@
+export function abortError(): DOMException {
+  return new DOMException('Scenario cancelled', 'AbortError')
+}

--- a/packages/web/src/stagehand-factory.ts
+++ b/packages/web/src/stagehand-factory.ts
@@ -1,0 +1,217 @@
+import {
+  browserbase,
+  localBrowser,
+  type ModelConfig,
+  Stagehand,
+} from '@browserbasehq/stagehand'
+import { z } from 'zod'
+import { abortError } from './abort'
+import type {
+  WebAutomation,
+  WebAutomationFactory,
+  WebClientContext,
+  WebIsolationState,
+  WebScreenshotCapture,
+} from './web-adapter'
+import { defaultModelName } from './web-options'
+
+const defaultDomSettleTimeoutMs = 3_000
+const defaultNavigationTimeoutMs = 15_000
+const defaultObserveTimeoutMs = 10_000
+const defaultActTimeoutMs = 15_000
+
+const verificationSchema = z.object({
+  meetsExpectation: z.boolean(),
+  actualState: z.string(),
+})
+
+type StagehandTimeouts = {
+  navigationTimeoutMs: number
+  observeTimeoutMs: number
+  actTimeoutMs: number
+}
+
+function withAbort<T>(operation: Promise<T>, signal?: AbortSignal): Promise<T> {
+  if (!signal) return operation
+  if (signal.aborted) return Promise.reject(abortError())
+
+  return new Promise<T>((resolvePromise, reject) => {
+    const onAbort = () => reject(abortError())
+    signal.addEventListener('abort', onAbort, { once: true })
+    operation.then(
+      (value) => {
+        signal.removeEventListener('abort', onAbort)
+        resolvePromise(value)
+      },
+      (error) => {
+        signal.removeEventListener('abort', onAbort)
+        reject(error)
+      },
+    )
+  })
+}
+
+async function activePage(stagehand: Stagehand) {
+  const page = await stagehand.browser.context.activePage()
+  if (!page) throw new Error('No active browser page')
+  return page
+}
+
+async function readStagehandIsolation(
+  stagehand: Stagehand,
+): Promise<WebIsolationState> {
+  const context = stagehand.browser.context
+  const cookieCount = (await context.cookies()).length
+  const page = await context.activePage()
+  let storageKeyCount = 0
+  if (page) {
+    storageKeyCount = (await page.evaluate(
+      '(() => { try { return localStorage.length } catch { return 0 } })()',
+    )) as number
+  }
+  return { cookieCount, storageKeyCount }
+}
+
+function createStagehandAutomation(
+  stagehand: Stagehand,
+  timeouts: StagehandTimeouts,
+): WebAutomation {
+  return {
+    async navigate(url, signal) {
+      const page = await activePage(stagehand)
+      await withAbort(
+        page
+          .goto(url, {
+            waitUntil: 'domcontentloaded',
+            timeout: timeouts.navigationTimeoutMs,
+          })
+          .then(() => undefined),
+        signal,
+      )
+    },
+    async observe(prompt, signal) {
+      const result = await withAbort(
+        stagehand.observe(prompt, {
+          timeout: timeouts.observeTimeoutMs,
+        }),
+        signal,
+      )
+      return result.data.map((action) => ({
+        description: action.description,
+        handle: action,
+      }))
+    },
+    async act(action, signal) {
+      const result = await withAbort(
+        stagehand.act(action.handle as Parameters<Stagehand['act']>[0], {
+          timeout: timeouts.actTimeoutMs,
+        }),
+        signal,
+      )
+      return {
+        success: result.data.success,
+        message: result.data.success ? undefined : result.data.message,
+      }
+    },
+    async verify(prompt, signal) {
+      const result = await withAbort(
+        stagehand.extract(
+          `Verify the following condition on the current page: "${prompt}". ` +
+            'Determine if the page currently meets this expectation.',
+          verificationSchema,
+        ),
+        signal,
+      )
+      return result.data
+    },
+    async screenshot(options: WebScreenshotCapture) {
+      const page = await activePage(stagehand)
+      return new Uint8Array(
+        await page.screenshot({
+          type: options.format,
+          fullPage: options.fullPage,
+        }),
+      )
+    },
+    readIsolationState: () => readStagehandIsolation(stagehand),
+    async close() {},
+  }
+}
+
+export const stagehandFactory: WebAutomationFactory = {
+  async launch({ browser: options, signal }) {
+    if (signal?.aborted) throw abortError()
+    const browser =
+      options.environment === 'browserbase'
+        ? await browserbase.launch({
+            apiKey:
+              options.browserbaseApiKey ?? process.env.BROWSERBASE_API_KEY!,
+            projectId:
+              options.browserbaseProjectId ??
+              process.env.BROWSERBASE_PROJECT_ID!,
+          })
+        : await localBrowser.launch({ headless: options.headless ?? true })
+
+    let stagehand: Stagehand | undefined
+
+    async function ensureStagehand(
+      context: WebClientContext,
+    ): Promise<Stagehand> {
+      if (stagehand) return stagehand
+      const modelName =
+        context.browser.modelName ?? options.modelName ?? defaultModelName
+      const modelApiKey = context.browser.modelApiKey ?? options.modelApiKey
+      const selfHeal = context.browser.selfHeal ?? options.selfHeal ?? true
+      const domSettleTimeoutMs =
+        context.browser.domSettleTimeoutMs ??
+        options.domSettleTimeoutMs ??
+        defaultDomSettleTimeoutMs
+      const cache = context.browser.cache ?? options.cache
+
+      stagehand = await Stagehand.create({
+        browser,
+        model: {
+          modelName: modelName as ModelConfig['modelName'],
+          apiKey: modelApiKey,
+        },
+        logging: { level: 'off', format: 'json' },
+        selfHeal,
+        domSettleTimeoutMs,
+        cache,
+      })
+      return stagehand
+    }
+
+    return {
+      async openContext(context) {
+        if (context.signal?.aborted) throw abortError()
+        const activeStagehand = await ensureStagehand(context)
+        return createStagehandAutomation(activeStagehand, {
+          navigationTimeoutMs:
+            context.browser.navigationTimeoutMs ??
+            options.navigationTimeoutMs ??
+            defaultNavigationTimeoutMs,
+          observeTimeoutMs:
+            context.browser.observeTimeoutMs ??
+            options.observeTimeoutMs ??
+            defaultObserveTimeoutMs,
+          actTimeoutMs:
+            context.browser.actTimeoutMs ??
+            options.actTimeoutMs ??
+            defaultActTimeoutMs,
+        })
+      },
+      async close() {
+        try {
+          if (stagehand) {
+            await stagehand.close()
+            stagehand = undefined
+          }
+        } catch {}
+        try {
+          await browser.close()
+        } catch {}
+      },
+    }
+  },
+}

--- a/packages/web/src/web-adapter.test.ts
+++ b/packages/web/src/web-adapter.test.ts
@@ -5,19 +5,31 @@ import { join } from 'node:path'
 import type { Scenario, Specification } from '@pickle-spec/spec'
 import {
   createWebAdapter,
+  validateWebAdapterOptions,
   type WebAutomation,
   type WebAutomationFactory,
 } from '../index'
 
-function withIsolation(
-  automation: Omit<WebAutomation, 'readIsolationState'> &
-    Partial<Pick<WebAutomation, 'readIsolationState'>>,
-): WebAutomation {
+function stubAutomation(overrides: Partial<WebAutomation> = {}): WebAutomation {
   return {
+    async navigate() {},
+    async observe() {
+      return []
+    },
+    async act() {
+      return { success: true }
+    },
+    async verify() {
+      return { meetsExpectation: true, actualState: 'Ready' }
+    },
+    async screenshot() {
+      return new Uint8Array()
+    },
     async readIsolationState() {
       return { cookieCount: 0, storageKeyCount: 0 }
     },
-    ...automation,
+    async close() {},
+    ...overrides,
   }
 }
 
@@ -47,6 +59,33 @@ const specification: Specification = {
   scenarios: [scenario],
 }
 
+const clearedGoogleApiKeys = {
+  GOOGLE_API_KEY: undefined,
+  GOOGLE_GENERATIVE_AI_API_KEY: undefined,
+  GEMINI_API_KEY: undefined,
+}
+
+async function withEnv(
+  values: Record<string, string | undefined>,
+  run: () => Promise<void>,
+): Promise<void> {
+  const previous = Object.fromEntries(
+    Object.keys(values).map((name) => [name, process.env[name]]),
+  )
+  for (const [name, value] of Object.entries(values)) {
+    if (value === undefined) delete process.env[name]
+    else process.env[name] = value
+  }
+  try {
+    await run()
+  } finally {
+    for (const name of Object.keys(values)) {
+      if (previous[name] === undefined) delete process.env[name]
+      else process.env[name] = previous[name]
+    }
+  }
+}
+
 describe('createWebAdapter', () => {
   const artifactDirectories: string[] = []
 
@@ -73,22 +112,23 @@ describe('createWebAdapter', () => {
       actualState: 'No results were shown',
     }))
     const close = mock(async () => {})
-    const automation = withIsolation({
-      navigate,
-      observe,
-      act,
-      verify,
-      async screenshot() {
-        return new Uint8Array([137, 80, 78, 71])
-      },
-      close,
-    })
     const adapter = createWebAdapter(
       {
         baseUrl: 'https://example.test',
         screenshots: { mode: 'on-step', outputDir: artifactDirectory },
       },
-      factoryFor(automation),
+      factoryFor(
+        stubAutomation({
+          navigate,
+          observe,
+          act,
+          verify,
+          async screenshot() {
+            return new Uint8Array([137, 80, 78, 71])
+          },
+          close,
+        }),
+      ),
     )
     const session = await adapter.openSession({
       executionTargetProfile: { id: 'web' },
@@ -127,23 +167,9 @@ describe('createWebAdapter', () => {
   test('gives explicit navigation precedence for an action step', async () => {
     const navigate = mock(async () => {})
     const observe = mock(async () => [])
-    const automation = withIsolation({
-      navigate,
-      observe,
-      async act() {
-        return { success: true }
-      },
-      async verify() {
-        return { meetsExpectation: true, actualState: 'Ready' }
-      },
-      async screenshot() {
-        return new Uint8Array()
-      },
-      async close() {},
-    })
     const adapter = createWebAdapter(
       { baseUrl: 'https://example.test' },
-      factoryFor(automation),
+      factoryFor(stubAutomation({ navigate, observe })),
     )
     const session = await adapter.openSession({
       executionTargetProfile: { id: 'web' },
@@ -172,28 +198,20 @@ describe('createWebAdapter', () => {
     expect(observe).not.toHaveBeenCalled()
   })
 
-  test('rejects an unsupported Stagehand model before opening a logical session', () => {
-    const launch = mock(async () => {
-      throw new Error('logical session must not start')
-    })
-
+  test('rejects an unsupported Stagehand model', () => {
     expect(() =>
-      createWebAdapter(
-        {
-          baseUrl: 'https://example.test',
-          browser: { modelName: 'google/gemini-3.7-flash' },
-        },
-        { launch },
-      ),
+      validateWebAdapterOptions({
+        baseUrl: 'https://example.test',
+        browser: { modelName: 'google/gemini-3.7-flash' },
+      }),
     ).toThrow(
       'web.browser.modelName "google/gemini-3.7-flash" is not a Stagehand-supported model',
     )
-    expect(launch).not.toHaveBeenCalled()
   })
 
   test('accepts a Stagehand-supported model name', () => {
     expect(() =>
-      createWebAdapter({
+      validateWebAdapterOptions({
         baseUrl: 'https://example.test',
         browser: { modelName: 'google/gemini-3.6-flash' },
       }),
@@ -201,58 +219,29 @@ describe('createWebAdapter', () => {
   })
 
   test('forwards GOOGLE_API_KEY to the automation factory for a Google model', async () => {
-    const names = [
-      'GOOGLE_API_KEY',
-      'GOOGLE_GENERATIVE_AI_API_KEY',
-      'GEMINI_API_KEY',
-    ]
-    const previous = Object.fromEntries(
-      names.map((name) => [name, process.env[name]]),
-    )
-    for (const name of names) delete process.env[name]
-    process.env.GOOGLE_API_KEY = 'test-google-key'
-    const openContext = mock(async () =>
-      withIsolation({
-        async navigate() {},
-        async observe() {
-          return []
-        },
-        async act() {
-          return { success: true }
-        },
-        async verify() {
-          return { meetsExpectation: true, actualState: 'Ready' }
-        },
-        async screenshot() {
-          return new Uint8Array()
-        },
-        async close() {},
-      }),
-    )
+    const openContext = mock(async () => stubAutomation())
     const launch = mock(async () => ({
       openContext,
       close: mock(async () => {}),
     }))
-    try {
-      const adapter = createWebAdapter(
-        {
-          baseUrl: 'https://example.test',
-          browser: { modelName: 'google/gemini-3.6-flash' },
-        },
-        { launch },
-      )
-      const session = await adapter.openSession({
-        executionTargetProfile: { id: 'web' },
-        specification,
-        scenario,
-      })
-      await session.close()
-    } finally {
-      for (const name of names) {
-        if (previous[name] === undefined) delete process.env[name]
-        else process.env[name] = previous[name]
-      }
-    }
+    await withEnv(
+      { ...clearedGoogleApiKeys, GOOGLE_API_KEY: 'test-google-key' },
+      async () => {
+        const adapter = createWebAdapter(
+          {
+            baseUrl: 'https://example.test',
+            browser: { modelName: 'google/gemini-3.6-flash' },
+          },
+          { launch },
+        )
+        const session = await adapter.openSession({
+          executionTargetProfile: { id: 'web' },
+          specification,
+          scenario,
+        })
+        await session.close()
+      },
+    )
 
     expect(launch).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -262,19 +251,11 @@ describe('createWebAdapter', () => {
   })
 
   test('rejects a local Stagehand session without a provider API key before launching a browser', async () => {
-    const previous = {
-      GOOGLE_API_KEY: process.env.GOOGLE_API_KEY,
-      GOOGLE_GENERATIVE_AI_API_KEY: process.env.GOOGLE_GENERATIVE_AI_API_KEY,
-      GEMINI_API_KEY: process.env.GEMINI_API_KEY,
-    }
-    delete process.env.GOOGLE_API_KEY
-    delete process.env.GOOGLE_GENERATIVE_AI_API_KEY
-    delete process.env.GEMINI_API_KEY
     const adapter = createWebAdapter({
       baseUrl: 'https://example.test',
       browser: { modelName: 'google/gemini-3.6-flash' },
     })
-    try {
+    await withEnv(clearedGoogleApiKeys, async () => {
       await expect(
         adapter.openSession({
           executionTargetProfile: { id: 'web' },
@@ -284,12 +265,7 @@ describe('createWebAdapter', () => {
       ).rejects.toThrow(
         'Model inference requires a provider API key or a Browserbase session',
       )
-    } finally {
-      for (const [name, value] of Object.entries(previous)) {
-        if (value === undefined) delete process.env[name]
-        else process.env[name] = value
-      }
-    }
+    })
   })
 
   test('replays multiple planned actions without model action resolution', async () => {
@@ -297,21 +273,9 @@ describe('createWebAdapter', () => {
       { description: 'Must not resolve', handle: { selector: '#new' } },
     ])
     const act = mock(async () => ({ success: true }))
-    const automation = withIsolation({
-      async navigate() {},
-      observe,
-      act,
-      async verify() {
-        return { meetsExpectation: true, actualState: 'Ready' }
-      },
-      async screenshot() {
-        return new Uint8Array()
-      },
-      async close() {},
-    })
     const adapter = createWebAdapter(
       { baseUrl: 'https://example.test' },
-      factoryFor(automation),
+      factoryFor(stubAutomation({ observe, act })),
     )
     const session = await adapter.openSession({
       executionTargetProfile: { id: 'web' },
@@ -392,20 +356,7 @@ describe('createWebAdapter', () => {
     }))
     const adapter = createWebAdapter(
       { baseUrl: 'https://example.test' },
-      factoryFor(
-        withIsolation({
-          async navigate() {},
-          observe,
-          act,
-          async verify() {
-            return { meetsExpectation: true, actualState: 'Ready' }
-          },
-          async screenshot() {
-            return new Uint8Array()
-          },
-          async close() {},
-        }),
-      ),
+      factoryFor(stubAutomation({ observe, act })),
     )
     const plan = {
       schemaVersion: 1 as const,
@@ -463,20 +414,7 @@ describe('createWebAdapter', () => {
     const act = mock(async () => ({ success: true }))
     const adapter = createWebAdapter(
       { baseUrl: 'https://example.test' },
-      factoryFor(
-        withIsolation({
-          async navigate() {},
-          observe,
-          act,
-          async verify() {
-            return { meetsExpectation: true, actualState: 'Ready' }
-          },
-          async screenshot() {
-            return new Uint8Array()
-          },
-          async close() {},
-        }),
-      ),
+      factoryFor(stubAutomation({ observe, act })),
     )
     const session = await adapter.openSession({
       executionTargetProfile: { id: 'web' },
@@ -511,24 +449,7 @@ describe('createWebAdapter', () => {
 
   test('pools browser processes across consecutive logical sessions', async () => {
     const launch = mock(async () => ({
-      openContext: mock(async () =>
-        withIsolation({
-          async navigate() {},
-          async observe() {
-            return []
-          },
-          async act() {
-            return { success: true }
-          },
-          async verify() {
-            return { meetsExpectation: true, actualState: 'Ready' }
-          },
-          async screenshot() {
-            return new Uint8Array()
-          },
-          async close() {},
-        }),
-      ),
+      openContext: mock(async () => stubAutomation()),
       close: mock(async () => {}),
     }))
     const adapter = createWebAdapter(
@@ -556,32 +477,13 @@ describe('createWebAdapter', () => {
   test('surfaces isolation verification failure when opening a logical session', async () => {
     const adapter = createWebAdapter(
       { baseUrl: 'https://example.test' },
-      {
-        launch: mock(async () => ({
-          openContext: mock(async () =>
-            withIsolation({
-              async readIsolationState() {
-                return { cookieCount: 2, storageKeyCount: 0 }
-              },
-              async navigate() {},
-              async observe() {
-                return []
-              },
-              async act() {
-                return { success: true }
-              },
-              async verify() {
-                return { meetsExpectation: true, actualState: 'Ready' }
-              },
-              async screenshot() {
-                return new Uint8Array()
-              },
-              async close() {},
-            }),
-          ),
-          close: mock(async () => {}),
-        })),
-      },
+      factoryFor(
+        stubAutomation({
+          async readIsolationState() {
+            return { cookieCount: 2, storageKeyCount: 0 }
+          },
+        }),
+      ),
     )
 
     await expect(
@@ -598,7 +500,7 @@ describe('createWebAdapter', () => {
     let closeFinished = false
     const launch = mock(async () => ({
       openContext: mock(async () =>
-        withIsolation({
+        stubAutomation({
           async navigate(_url, signal) {
             await new Promise((_resolve, reject) => {
               signal?.addEventListener(
@@ -608,18 +510,6 @@ describe('createWebAdapter', () => {
                 { once: true },
               )
             })
-          },
-          async observe() {
-            return []
-          },
-          async act() {
-            return { success: true }
-          },
-          async verify() {
-            return { meetsExpectation: true, actualState: 'Ready' }
-          },
-          async screenshot() {
-            return new Uint8Array()
           },
           async close() {
             closeStarted = true

--- a/packages/web/src/web-adapter.test.ts
+++ b/packages/web/src/web-adapter.test.ts
@@ -9,6 +9,27 @@ import {
   type WebAutomationFactory,
 } from '../index'
 
+function withIsolation(
+  automation: Omit<WebAutomation, 'readIsolationState'> &
+    Partial<Pick<WebAutomation, 'readIsolationState'>>,
+): WebAutomation {
+  return {
+    async readIsolationState() {
+      return { cookieCount: 0, storageKeyCount: 0 }
+    },
+    ...automation,
+  }
+}
+
+function factoryFor(automation: WebAutomation): WebAutomationFactory {
+  return {
+    launch: mock(async () => ({
+      openContext: mock(async () => automation),
+      close: mock(async () => {}),
+    })),
+  }
+}
+
 const scenario: Scenario = {
   name: 'Search for pickles',
   tags: ['@web'],
@@ -52,7 +73,7 @@ describe('createWebAdapter', () => {
       actualState: 'No results were shown',
     }))
     const close = mock(async () => {})
-    const automation: WebAutomation = {
+    const automation = withIsolation({
       navigate,
       observe,
       act,
@@ -61,16 +82,13 @@ describe('createWebAdapter', () => {
         return new Uint8Array([137, 80, 78, 71])
       },
       close,
-    }
-    const factory: WebAutomationFactory = {
-      open: mock(async () => automation),
-    }
+    })
     const adapter = createWebAdapter(
       {
         baseUrl: 'https://example.test',
         screenshots: { mode: 'on-step', outputDir: artifactDirectory },
       },
-      factory,
+      factoryFor(automation),
     )
     const session = await adapter.openSession({
       executionTargetProfile: { id: 'web' },
@@ -109,7 +127,7 @@ describe('createWebAdapter', () => {
   test('gives explicit navigation precedence for an action step', async () => {
     const navigate = mock(async () => {})
     const observe = mock(async () => [])
-    const automation: WebAutomation = {
+    const automation = withIsolation({
       navigate,
       observe,
       async act() {
@@ -122,14 +140,10 @@ describe('createWebAdapter', () => {
         return new Uint8Array()
       },
       async close() {},
-    }
+    })
     const adapter = createWebAdapter(
       { baseUrl: 'https://example.test' },
-      {
-        async open() {
-          return automation
-        },
-      },
+      factoryFor(automation),
     )
     const session = await adapter.openSession({
       executionTargetProfile: { id: 'web' },
@@ -159,7 +173,7 @@ describe('createWebAdapter', () => {
   })
 
   test('rejects an unsupported Stagehand model before opening a logical session', () => {
-    const open = mock(async () => {
+    const launch = mock(async () => {
       throw new Error('logical session must not start')
     })
 
@@ -169,12 +183,12 @@ describe('createWebAdapter', () => {
           baseUrl: 'https://example.test',
           browser: { modelName: 'google/gemini-3.7-flash' },
         },
-        { open },
+        { launch },
       ),
     ).toThrow(
       'web.browser.modelName "google/gemini-3.7-flash" is not a Stagehand-supported model',
     )
-    expect(open).not.toHaveBeenCalled()
+    expect(launch).not.toHaveBeenCalled()
   })
 
   test('accepts a Stagehand-supported model name', () => {
@@ -197,21 +211,27 @@ describe('createWebAdapter', () => {
     )
     for (const name of names) delete process.env[name]
     process.env.GOOGLE_API_KEY = 'test-google-key'
-    const open = mock(async () => ({
-      async navigate() {},
-      async observe() {
-        return []
-      },
-      async act() {
-        return { success: true }
-      },
-      async verify() {
-        return { meetsExpectation: true, actualState: 'Ready' }
-      },
-      async screenshot() {
-        return new Uint8Array()
-      },
-      async close() {},
+    const openContext = mock(async () =>
+      withIsolation({
+        async navigate() {},
+        async observe() {
+          return []
+        },
+        async act() {
+          return { success: true }
+        },
+        async verify() {
+          return { meetsExpectation: true, actualState: 'Ready' }
+        },
+        async screenshot() {
+          return new Uint8Array()
+        },
+        async close() {},
+      }),
+    )
+    const launch = mock(async () => ({
+      openContext,
+      close: mock(async () => {}),
     }))
     try {
       const adapter = createWebAdapter(
@@ -219,7 +239,7 @@ describe('createWebAdapter', () => {
           baseUrl: 'https://example.test',
           browser: { modelName: 'google/gemini-3.6-flash' },
         },
-        { open },
+        { launch },
       )
       const session = await adapter.openSession({
         executionTargetProfile: { id: 'web' },
@@ -234,7 +254,7 @@ describe('createWebAdapter', () => {
       }
     }
 
-    expect(open).toHaveBeenCalledWith(
+    expect(launch).toHaveBeenCalledWith(
       expect.objectContaining({
         browser: expect.objectContaining({ modelApiKey: 'test-google-key' }),
       }),
@@ -277,7 +297,7 @@ describe('createWebAdapter', () => {
       { description: 'Must not resolve', handle: { selector: '#new' } },
     ])
     const act = mock(async () => ({ success: true }))
-    const automation: WebAutomation = {
+    const automation = withIsolation({
       async navigate() {},
       observe,
       act,
@@ -288,14 +308,10 @@ describe('createWebAdapter', () => {
         return new Uint8Array()
       },
       async close() {},
-    }
+    })
     const adapter = createWebAdapter(
       { baseUrl: 'https://example.test' },
-      {
-        async open() {
-          return automation
-        },
-      },
+      factoryFor(automation),
     )
     const session = await adapter.openSession({
       executionTargetProfile: { id: 'web' },
@@ -376,22 +392,20 @@ describe('createWebAdapter', () => {
     }))
     const adapter = createWebAdapter(
       { baseUrl: 'https://example.test' },
-      {
-        async open() {
-          return {
-            async navigate() {},
-            observe,
-            act,
-            async verify() {
-              return { meetsExpectation: true, actualState: 'Ready' }
-            },
-            async screenshot() {
-              return new Uint8Array()
-            },
-            async close() {},
-          }
-        },
-      },
+      factoryFor(
+        withIsolation({
+          async navigate() {},
+          observe,
+          act,
+          async verify() {
+            return { meetsExpectation: true, actualState: 'Ready' }
+          },
+          async screenshot() {
+            return new Uint8Array()
+          },
+          async close() {},
+        }),
+      ),
     )
     const plan = {
       schemaVersion: 1 as const,
@@ -449,22 +463,20 @@ describe('createWebAdapter', () => {
     const act = mock(async () => ({ success: true }))
     const adapter = createWebAdapter(
       { baseUrl: 'https://example.test' },
-      {
-        async open() {
-          return {
-            async navigate() {},
-            observe,
-            act,
-            async verify() {
-              return { meetsExpectation: true, actualState: 'Ready' }
-            },
-            async screenshot() {
-              return new Uint8Array()
-            },
-            async close() {},
-          }
-        },
-      },
+      factoryFor(
+        withIsolation({
+          async navigate() {},
+          observe,
+          act,
+          async verify() {
+            return { meetsExpectation: true, actualState: 'Ready' }
+          },
+          async screenshot() {
+            return new Uint8Array()
+          },
+          async close() {},
+        }),
+      ),
     )
     const session = await adapter.openSession({
       executionTargetProfile: { id: 'web' },
@@ -495,5 +507,154 @@ describe('createWebAdapter', () => {
     expect(action.state).toBe('passed-with-adaptation')
     expect(observe).toHaveBeenCalledTimes(1)
     expect(act).toHaveBeenCalledTimes(1)
+  })
+
+  test('pools browser processes across consecutive logical sessions', async () => {
+    const launch = mock(async () => ({
+      openContext: mock(async () =>
+        withIsolation({
+          async navigate() {},
+          async observe() {
+            return []
+          },
+          async act() {
+            return { success: true }
+          },
+          async verify() {
+            return { meetsExpectation: true, actualState: 'Ready' }
+          },
+          async screenshot() {
+            return new Uint8Array()
+          },
+          async close() {},
+        }),
+      ),
+      close: mock(async () => {}),
+    }))
+    const adapter = createWebAdapter(
+      { baseUrl: 'https://example.test' },
+      { launch },
+    )
+
+    const first = await adapter.openSession({
+      executionTargetProfile: { id: 'web' },
+      specification,
+      scenario,
+    })
+    await first.close()
+    const second = await adapter.openSession({
+      executionTargetProfile: { id: 'web' },
+      specification,
+      scenario: { ...scenario, name: 'Second search' },
+    })
+    await second.close()
+    await adapter.dispose?.()
+
+    expect(launch).toHaveBeenCalledTimes(1)
+  })
+
+  test('surfaces isolation verification failure when opening a logical session', async () => {
+    const adapter = createWebAdapter(
+      { baseUrl: 'https://example.test' },
+      {
+        launch: mock(async () => ({
+          openContext: mock(async () =>
+            withIsolation({
+              async readIsolationState() {
+                return { cookieCount: 2, storageKeyCount: 0 }
+              },
+              async navigate() {},
+              async observe() {
+                return []
+              },
+              async act() {
+                return { success: true }
+              },
+              async verify() {
+                return { meetsExpectation: true, actualState: 'Ready' }
+              },
+              async screenshot() {
+                return new Uint8Array()
+              },
+              async close() {},
+            }),
+          ),
+          close: mock(async () => {}),
+        })),
+      },
+    )
+
+    await expect(
+      adapter.openSession({
+        executionTargetProfile: { id: 'web' },
+        specification,
+        scenario,
+      }),
+    ).rejects.toThrow('Logical session isolation verification failed')
+  })
+
+  test('closes automation on abort before returning the browser process to the pool', async () => {
+    let closeStarted = false
+    let closeFinished = false
+    const launch = mock(async () => ({
+      openContext: mock(async () =>
+        withIsolation({
+          async navigate(_url, signal) {
+            await new Promise((_resolve, reject) => {
+              signal?.addEventListener(
+                'abort',
+                () =>
+                  reject(new DOMException('Scenario cancelled', 'AbortError')),
+                { once: true },
+              )
+            })
+          },
+          async observe() {
+            return []
+          },
+          async act() {
+            return { success: true }
+          },
+          async verify() {
+            return { meetsExpectation: true, actualState: 'Ready' }
+          },
+          async screenshot() {
+            return new Uint8Array()
+          },
+          async close() {
+            closeStarted = true
+            await Bun.sleep(10)
+            closeFinished = true
+          },
+        }),
+      ),
+      close: mock(async () => {}),
+    }))
+    const adapter = createWebAdapter(
+      { baseUrl: 'https://example.test' },
+      { launch },
+    )
+    const controller = new AbortController()
+    const session = await adapter.openSession({
+      executionTargetProfile: { id: 'web' },
+      specification,
+      scenario,
+      signal: controller.signal,
+    })
+    const execution = session.executeStep(scenario.steps[0]!, controller.signal)
+    controller.abort()
+    await expect(execution).rejects.toThrow('Scenario cancelled')
+    await session.close()
+    expect(closeStarted).toBe(true)
+    expect(closeFinished).toBe(true)
+
+    const reused = await adapter.openSession({
+      executionTargetProfile: { id: 'web' },
+      specification,
+      scenario: { ...scenario, name: 'Reuse after abort' },
+    })
+    await reused.close()
+    await adapter.dispose?.()
+    expect(launch).toHaveBeenCalledTimes(1)
   })
 })

--- a/packages/web/src/web-adapter.ts
+++ b/packages/web/src/web-adapter.ts
@@ -15,6 +15,7 @@ import type {
 } from '@pickle-spec/runner'
 import type { ScenarioStep } from '@pickle-spec/spec'
 import { z } from 'zod'
+import { WebProcessPool } from './web-pool'
 
 export interface BrowserOptions {
   environment?: 'local' | 'browserbase'
@@ -29,6 +30,7 @@ export interface BrowserOptions {
   observeTimeoutMs?: number
   actTimeoutMs?: number
   navigationTimeoutMs?: number
+  idleTimeoutMs?: number
 }
 
 export interface ScreenshotOptions {
@@ -126,6 +128,7 @@ export function validateWebAdapterOptions(value: unknown): WebAdapterOptions {
         'observeTimeoutMs',
         'actTimeoutMs',
         'navigationTimeoutMs',
+        'idleTimeoutMs',
       ],
       'web.browser',
     )
@@ -159,6 +162,7 @@ export function validateWebAdapterOptions(value: unknown): WebAdapterOptions {
       browser.navigationTimeoutMs,
       'web.browser.navigationTimeoutMs',
     )
+    optionalPositiveInteger(browser.idleTimeoutMs, 'web.browser.idleTimeoutMs')
   }
 
   if (web.screenshots !== undefined) {
@@ -195,6 +199,11 @@ export interface WebObservedAction {
   handle: unknown
 }
 
+export interface WebIsolationState {
+  cookieCount: number
+  storageKeyCount: number
+}
+
 export interface WebAutomation {
   navigate(url: string, signal?: AbortSignal): Promise<void>
   observe(prompt: string, signal?: AbortSignal): Promise<WebObservedAction[]>
@@ -213,14 +222,23 @@ export interface WebAutomation {
     format: 'png' | 'jpeg'
     fullPage: boolean
   }): Promise<Uint8Array>
+  readIsolationState(): Promise<WebIsolationState>
+  close(): Promise<void>
+}
+
+export interface WebBrowserProcess {
+  openContext(input: {
+    browser: BrowserOptions
+    signal?: AbortSignal
+  }): Promise<WebAutomation>
   close(): Promise<void>
 }
 
 export interface WebAutomationFactory {
-  open(input: {
+  launch(input: {
     browser: BrowserOptions
     signal?: AbortSignal
-  }): Promise<WebAutomation>
+  }): Promise<WebBrowserProcess>
 }
 
 const verificationSchema = z.object({
@@ -271,7 +289,7 @@ async function activePage(stagehand: Stagehand) {
 }
 
 const stagehandFactory: WebAutomationFactory = {
-  async open({ browser: options, signal }) {
+  async launch({ browser: options, signal }) {
     if (signal?.aborted) throw abortError()
     const browser =
       options.environment === 'browserbase'
@@ -283,91 +301,125 @@ const stagehandFactory: WebAutomationFactory = {
               process.env.BROWSERBASE_PROJECT_ID!,
           })
         : await localBrowser.launch({ headless: options.headless ?? true })
-    const model: ModelConfig = {
-      modelName: (options.modelName ??
-        'anthropic/claude-sonnet-4-6') as ModelConfig['modelName'],
-      ...(options.modelApiKey ? { apiKey: options.modelApiKey } : {}),
-    }
-    let stagehand: Stagehand
-    try {
-      stagehand = await Stagehand.create({
-        browser,
-        model,
-        logging: { level: 'off', format: 'json' },
-        selfHeal: options.selfHeal ?? true,
-        domSettleTimeoutMs: options.domSettleTimeoutMs ?? 3_000,
-        ...(options.cache !== undefined ? { cache: options.cache } : {}),
-      })
-    } catch (error) {
-      try {
-        await browser.close()
-      } catch {}
-      throw error
-    }
 
     return {
-      async navigate(url, operationSignal) {
-        const page = await activePage(stagehand)
-        await withAbort(
-          page
-            .goto(url, {
-              waitUntil: 'domcontentloaded',
-              timeout: options.navigationTimeoutMs ?? 15_000,
-            })
-            .then(() => undefined),
-          operationSignal,
-        )
-      },
-      async observe(prompt, operationSignal) {
-        const result = await withAbort(
-          stagehand.observe(prompt, {
-            timeout: options.observeTimeoutMs ?? 10_000,
-          }),
-          operationSignal,
-        )
-        return result.data.map((action) => ({
-          description: action.description,
-          handle: action,
-        }))
-      },
-      async act(action, operationSignal) {
-        const result = await withAbort(
-          stagehand.act(action.handle as Parameters<Stagehand['act']>[0], {
-            timeout: options.actTimeoutMs ?? 15_000,
-          }),
-          operationSignal,
-        )
-        return {
-          success: result.data.success,
-          ...(result.data.success ? {} : { message: result.data.message }),
+      async openContext(contextInput) {
+        if (contextInput.signal?.aborted) throw abortError()
+        const model: ModelConfig = {
+          modelName: (contextInput.browser.modelName ??
+            options.modelName ??
+            'anthropic/claude-sonnet-4-6') as ModelConfig['modelName'],
+          ...((contextInput.browser.modelApiKey ?? options.modelApiKey)
+            ? {
+                apiKey: (contextInput.browser.modelApiKey ??
+                  options.modelApiKey)!,
+              }
+            : {}),
         }
-      },
-      async verify(prompt, operationSignal) {
-        const result = await withAbort(
-          stagehand.extract(
-            `Verify the following condition on the current page: "${prompt}". ` +
-              'Determine if the page currently meets this expectation.',
-            verificationSchema,
-          ),
-          operationSignal,
-        )
-        return result.data
-      },
-      async screenshot(screenshotOptions) {
-        const page = await activePage(stagehand)
-        return new Uint8Array(
-          await page.screenshot({
-            type: screenshotOptions.format,
-            fullPage: screenshotOptions.fullPage,
-          }),
-        )
+        let stagehand: Stagehand
+        stagehand = await Stagehand.create({
+          browser,
+          model,
+          logging: { level: 'off', format: 'json' },
+          selfHeal: contextInput.browser.selfHeal ?? options.selfHeal ?? true,
+          domSettleTimeoutMs:
+            contextInput.browser.domSettleTimeoutMs ??
+            options.domSettleTimeoutMs ??
+            3_000,
+          ...((contextInput.browser.cache ?? options.cache) !== undefined
+            ? { cache: contextInput.browser.cache ?? options.cache }
+            : {}),
+        })
+
+        const navigationTimeoutMs =
+          contextInput.browser.navigationTimeoutMs ??
+          options.navigationTimeoutMs ??
+          15_000
+        const observeTimeoutMs =
+          contextInput.browser.observeTimeoutMs ??
+          options.observeTimeoutMs ??
+          10_000
+        const actTimeoutMs =
+          contextInput.browser.actTimeoutMs ?? options.actTimeoutMs ?? 15_000
+
+        return {
+          async navigate(url, operationSignal) {
+            const page = await activePage(stagehand)
+            await withAbort(
+              page
+                .goto(url, {
+                  waitUntil: 'domcontentloaded',
+                  timeout: navigationTimeoutMs,
+                })
+                .then(() => undefined),
+              operationSignal,
+            )
+          },
+          async observe(prompt, operationSignal) {
+            const result = await withAbort(
+              stagehand.observe(prompt, {
+                timeout: observeTimeoutMs,
+              }),
+              operationSignal,
+            )
+            return result.data.map((action) => ({
+              description: action.description,
+              handle: action,
+            }))
+          },
+          async act(action, operationSignal) {
+            const result = await withAbort(
+              stagehand.act(action.handle as Parameters<Stagehand['act']>[0], {
+                timeout: actTimeoutMs,
+              }),
+              operationSignal,
+            )
+            return {
+              success: result.data.success,
+              ...(result.data.success ? {} : { message: result.data.message }),
+            }
+          },
+          async verify(prompt, operationSignal) {
+            const result = await withAbort(
+              stagehand.extract(
+                `Verify the following condition on the current page: "${prompt}". ` +
+                  'Determine if the page currently meets this expectation.',
+                verificationSchema,
+              ),
+              operationSignal,
+            )
+            return result.data
+          },
+          async screenshot(screenshotOptions) {
+            const page = await activePage(stagehand)
+            return new Uint8Array(
+              await page.screenshot({
+                type: screenshotOptions.format,
+                fullPage: screenshotOptions.fullPage,
+              }),
+            )
+          },
+          async readIsolationState() {
+            const page = await activePage(stagehand)
+            return page.evaluate(`
+              ({
+                cookieCount: document.cookie
+                  ? document.cookie.split(';').filter((part) => part.trim()).length
+                  : 0,
+                storageKeyCount: localStorage.length,
+              })
+            `) as Promise<WebIsolationState>
+          },
+          async close() {
+            try {
+              await stagehand.close()
+            } catch {}
+          },
+        }
       },
       async close() {
         try {
-          await stagehand.close()
-        } catch {}
-        try {
-          await stagehand.browser.close()
+          await browser.close()
         } catch {}
       },
     }
@@ -479,33 +531,49 @@ export function createWebAdapter(
   factory: WebAutomationFactory = stagehandFactory,
 ): ExecutionTargetAdapter {
   const validatedOptions = validateWebAdapterOptions(options)
+  const pool = new WebProcessPool({
+    factory,
+    idleTimeoutMs: validatedOptions.browser?.idleTimeoutMs,
+  })
+
   return {
     capabilities: ['web', 'screenshots'],
     planFormatVersion: 'web.1',
+    async dispose() {
+      await pool.dispose()
+    },
     async openSession(input) {
-      const automation = await factory.open({
-        browser: stagehandBrowserOptions(
-          {
-            ...validatedOptions.browser,
-            selfHeal:
-              (input.mode ?? 'adaptive') === 'replay'
-                ? false
-                : (validatedOptions.browser?.selfHeal ?? true),
-          },
-          factory === stagehandFactory,
-        ),
-        signal: input.signal,
-      })
+      const browserOptions = stagehandBrowserOptions(
+        {
+          ...validatedOptions.browser,
+          selfHeal:
+            (input.mode ?? 'adaptive') === 'replay'
+              ? false
+              : (validatedOptions.browser?.selfHeal ?? true),
+        },
+        factory === stagehandFactory,
+      )
+      const logicalSession = await pool.openLogicalSession(
+        browserOptions,
+        input.signal,
+      )
+      const automation = logicalSession.automation
       let closed = false
+      let closePromise: Promise<void> | undefined
       let navigated = false
       let stepIndex = 0
       let executionMode = input.mode ?? 'adaptive'
 
       const close = async () => {
-        if (closed) return
-        closed = true
-        input.signal?.removeEventListener('abort', onAbort)
-        await automation.close()
+        if (closePromise) return closePromise
+        closePromise = (async () => {
+          if (closed) return
+          closed = true
+          input.signal?.removeEventListener('abort', onAbort)
+          await automation.close()
+          await logicalSession.release()
+        })()
+        return closePromise
       }
       const onAbort = () => {
         void close()

--- a/packages/web/src/web-adapter.ts
+++ b/packages/web/src/web-adapter.ts
@@ -1,198 +1,34 @@
 import { mkdir } from 'node:fs/promises'
 import { join, resolve } from 'node:path'
 import {
-  browserbase,
-  localBrowser,
-  type ModelConfig,
-  Stagehand,
-  StagehandCreateOptionsSchema,
-} from '@browserbasehq/stagehand'
-import type {
-  ExecutionTargetAdapter,
-  ResolvedAction,
-  StepExecution,
-  TestArtifact,
+  type ExecutionTargetAdapter,
+  isEvidenceState,
+  type ResolvedAction,
+  type StepExecution,
+  slug,
+  type TestArtifact,
 } from '@pickle-spec/runner'
 import type { ScenarioStep } from '@pickle-spec/spec'
-import { z } from 'zod'
+import { abortError } from './abort'
+import { stagehandFactory } from './stagehand-factory'
+import {
+  type BrowserOptions,
+  defaultModelName,
+  type ScreenshotOptions,
+  type WebAdapterOptions,
+} from './web-options'
 import { WebProcessPool } from './web-pool'
 
-export interface BrowserOptions {
-  environment?: 'local' | 'browserbase'
-  modelName?: string
-  modelApiKey?: string
-  headless?: boolean
-  browserbaseApiKey?: string
-  browserbaseProjectId?: string
-  cache?: boolean
-  selfHeal?: boolean
-  domSettleTimeoutMs?: number
-  observeTimeoutMs?: number
-  actTimeoutMs?: number
-  navigationTimeoutMs?: number
-  idleTimeoutMs?: number
-}
-
-export interface ScreenshotOptions {
-  mode?: 'off' | 'on-failure' | 'on-step'
-  outputDir?: string
-  format?: 'png' | 'jpeg'
-  fullPage?: boolean
-}
-
-export interface WebAdapterOptions {
-  baseUrl: string
-  browser?: BrowserOptions
-  screenshots?: ScreenshotOptions
-}
-
-function record(value: unknown, field: string): Record<string, unknown> {
-  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
-    throw new Error(`${field} must be an object`)
-  }
-  return value as Record<string, unknown>
-}
-
-function knownFields(
-  value: Record<string, unknown>,
-  fields: readonly string[],
-  parent: string,
-): void {
-  for (const field of Object.keys(value)) {
-    if (!fields.includes(field))
-      throw new Error(`${parent}.${field} is not supported`)
-  }
-}
-
-function optionalString(value: unknown, field: string): void {
-  if (value !== undefined && typeof value !== 'string')
-    throw new Error(`${field} must be a string`)
-}
-
-function optionalBoolean(value: unknown, field: string): void {
-  if (value !== undefined && typeof value !== 'boolean')
-    throw new Error(`${field} must be a boolean`)
-}
-
-function optionalPositiveInteger(value: unknown, field: string): void {
-  if (
-    value !== undefined &&
-    (!Number.isInteger(value) || (value as number) < 1)
-  ) {
-    throw new Error(`${field} must be an integer greater than or equal to 1`)
-  }
-}
-
-function validateModelName(value: unknown): void {
-  optionalString(value, 'web.browser.modelName')
-  if (value === undefined) return
-  if (!(value as string).trim()) {
-    throw new Error('web.browser.modelName must not be empty')
-  }
-  const parsed = StagehandCreateOptionsSchema.shape.model.safeParse({
-    modelName: value,
-  })
-  if (!parsed.success) {
-    throw new Error(
-      `web.browser.modelName "${value}" is not a Stagehand-supported model`,
-    )
-  }
-}
-
-export function validateWebAdapterOptions(value: unknown): WebAdapterOptions {
-  const web = record(value, 'web')
-  knownFields(web, ['baseUrl', 'browser', 'screenshots'], 'web')
-  if (typeof web.baseUrl !== 'string' || !web.baseUrl.trim()) {
-    throw new Error('web.baseUrl must not be empty')
-  }
-  try {
-    new URL(web.baseUrl)
-  } catch {
-    throw new Error('web.baseUrl must be a valid URL')
-  }
-
-  if (web.browser !== undefined) {
-    const browser = record(web.browser, 'web.browser')
-    knownFields(
-      browser,
-      [
-        'environment',
-        'modelName',
-        'modelApiKey',
-        'headless',
-        'browserbaseApiKey',
-        'browserbaseProjectId',
-        'cache',
-        'selfHeal',
-        'domSettleTimeoutMs',
-        'observeTimeoutMs',
-        'actTimeoutMs',
-        'navigationTimeoutMs',
-        'idleTimeoutMs',
-      ],
-      'web.browser',
-    )
-    if (
-      browser.environment !== undefined &&
-      browser.environment !== 'local' &&
-      browser.environment !== 'browserbase'
-    ) {
-      throw new Error('web.browser.environment must be local or browserbase')
-    }
-    validateModelName(browser.modelName)
-    optionalString(browser.modelApiKey, 'web.browser.modelApiKey')
-    optionalString(browser.browserbaseApiKey, 'web.browser.browserbaseApiKey')
-    optionalString(
-      browser.browserbaseProjectId,
-      'web.browser.browserbaseProjectId',
-    )
-    optionalBoolean(browser.headless, 'web.browser.headless')
-    optionalBoolean(browser.cache, 'web.browser.cache')
-    optionalBoolean(browser.selfHeal, 'web.browser.selfHeal')
-    optionalPositiveInteger(
-      browser.domSettleTimeoutMs,
-      'web.browser.domSettleTimeoutMs',
-    )
-    optionalPositiveInteger(
-      browser.observeTimeoutMs,
-      'web.browser.observeTimeoutMs',
-    )
-    optionalPositiveInteger(browser.actTimeoutMs, 'web.browser.actTimeoutMs')
-    optionalPositiveInteger(
-      browser.navigationTimeoutMs,
-      'web.browser.navigationTimeoutMs',
-    )
-    optionalPositiveInteger(browser.idleTimeoutMs, 'web.browser.idleTimeoutMs')
-  }
-
-  if (web.screenshots !== undefined) {
-    const screenshots = record(web.screenshots, 'web.screenshots')
-    knownFields(
-      screenshots,
-      ['mode', 'outputDir', 'format', 'fullPage'],
-      'web.screenshots',
-    )
-    if (
-      screenshots.mode !== undefined &&
-      !['off', 'on-failure', 'on-step'].includes(screenshots.mode as string)
-    ) {
-      throw new Error(
-        'web.screenshots.mode must be off, on-failure, or on-step',
-      )
-    }
-    optionalString(screenshots.outputDir, 'web.screenshots.outputDir')
-    if (
-      screenshots.format !== undefined &&
-      screenshots.format !== 'png' &&
-      screenshots.format !== 'jpeg'
-    ) {
-      throw new Error('web.screenshots.format must be png or jpeg')
-    }
-    optionalBoolean(screenshots.fullPage, 'web.screenshots.fullPage')
-  }
-
-  return web as unknown as WebAdapterOptions
-}
+export type {
+  BrowserOptions,
+  ScreenshotOptions,
+  WebAdapterOptions,
+} from './web-options'
+export {
+  screenshotModes,
+  validateWebAdapterOptions,
+  webAdapterOptionsSchema,
+} from './web-options'
 
 export interface WebObservedAction {
   description: string
@@ -204,47 +40,44 @@ export interface WebIsolationState {
   storageKeyCount: number
 }
 
+export interface WebActResult {
+  success: boolean
+  message?: string
+}
+
+export interface WebVerificationResult {
+  meetsExpectation: boolean
+  actualState: string
+}
+
+export interface WebScreenshotCapture {
+  format: 'png' | 'jpeg'
+  fullPage: boolean
+}
+
+export interface WebClientContext {
+  browser: BrowserOptions
+  signal?: AbortSignal
+}
+
 export interface WebAutomation {
   navigate(url: string, signal?: AbortSignal): Promise<void>
   observe(prompt: string, signal?: AbortSignal): Promise<WebObservedAction[]>
-  act(
-    action: WebObservedAction,
-    signal?: AbortSignal,
-  ): Promise<{ success: boolean; message?: string }>
-  verify(
-    prompt: string,
-    signal?: AbortSignal,
-  ): Promise<{
-    meetsExpectation: boolean
-    actualState: string
-  }>
-  screenshot(options: {
-    format: 'png' | 'jpeg'
-    fullPage: boolean
-  }): Promise<Uint8Array>
+  act(action: WebObservedAction, signal?: AbortSignal): Promise<WebActResult>
+  verify(prompt: string, signal?: AbortSignal): Promise<WebVerificationResult>
+  screenshot(options: WebScreenshotCapture): Promise<Uint8Array>
   readIsolationState(): Promise<WebIsolationState>
   close(): Promise<void>
 }
 
 export interface WebBrowserProcess {
-  openContext(input: {
-    browser: BrowserOptions
-    signal?: AbortSignal
-  }): Promise<WebAutomation>
+  openContext(input: WebClientContext): Promise<WebAutomation>
   close(): Promise<void>
 }
 
 export interface WebAutomationFactory {
-  launch(input: {
-    browser: BrowserOptions
-    signal?: AbortSignal
-  }): Promise<WebBrowserProcess>
+  launch(input: WebClientContext): Promise<WebBrowserProcess>
 }
-
-const verificationSchema = z.object({
-  meetsExpectation: z.boolean(),
-  actualState: z.string(),
-})
 
 const navigationPattern = new RegExp(
   '(?:' +
@@ -258,185 +91,17 @@ const navigationPattern = new RegExp(
   'i',
 )
 
-function abortError(): DOMException {
-  return new DOMException('Scenario cancelled', 'AbortError')
+const providerApiKeyEnvNamesByProvider: Record<string, string[]> = {
+  openai: ['OPENAI_API_KEY'],
+  anthropic: ['ANTHROPIC_API_KEY'],
+  google: ['GOOGLE_GENERATIVE_AI_API_KEY', 'GOOGLE_API_KEY', 'GEMINI_API_KEY'],
+  groq: ['GROQ_API_KEY'],
+  cerebras: ['CEREBRAS_API_KEY'],
 }
 
-function withAbort<T>(operation: Promise<T>, signal?: AbortSignal): Promise<T> {
-  if (!signal) return operation
-  if (signal.aborted) return Promise.reject(abortError())
-
-  return new Promise<T>((resolvePromise, reject) => {
-    const onAbort = () => reject(abortError())
-    signal.addEventListener('abort', onAbort, { once: true })
-    operation.then(
-      (value) => {
-        signal.removeEventListener('abort', onAbort)
-        resolvePromise(value)
-      },
-      (error) => {
-        signal.removeEventListener('abort', onAbort)
-        reject(error)
-      },
-    )
-  })
-}
-
-async function activePage(stagehand: Stagehand) {
-  const page = await stagehand.browser.context.activePage()
-  if (!page) throw new Error('No active browser page')
-  return page
-}
-
-const stagehandFactory: WebAutomationFactory = {
-  async launch({ browser: options, signal }) {
-    if (signal?.aborted) throw abortError()
-    const browser =
-      options.environment === 'browserbase'
-        ? await browserbase.launch({
-            apiKey:
-              options.browserbaseApiKey ?? process.env.BROWSERBASE_API_KEY!,
-            projectId:
-              options.browserbaseProjectId ??
-              process.env.BROWSERBASE_PROJECT_ID!,
-          })
-        : await localBrowser.launch({ headless: options.headless ?? true })
-
-    let stagehand: Stagehand | undefined
-
-    async function ensureStagehand(contextInput: {
-      browser: BrowserOptions
-      signal?: AbortSignal
-    }): Promise<Stagehand> {
-      if (stagehand) return stagehand
-      const modelName =
-        contextInput.browser.modelName ??
-        options.modelName ??
-        'anthropic/claude-sonnet-4-6'
-
-      const domSettleTimeoutMs =
-        contextInput.browser.domSettleTimeoutMs ??
-        options.domSettleTimeoutMs ??
-        3_000
-
-      stagehand = await Stagehand.create({
-        browser,
-        model: {
-          modelName: modelName as ModelConfig['modelName'],
-          apiKey: contextInput.browser.modelApiKey ?? options.modelApiKey,
-        },
-        logging: { level: 'off', format: 'json' },
-        selfHeal: contextInput.browser.selfHeal ?? options.selfHeal ?? true,
-        domSettleTimeoutMs,
-        cache: contextInput.browser.cache ?? options.cache,
-      })
-      return stagehand
-    }
-
-    return {
-      async openContext(contextInput) {
-        if (contextInput.signal?.aborted) throw abortError()
-        const activeStagehand = await ensureStagehand(contextInput)
-
-        const navigationTimeoutMs =
-          contextInput.browser.navigationTimeoutMs ??
-          options.navigationTimeoutMs ??
-          15_000
-        const observeTimeoutMs =
-          contextInput.browser.observeTimeoutMs ??
-          options.observeTimeoutMs ??
-          10_000
-        const actTimeoutMs =
-          contextInput.browser.actTimeoutMs ?? options.actTimeoutMs ?? 15_000
-
-        return {
-          async navigate(url, operationSignal) {
-            const page = await activePage(activeStagehand)
-            await withAbort(
-              page
-                .goto(url, {
-                  waitUntil: 'domcontentloaded',
-                  timeout: navigationTimeoutMs,
-                })
-                .then(() => undefined),
-              operationSignal,
-            )
-          },
-          async observe(prompt, operationSignal) {
-            const result = await withAbort(
-              activeStagehand.observe(prompt, {
-                timeout: observeTimeoutMs,
-              }),
-              operationSignal,
-            )
-            return result.data.map((action) => ({
-              description: action.description,
-              handle: action,
-            }))
-          },
-          async act(action, operationSignal) {
-            const result = await withAbort(
-              activeStagehand.act(
-                action.handle as Parameters<Stagehand['act']>[0],
-                {
-                  timeout: actTimeoutMs,
-                },
-              ),
-              operationSignal,
-            )
-            return {
-              success: result.data.success,
-              ...(result.data.success ? {} : { message: result.data.message }),
-            }
-          },
-          async verify(prompt, operationSignal) {
-            const result = await withAbort(
-              activeStagehand.extract(
-                `Verify the following condition on the current page: "${prompt}". ` +
-                  'Determine if the page currently meets this expectation.',
-                verificationSchema,
-              ),
-              operationSignal,
-            )
-            return result.data
-          },
-          async screenshot(screenshotOptions) {
-            const page = await activePage(activeStagehand)
-            return new Uint8Array(
-              await page.screenshot({
-                type: screenshotOptions.format,
-                fullPage: screenshotOptions.fullPage,
-              }),
-            )
-          },
-          async readIsolationState() {
-            const context = activeStagehand.browser.context
-            const cookieCount = (await context.cookies()).length
-            let storageKeyCount = 0
-            const page = await context.activePage()
-            if (page) {
-              storageKeyCount = await page.evaluate(
-                '(() => { try { return localStorage.length } catch { return 0 } })()',
-              )
-            }
-            return { cookieCount, storageKeyCount }
-          },
-          async close() {},
-        }
-      },
-      async close() {
-        try {
-          if (stagehand) {
-            await stagehand.close()
-            stagehand = undefined
-          }
-        } catch {}
-        try {
-          await browser.close()
-        } catch {}
-      },
-    }
-  },
+type BrowserLaunchConfig = {
+  browser: BrowserOptions | undefined
+  requireProviderApiKey: boolean
 }
 
 function promptFor(step: ScenarioStep): string {
@@ -449,12 +114,8 @@ function promptFor(step: ScenarioStep): string {
   return prompt
 }
 
-function safeName(value: string): string {
-  return value
-    .toLowerCase()
-    .replace(/[^a-z0-9]+/g, '-')
-    .replace(/^-|-$/g, '')
-    .slice(0, 80)
+function screenshotName(value: string): string {
+  return slug(value).slice(0, 80)
 }
 
 function navigationUrl(baseUrl: string, target: string): string {
@@ -484,25 +145,8 @@ function plannedAction(action: ResolvedAction): WebObservedAction {
 }
 
 function providerApiKeyEnvNames(modelName: string | undefined): string[] {
-  const provider = (modelName ?? 'anthropic/claude-sonnet-4-6').split('/')[0]
-  switch (provider) {
-    case 'openai':
-      return ['OPENAI_API_KEY']
-    case 'anthropic':
-      return ['ANTHROPIC_API_KEY']
-    case 'google':
-      return [
-        'GOOGLE_GENERATIVE_AI_API_KEY',
-        'GOOGLE_API_KEY',
-        'GEMINI_API_KEY',
-      ]
-    case 'groq':
-      return ['GROQ_API_KEY']
-    case 'cerebras':
-      return ['CEREBRAS_API_KEY']
-    default:
-      return []
-  }
+  const provider = (modelName ?? defaultModelName).split('/')[0]!
+  return providerApiKeyEnvNamesByProvider[provider] ?? []
 }
 
 function resolveModelApiKey(
@@ -516,14 +160,14 @@ function resolveModelApiKey(
   }
 }
 
-function stagehandBrowserOptions(
-  browser: BrowserOptions | undefined,
-  requireProviderApiKey: boolean,
-): BrowserOptions {
+function resolveBrowserLaunchOptions({
+  browser,
+  requireProviderApiKey,
+}: BrowserLaunchConfig): BrowserOptions {
   const modelApiKey = resolveModelApiKey(browser)
   const next = {
     ...browser,
-    ...(modelApiKey ? { modelApiKey } : {}),
+    modelApiKey,
   }
   if (
     requireProviderApiKey &&
@@ -539,14 +183,25 @@ function stagehandBrowserOptions(
   return next
 }
 
+function shouldCaptureScreenshot(
+  mode: NonNullable<ScreenshotOptions['mode']>,
+  state: StepExecution['state'],
+): boolean {
+  if (mode === 'off') return false
+  if (state === 'cancelled' || state === 'skipped') return false
+  if (mode === 'on-failure') return isEvidenceState(state)
+  return true
+}
+
 export function createWebAdapter(
   options: WebAdapterOptions,
-  factory: WebAutomationFactory = stagehandFactory,
+  factory?: WebAutomationFactory,
 ): ExecutionTargetAdapter {
-  const validatedOptions = validateWebAdapterOptions(options)
+  const automationFactory = factory ?? stagehandFactory
+  const requireProviderApiKey = factory === undefined
   const pool = new WebProcessPool({
-    factory,
-    idleTimeoutMs: validatedOptions.browser?.idleTimeoutMs,
+    factory: automationFactory,
+    idleTimeoutMs: options.browser?.idleTimeoutMs,
   })
 
   return {
@@ -556,32 +211,29 @@ export function createWebAdapter(
       await pool.dispose()
     },
     async openSession(input) {
-      const browserOptions = stagehandBrowserOptions(
-        {
-          ...validatedOptions.browser,
+      let executionMode = input.mode ?? 'adaptive'
+      const browserOptions = resolveBrowserLaunchOptions({
+        browser: {
+          ...options.browser,
           selfHeal:
-            (input.mode ?? 'adaptive') === 'replay'
+            executionMode === 'replay'
               ? false
-              : (validatedOptions.browser?.selfHeal ?? true),
+              : (options.browser?.selfHeal ?? true),
         },
-        factory === stagehandFactory,
-      )
+        requireProviderApiKey,
+      })
       const logicalSession = await pool.openLogicalSession(
         browserOptions,
         input.signal,
       )
       const automation = logicalSession.automation
-      let closed = false
       let closePromise: Promise<void> | undefined
       let navigated = false
       let stepIndex = 0
-      let executionMode = input.mode ?? 'adaptive'
 
       const close = async () => {
         if (closePromise) return closePromise
         closePromise = (async () => {
-          if (closed) return
-          closed = true
           input.signal?.removeEventListener('abort', onAbort)
           await automation.close()
           await logicalSession.release()
@@ -597,29 +249,21 @@ export function createWebAdapter(
         step: ScenarioStep,
         state: StepExecution['state'],
       ): Promise<TestArtifact | undefined> {
-        const screenshotOptions = validatedOptions.screenshots
+        const screenshotOptions = options.screenshots
         const mode = screenshotOptions?.mode ?? 'off'
-        if (mode === 'off') return undefined
-        if (
-          mode === 'on-failure' &&
-          state !== 'failed' &&
-          state !== 'infrastructure-error'
-        ) {
-          return undefined
-        }
-        if (state === 'cancelled' || state === 'skipped') return undefined
+        if (!shouldCaptureScreenshot(mode, state)) return undefined
 
         try {
           const format = screenshotOptions?.format ?? 'png'
           const directory = resolve(
             screenshotOptions?.outputDir ?? './.pickle/artifacts',
-            safeName(input.specification.name),
-            safeName(input.scenario.name),
+            screenshotName(input.specification.name),
+            screenshotName(input.scenario.name),
           )
           await mkdir(directory, { recursive: true })
           const path = join(
             directory,
-            `step-${String(stepIndex).padStart(2, '0')}-${state}-${safeName(step.text).slice(0, 40)}.${format}`,
+            `step-${String(stepIndex).padStart(2, '0')}-${state}-${screenshotName(step.text).slice(0, 40)}.${format}`,
           )
           await Bun.write(
             path,
@@ -648,7 +292,7 @@ export function createWebAdapter(
 
       async function ensureNavigation(signal?: AbortSignal): Promise<void> {
         if (navigated) return
-        await automation.navigate(validatedOptions.baseUrl, signal)
+        await automation.navigate(options.baseUrl, signal)
         navigated = true
       }
 
@@ -661,7 +305,7 @@ export function createWebAdapter(
           actions = await automation.observe(prompt, signal)
         if (actions.length === 0) {
           return {
-            state: 'infrastructure-error',
+            state: 'failed',
             resolvedActions: [],
             message: 'Observe returned no actions',
           }
@@ -670,14 +314,13 @@ export function createWebAdapter(
         const resolvedActions: ResolvedAction[] = []
         for (const action of actions) {
           const result = await automation.act(action, signal)
-          const replay = replayPayload(action.handle)
           resolvedActions.push({
             description: action.description,
-            ...(replay ? { replay } : {}),
+            replay: replayPayload(action.handle),
           })
           if (!result.success) {
             return {
-              state: 'infrastructure-error',
+              state: 'failed',
               resolvedActions,
               message: result.message ?? 'Web action failed',
             }
@@ -721,10 +364,7 @@ export function createWebAdapter(
           try {
             const navigation = prompt.match(navigationPattern)
             if (navigation) {
-              const url = navigationUrl(
-                validatedOptions.baseUrl,
-                navigation[1]!.trim(),
-              )
+              const url = navigationUrl(options.baseUrl, navigation[1]!.trim())
               await automation.navigate(url, operationSignal)
               navigated = true
               return finish(step, {

--- a/packages/web/src/web-adapter.ts
+++ b/packages/web/src/web-adapter.ts
@@ -302,34 +302,41 @@ const stagehandFactory: WebAutomationFactory = {
           })
         : await localBrowser.launch({ headless: options.headless ?? true })
 
+    let stagehand: Stagehand | undefined
+
+    async function ensureStagehand(contextInput: {
+      browser: BrowserOptions
+      signal?: AbortSignal
+    }): Promise<Stagehand> {
+      if (stagehand) return stagehand
+      const modelName =
+        contextInput.browser.modelName ??
+        options.modelName ??
+        'anthropic/claude-sonnet-4-6'
+
+      const domSettleTimeoutMs =
+        contextInput.browser.domSettleTimeoutMs ??
+        options.domSettleTimeoutMs ??
+        3_000
+
+      stagehand = await Stagehand.create({
+        browser,
+        model: {
+          modelName: modelName as ModelConfig['modelName'],
+          apiKey: contextInput.browser.modelApiKey ?? options.modelApiKey,
+        },
+        logging: { level: 'off', format: 'json' },
+        selfHeal: contextInput.browser.selfHeal ?? options.selfHeal ?? true,
+        domSettleTimeoutMs,
+        cache: contextInput.browser.cache ?? options.cache,
+      })
+      return stagehand
+    }
+
     return {
       async openContext(contextInput) {
         if (contextInput.signal?.aborted) throw abortError()
-        const model: ModelConfig = {
-          modelName: (contextInput.browser.modelName ??
-            options.modelName ??
-            'anthropic/claude-sonnet-4-6') as ModelConfig['modelName'],
-          ...((contextInput.browser.modelApiKey ?? options.modelApiKey)
-            ? {
-                apiKey: (contextInput.browser.modelApiKey ??
-                  options.modelApiKey)!,
-              }
-            : {}),
-        }
-        let stagehand: Stagehand
-        stagehand = await Stagehand.create({
-          browser,
-          model,
-          logging: { level: 'off', format: 'json' },
-          selfHeal: contextInput.browser.selfHeal ?? options.selfHeal ?? true,
-          domSettleTimeoutMs:
-            contextInput.browser.domSettleTimeoutMs ??
-            options.domSettleTimeoutMs ??
-            3_000,
-          ...((contextInput.browser.cache ?? options.cache) !== undefined
-            ? { cache: contextInput.browser.cache ?? options.cache }
-            : {}),
-        })
+        const activeStagehand = await ensureStagehand(contextInput)
 
         const navigationTimeoutMs =
           contextInput.browser.navigationTimeoutMs ??
@@ -344,7 +351,7 @@ const stagehandFactory: WebAutomationFactory = {
 
         return {
           async navigate(url, operationSignal) {
-            const page = await activePage(stagehand)
+            const page = await activePage(activeStagehand)
             await withAbort(
               page
                 .goto(url, {
@@ -357,7 +364,7 @@ const stagehandFactory: WebAutomationFactory = {
           },
           async observe(prompt, operationSignal) {
             const result = await withAbort(
-              stagehand.observe(prompt, {
+              activeStagehand.observe(prompt, {
                 timeout: observeTimeoutMs,
               }),
               operationSignal,
@@ -369,9 +376,12 @@ const stagehandFactory: WebAutomationFactory = {
           },
           async act(action, operationSignal) {
             const result = await withAbort(
-              stagehand.act(action.handle as Parameters<Stagehand['act']>[0], {
-                timeout: actTimeoutMs,
-              }),
+              activeStagehand.act(
+                action.handle as Parameters<Stagehand['act']>[0],
+                {
+                  timeout: actTimeoutMs,
+                },
+              ),
               operationSignal,
             )
             return {
@@ -381,7 +391,7 @@ const stagehandFactory: WebAutomationFactory = {
           },
           async verify(prompt, operationSignal) {
             const result = await withAbort(
-              stagehand.extract(
+              activeStagehand.extract(
                 `Verify the following condition on the current page: "${prompt}". ` +
                   'Determine if the page currently meets this expectation.',
                 verificationSchema,
@@ -391,7 +401,7 @@ const stagehandFactory: WebAutomationFactory = {
             return result.data
           },
           async screenshot(screenshotOptions) {
-            const page = await activePage(stagehand)
+            const page = await activePage(activeStagehand)
             return new Uint8Array(
               await page.screenshot({
                 type: screenshotOptions.format,
@@ -400,24 +410,27 @@ const stagehandFactory: WebAutomationFactory = {
             )
           },
           async readIsolationState() {
-            const page = await activePage(stagehand)
-            return page.evaluate(`
-              ({
-                cookieCount: document.cookie
-                  ? document.cookie.split(';').filter((part) => part.trim()).length
-                  : 0,
-                storageKeyCount: localStorage.length,
-              })
-            `) as Promise<WebIsolationState>
+            const context = activeStagehand.browser.context
+            const cookieCount = (await context.cookies()).length
+            let storageKeyCount = 0
+            const page = await context.activePage()
+            if (page) {
+              storageKeyCount = await page.evaluate(
+                '(() => { try { return localStorage.length } catch { return 0 } })()',
+              )
+            }
+            return { cookieCount, storageKeyCount }
           },
-          async close() {
-            try {
-              await stagehand.close()
-            } catch {}
-          },
+          async close() {},
         }
       },
       async close() {
+        try {
+          if (stagehand) {
+            await stagehand.close()
+            stagehand = undefined
+          }
+        } catch {}
         try {
           await browser.close()
         } catch {}

--- a/packages/web/src/web-options.ts
+++ b/packages/web/src/web-options.ts
@@ -1,0 +1,135 @@
+import { StagehandCreateOptionsSchema } from '@browserbasehq/stagehand'
+import { z } from 'zod'
+
+export const defaultModelName = 'anthropic/claude-sonnet-4-6'
+export const screenshotModes = ['off', 'on-failure', 'on-step'] as const
+export const screenshotFormats = ['png', 'jpeg'] as const
+export const browserEnvironments = ['local', 'browserbase'] as const
+
+function parsed<T>(schema: z.ZodType<T>, value: unknown): T {
+  const result = schema.safeParse(value)
+  if (result.success) return result.data
+  throw new Error(result.error.issues[0]?.message ?? 'Invalid web options')
+}
+
+function strictObject<Shape extends z.ZodRawShape>(
+  field: string,
+  shape: Shape,
+) {
+  return z.strictObject(shape, {
+    error: (issue) => {
+      if (issue.code === 'unrecognized_keys') {
+        const keys = 'keys' in issue ? (issue.keys as string[]) : []
+        return keys.map((key) => `${field}.${key} is not supported`).join('\n')
+      }
+      return `${field} must be an object`
+    },
+  })
+}
+
+function optionalString(field: string) {
+  return z.string({ error: `${field} must be a string` }).optional()
+}
+
+function optionalBoolean(field: string) {
+  return z.boolean({ error: `${field} must be a boolean` }).optional()
+}
+
+function optionalPositiveInteger(field: string) {
+  return z
+    .number({
+      error: `${field} must be an integer greater than or equal to 1`,
+    })
+    .int({
+      error: `${field} must be an integer greater than or equal to 1`,
+    })
+    .min(1, {
+      error: `${field} must be an integer greater than or equal to 1`,
+    })
+    .optional()
+}
+
+const browserOptionsSchema = strictObject('web.browser', {
+  environment: z
+    .enum(browserEnvironments, {
+      error: 'web.browser.environment must be local or browserbase',
+    })
+    .optional(),
+  modelName: optionalString('web.browser.modelName').superRefine(
+    (value, context) => {
+      if (value === undefined) return
+      if (!value.trim()) {
+        context.addIssue({
+          code: 'custom',
+          message: 'web.browser.modelName must not be empty',
+        })
+        return
+      }
+      const parsedModel = StagehandCreateOptionsSchema.shape.model.safeParse({
+        modelName: value,
+      })
+      if (!parsedModel.success) {
+        context.addIssue({
+          code: 'custom',
+          message: `web.browser.modelName "${value}" is not a Stagehand-supported model`,
+        })
+      }
+    },
+  ),
+  modelApiKey: optionalString('web.browser.modelApiKey'),
+  headless: optionalBoolean('web.browser.headless'),
+  browserbaseApiKey: optionalString('web.browser.browserbaseApiKey'),
+  browserbaseProjectId: optionalString('web.browser.browserbaseProjectId'),
+  cache: optionalBoolean('web.browser.cache'),
+  selfHeal: optionalBoolean('web.browser.selfHeal'),
+  domSettleTimeoutMs: optionalPositiveInteger('web.browser.domSettleTimeoutMs'),
+  observeTimeoutMs: optionalPositiveInteger('web.browser.observeTimeoutMs'),
+  actTimeoutMs: optionalPositiveInteger('web.browser.actTimeoutMs'),
+  navigationTimeoutMs: optionalPositiveInteger(
+    'web.browser.navigationTimeoutMs',
+  ),
+  idleTimeoutMs: optionalPositiveInteger('web.browser.idleTimeoutMs'),
+})
+
+const screenshotOptionsSchema = strictObject('web.screenshots', {
+  mode: z
+    .enum(screenshotModes, {
+      error: 'web.screenshots.mode must be off, on-failure, or on-step',
+    })
+    .optional(),
+  outputDir: optionalString('web.screenshots.outputDir'),
+  format: z
+    .enum(screenshotFormats, {
+      error: 'web.screenshots.format must be png or jpeg',
+    })
+    .optional(),
+  fullPage: optionalBoolean('web.screenshots.fullPage'),
+})
+
+export const webAdapterOptionsSchema = strictObject('web', {
+  baseUrl: z
+    .string({ error: 'web.baseUrl must not be empty' })
+    .trim()
+    .min(1, { error: 'web.baseUrl must not be empty' })
+    .refine(
+      (value) => {
+        try {
+          new URL(value)
+          return true
+        } catch {
+          return false
+        }
+      },
+      { error: 'web.baseUrl must be a valid URL' },
+    ),
+  browser: browserOptionsSchema.optional(),
+  screenshots: screenshotOptionsSchema.optional(),
+})
+
+export type BrowserOptions = z.infer<typeof browserOptionsSchema>
+export type ScreenshotOptions = z.infer<typeof screenshotOptionsSchema>
+export type WebAdapterOptions = z.infer<typeof webAdapterOptionsSchema>
+
+export function validateWebAdapterOptions(value: unknown): WebAdapterOptions {
+  return parsed(webAdapterOptionsSchema, value)
+}

--- a/packages/web/src/web-pool.test.ts
+++ b/packages/web/src/web-pool.test.ts
@@ -71,6 +71,33 @@ describe('WebProcessPool', () => {
     expect(launch).toHaveBeenCalledTimes(1)
   })
 
+  test('retires a process when release finds a dirty logical session', async () => {
+    const launch = mock(async () => {
+      let readCount = 0
+      return mockProcess(
+        isolatedAutomation({
+          async readIsolationState() {
+            readCount++
+            if (readCount === 1) return { cookieCount: 0, storageKeyCount: 0 }
+            return { cookieCount: 2, storageKeyCount: 0 }
+          },
+        }),
+      )
+    })
+    const pool = new WebProcessPool({ factory: { launch } })
+
+    const session = await pool.openLogicalSession({}, undefined)
+    await session.automation.close()
+    await session.release()
+
+    const recovered = await pool.openLogicalSession({}, undefined)
+    await recovered.automation.close()
+    await recovered.release()
+    await pool.dispose()
+
+    expect(launch).toHaveBeenCalledTimes(2)
+  })
+
   test('retires a process when isolation verification fails', async () => {
     let launchCount = 0
     const launch = mock(async () => {

--- a/packages/web/src/web-pool.test.ts
+++ b/packages/web/src/web-pool.test.ts
@@ -1,0 +1,158 @@
+import { afterEach, describe, expect, mock, test } from 'bun:test'
+import type {
+  WebAutomation,
+  WebAutomationFactory,
+  WebBrowserProcess,
+} from './web-adapter'
+import { IsolationVerificationError, WebProcessPool } from './web-pool'
+
+function isolatedAutomation(
+  overrides: Partial<WebAutomation> = {},
+): WebAutomation {
+  return {
+    async navigate() {},
+    async observe() {
+      return []
+    },
+    async act() {
+      return { success: true }
+    },
+    async verify() {
+      return { meetsExpectation: true, actualState: 'Ready' }
+    },
+    async screenshot() {
+      return new Uint8Array()
+    },
+    async readIsolationState() {
+      return { cookieCount: 0, storageKeyCount: 0 }
+    },
+    async close() {},
+    ...overrides,
+  }
+}
+
+function mockProcess(
+  automation: WebAutomation | (() => WebAutomation),
+): WebBrowserProcess {
+  return {
+    openContext: mock(async () =>
+      typeof automation === 'function' ? automation() : automation,
+    ),
+    close: mock(async () => {}),
+  }
+}
+
+function mockFactory(process: WebBrowserProcess | (() => WebBrowserProcess)) {
+  const launch = mock(async () =>
+    typeof process === 'function' ? process() : process,
+  )
+  const factory: WebAutomationFactory = { launch }
+  return { factory, launch }
+}
+
+describe('WebProcessPool', () => {
+  afterEach(() => {
+    mock.restore()
+  })
+
+  test('reuses a browser process for consecutive logical sessions', async () => {
+    const { factory, launch } = mockFactory(mockProcess(isolatedAutomation()))
+    const pool = new WebProcessPool({ factory, idleTimeoutMs: 60_000 })
+
+    const first = await pool.openLogicalSession({}, undefined)
+    await first.automation.close()
+    await first.release()
+
+    const second = await pool.openLogicalSession({}, undefined)
+    await second.automation.close()
+    await second.release()
+    await pool.dispose()
+
+    expect(launch).toHaveBeenCalledTimes(1)
+  })
+
+  test('retires a process when isolation verification fails', async () => {
+    let launchCount = 0
+    const launch = mock(async () => {
+      launchCount++
+      const process =
+        launchCount === 1
+          ? mockProcess(
+              isolatedAutomation({
+                async readIsolationState() {
+                  return { cookieCount: 1, storageKeyCount: 0 }
+                },
+              }),
+            )
+          : mockProcess(isolatedAutomation())
+      return process
+    })
+    const pool = new WebProcessPool({ factory: { launch } })
+
+    await expect(pool.openLogicalSession({}, undefined)).rejects.toThrow(
+      IsolationVerificationError,
+    )
+
+    const recovered = await pool.openLogicalSession({}, undefined)
+    await recovered.automation.close()
+    await recovered.release()
+    await pool.dispose()
+
+    expect(launch).toHaveBeenCalledTimes(2)
+  })
+
+  test('waits for logical session close before returning a process to the pool', async () => {
+    let closeStarted = false
+    let closeFinished = false
+    const automation = isolatedAutomation({
+      async close() {
+        closeStarted = true
+        await Bun.sleep(20)
+        closeFinished = true
+      },
+    })
+    const { factory } = mockFactory(mockProcess(automation))
+    const pool = new WebProcessPool({ factory, idleTimeoutMs: 60_000 })
+
+    const session = await pool.openLogicalSession({}, undefined)
+    const releasePromise = (async () => {
+      await session.automation.close()
+      await session.release()
+    })()
+    expect(closeFinished).toBe(false)
+    await releasePromise
+    expect(closeStarted).toBe(true)
+    expect(closeFinished).toBe(true)
+
+    await pool.openLogicalSession({}, undefined)
+    await pool.dispose()
+  })
+
+  test('closes idle processes after the configured timeout', async () => {
+    const process = mockProcess(isolatedAutomation())
+    const { factory } = mockFactory(process)
+    const pool = new WebProcessPool({ factory, idleTimeoutMs: 5 })
+
+    const session = await pool.openLogicalSession({}, undefined)
+    await session.automation.close()
+    await session.release()
+
+    await Bun.sleep(15)
+    expect(process.close).toHaveBeenCalledTimes(1)
+
+    await pool.dispose()
+  })
+
+  test('dispose closes warm processes immediately', async () => {
+    const process = mockProcess(isolatedAutomation())
+    const { factory } = mockFactory(process)
+    const pool = new WebProcessPool({ factory, idleTimeoutMs: 60_000 })
+
+    const session = await pool.openLogicalSession({}, undefined)
+    await session.automation.close()
+    await session.release()
+    await pool.dispose()
+
+    expect(process.close).toHaveBeenCalledTimes(1)
+  })
+})

--- a/packages/web/src/web-pool.ts
+++ b/packages/web/src/web-pool.ts
@@ -1,0 +1,122 @@
+import type { BrowserOptions, WebAutomationFactory } from './web-adapter'
+
+export class IsolationVerificationError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = 'IsolationVerificationError'
+  }
+}
+
+interface PooledProcess {
+  process: Awaited<ReturnType<WebAutomationFactory['launch']>>
+  idleTimer?: ReturnType<typeof setTimeout>
+}
+
+export interface WebProcessPoolOptions {
+  factory: WebAutomationFactory
+  idleTimeoutMs?: number
+}
+
+export class WebProcessPool {
+  private readonly factory: WebAutomationFactory
+  private readonly idleTimeoutMs: number
+  private readonly available: PooledProcess[] = []
+  private disposed = false
+
+  constructor(options: WebProcessPoolOptions) {
+    this.factory = options.factory
+    this.idleTimeoutMs = options.idleTimeoutMs ?? 30_000
+  }
+
+  async openLogicalSession(
+    browserOptions: BrowserOptions,
+    signal?: AbortSignal,
+  ) {
+    if (this.disposed) {
+      throw new Error('Web process pool is disposed')
+    }
+    if (signal?.aborted) {
+      throw new DOMException('Scenario cancelled', 'AbortError')
+    }
+
+    const pooled = await this.checkout(browserOptions, signal)
+    try {
+      const automation = await pooled.process.openContext({
+        browser: browserOptions,
+        signal,
+      })
+      const isolation = await automation.readIsolationState()
+      if (isolation.cookieCount > 0 || isolation.storageKeyCount > 0) {
+        await this.retire(pooled)
+        throw new IsolationVerificationError(
+          'Logical session isolation verification failed',
+        )
+      }
+      let released = false
+      const release = async () => {
+        if (released) return
+        released = true
+        await this.release(pooled)
+      }
+      return { automation, release }
+    } catch (error) {
+      if (!(error instanceof IsolationVerificationError)) {
+        await this.retire(pooled)
+      }
+      throw error
+    }
+  }
+
+  async dispose(): Promise<void> {
+    if (this.disposed) return
+    this.disposed = true
+    const processes = this.available.splice(0)
+    await Promise.all(processes.map((entry) => this.closePooled(entry)))
+  }
+
+  private async checkout(
+    browserOptions: BrowserOptions,
+    signal?: AbortSignal,
+  ): Promise<PooledProcess> {
+    while (this.available.length > 0) {
+      const pooled = this.available.pop()!
+      if (pooled.idleTimer) clearTimeout(pooled.idleTimer)
+      pooled.idleTimer = undefined
+      return pooled
+    }
+    const process = await this.factory.launch({
+      browser: browserOptions,
+      signal,
+    })
+    return { process }
+  }
+
+  private async release(pooled: PooledProcess): Promise<void> {
+    if (this.disposed) {
+      await pooled.process.close()
+      return
+    }
+    if (pooled.idleTimer) clearTimeout(pooled.idleTimer)
+    pooled.idleTimer = setTimeout(() => {
+      void this.closeIdle(pooled)
+    }, this.idleTimeoutMs)
+    this.available.push(pooled)
+  }
+
+  private async retire(pooled: PooledProcess): Promise<void> {
+    if (pooled.idleTimer) clearTimeout(pooled.idleTimer)
+    await pooled.process.close()
+  }
+
+  private async closeIdle(pooled: PooledProcess): Promise<void> {
+    const index = this.available.indexOf(pooled)
+    if (index === -1) return
+    this.available.splice(index, 1)
+    await pooled.process.close()
+  }
+
+  private async closePooled(pooled: PooledProcess): Promise<void> {
+    if (pooled.idleTimer) clearTimeout(pooled.idleTimer)
+    await pooled.process.close()
+  }
+}

--- a/packages/web/src/web-pool.ts
+++ b/packages/web/src/web-pool.ts
@@ -56,6 +56,11 @@ export class WebProcessPool {
       const release = async () => {
         if (released) return
         released = true
+        const state = await automation.readIsolationState()
+        if (state.cookieCount > 0 || state.storageKeyCount > 0) {
+          await this.retire(pooled)
+          return
+        }
         await this.release(pooled)
       }
       return { automation, release }

--- a/packages/web/src/web-pool.ts
+++ b/packages/web/src/web-pool.ts
@@ -1,4 +1,13 @@
-import type { BrowserOptions, WebAutomationFactory } from './web-adapter'
+import { abortError } from './abort'
+import type {
+  BrowserOptions,
+  WebAutomation,
+  WebAutomationFactory,
+  WebBrowserProcess,
+  WebIsolationState,
+} from './web-adapter'
+
+const defaultIdleTimeoutMs = 30_000
 
 export class IsolationVerificationError extends Error {
   constructor(message: string) {
@@ -8,13 +17,22 @@ export class IsolationVerificationError extends Error {
 }
 
 interface PooledProcess {
-  process: Awaited<ReturnType<WebAutomationFactory['launch']>>
+  process: WebBrowserProcess
   idleTimer?: ReturnType<typeof setTimeout>
 }
 
 export interface WebProcessPoolOptions {
   factory: WebAutomationFactory
   idleTimeoutMs?: number
+}
+
+export interface WebLogicalSession {
+  automation: WebAutomation
+  release(): Promise<void>
+}
+
+function isDirty(state: WebIsolationState): boolean {
+  return state.cookieCount > 0 || state.storageKeyCount > 0
 }
 
 export class WebProcessPool {
@@ -25,18 +43,18 @@ export class WebProcessPool {
 
   constructor(options: WebProcessPoolOptions) {
     this.factory = options.factory
-    this.idleTimeoutMs = options.idleTimeoutMs ?? 30_000
+    this.idleTimeoutMs = options.idleTimeoutMs ?? defaultIdleTimeoutMs
   }
 
   async openLogicalSession(
     browserOptions: BrowserOptions,
     signal?: AbortSignal,
-  ) {
+  ): Promise<WebLogicalSession> {
     if (this.disposed) {
       throw new Error('Web process pool is disposed')
     }
     if (signal?.aborted) {
-      throw new DOMException('Scenario cancelled', 'AbortError')
+      throw abortError()
     }
 
     const pooled = await this.checkout(browserOptions, signal)
@@ -46,8 +64,8 @@ export class WebProcessPool {
         signal,
       })
       const isolation = await automation.readIsolationState()
-      if (isolation.cookieCount > 0 || isolation.storageKeyCount > 0) {
-        await this.retire(pooled)
+      if (isDirty(isolation)) {
+        await this.closeProcess(pooled)
         throw new IsolationVerificationError(
           'Logical session isolation verification failed',
         )
@@ -57,17 +75,16 @@ export class WebProcessPool {
         if (released) return
         released = true
         const state = await automation.readIsolationState()
-        if (state.cookieCount > 0 || state.storageKeyCount > 0) {
-          await this.retire(pooled)
+        if (isDirty(state)) {
+          await this.closeProcess(pooled)
           return
         }
         await this.release(pooled)
       }
       return { automation, release }
     } catch (error) {
-      if (!(error instanceof IsolationVerificationError)) {
-        await this.retire(pooled)
-      }
+      if (error instanceof IsolationVerificationError) throw error
+      await this.closeProcess(pooled)
       throw error
     }
   }
@@ -76,17 +93,16 @@ export class WebProcessPool {
     if (this.disposed) return
     this.disposed = true
     const processes = this.available.splice(0)
-    await Promise.all(processes.map((entry) => this.closePooled(entry)))
+    await Promise.all(processes.map((entry) => this.closeProcess(entry)))
   }
 
   private async checkout(
     browserOptions: BrowserOptions,
     signal?: AbortSignal,
   ): Promise<PooledProcess> {
-    while (this.available.length > 0) {
-      const pooled = this.available.pop()!
-      if (pooled.idleTimer) clearTimeout(pooled.idleTimer)
-      pooled.idleTimer = undefined
+    const pooled = this.available.pop()
+    if (pooled) {
+      this.clearIdleTimer(pooled)
       return pooled
     }
     const process = await this.factory.launch({
@@ -98,30 +114,30 @@ export class WebProcessPool {
 
   private async release(pooled: PooledProcess): Promise<void> {
     if (this.disposed) {
-      await pooled.process.close()
+      await this.closeProcess(pooled)
       return
     }
-    if (pooled.idleTimer) clearTimeout(pooled.idleTimer)
+    this.clearIdleTimer(pooled)
     pooled.idleTimer = setTimeout(() => {
       void this.closeIdle(pooled)
     }, this.idleTimeoutMs)
     this.available.push(pooled)
   }
 
-  private async retire(pooled: PooledProcess): Promise<void> {
-    if (pooled.idleTimer) clearTimeout(pooled.idleTimer)
-    await pooled.process.close()
-  }
-
   private async closeIdle(pooled: PooledProcess): Promise<void> {
     const index = this.available.indexOf(pooled)
     if (index === -1) return
     this.available.splice(index, 1)
+    await this.closeProcess(pooled)
+  }
+
+  private async closeProcess(pooled: PooledProcess): Promise<void> {
+    this.clearIdleTimer(pooled)
     await pooled.process.close()
   }
 
-  private async closePooled(pooled: PooledProcess): Promise<void> {
+  private clearIdleTimer(pooled: PooledProcess): void {
     if (pooled.idleTimer) clearTimeout(pooled.idleTimer)
-    await pooled.process.close()
+    pooled.idleTimer = undefined
   }
 }


### PR DESCRIPTION
## Summary
- Schedule all selected Scenarios under one global concurrency limit and preserve deterministic result order in manifests via `scheduleIndex`.
- Pool browser processes in the web adapter with verified logical sessions, idle timeout, and `dispose()` for warm resource lifecycle.
- Default infrastructure retries to one attempt and add explicit `execution.functionalRetries` policy; dispose adapters after `pickle run`.

## Test plan
- [x] `bun run lint`
- [x] `bun run typecheck`
- [x] `bun run test`
- [x] Runner scheduling, retry, and manifest-order tests
- [x] Web pool isolation, idle, cancel-before-reuse, and process reuse tests
- [x] CLI workspace seam including web adapter composition

Closes #19

Made with [Cursor](https://cursor.com)