### PR TITLE
Launch Studio with live web run diagnosis

### DIFF
--- a/.impeccable/critique/2026-08-16T14-10-19Z__packages-studio-src-frontend-tsx.md
+++ b/.impeccable/critique/2026-08-16T14-10-19Z__packages-studio-src-frontend-tsx.md
@@ -1,0 +1,81 @@
+---
+target: studio page
+total_score: 20
+max_score: 40
+na_heuristics: 
+p0_count: 0
+p1_count: 3
+timestamp: 2026-08-16T14-10-19Z
+slug: packages-studio-src-frontend-tsx
+---
+Method: dual-agent (A: e5528ae4-8eb2-444a-b6e7-08b365227a31 · B: 1e786e82-a26e-4006-aa88-2b6b865fb2f5)
+
+## Design Health Score
+
+| # | Heuristic | Score | Key Issue |
+|---|-----------|-------|-----------|
+| 1 | Visibility of System Status | 2 | Badge + activity names; no run id, counts, or busy state |
+| 2 | Match System / Real World | 3 | Domain terms solid; `idle` and “later Studio slice” leak system-speak |
+| 3 | User Control and Freedom | 1 | No cancel/stop; Start stays armed; no deselect |
+| 4 | Consistency and Standards | 3 | Ledger tokens hold; attention rows are unlabeled text vs matrix state buttons |
+| 5 | Error Prevention | 2 | Double-start allowed; stub nav looks like real destinations |
+| 6 | Recognition Rather Than Recall | 2 | Empty matrix until run; suite/profile not shown before Start |
+| 7 | Flexibility and Efficiency | 1 | No shortcuts, filters, or rerun-this-Scenario |
+| 8 | Aesthetic and Minimalist Design | 3 | Flat Night Ledger is coherent; empty attention + stub nav waste chrome |
+| 9 | Error Recovery | 2 | Step message in oxide; no next action; screenshot alt is `kind` only |
+| 10 | Help and Documentation | 1 | One empty-state sentence; Adaptation undefined |
+| **Total** | | **20/40** | **Acceptable** |
+
+Cognitive load: **5/8 failures** (high). Fail: single focus, hierarchy, one thing at a time, minimal choices, progressive disclosure. Pass: grouping, working memory, idle chunking. Decision points >4: four area links (three stubs) plus Start; matrix cells scale with Scenarios × profiles.
+
+## Design Specificity Verdict
+
+**LLM assessment:** The diagnosis instruments are authored for Pickle Spec: Scenario × execution-target-profile matrix, labeled `failed` / `passed-with-adaptation` / `running` chips, Bone “Start test run,” Needs attention ordered failed-then-adapted. Domain language is clean. The shell is still interchangeable dark-tool chrome — four equal nav labels, shadcn button/badge, an `idle` chip, a hollow plate table. A neighboring runner could wear this frame unchanged. Specificity lives in the matrix and Adaptation mark, not yet in the ledger as a bound instrument (no run identity, no ink-on-page density).
+
+**Deterministic scan:** CLI `detect.mjs` exit 2, **1 finding**: `overused-font` (Inter) at `packages/studio/src/index.html:11`. DESIGN.md pins Inter as the Spec Ledger UI face; this is a brief override, not a backlog item. Overlay on the live idle page logged `[impeccable] No anti-patterns found.` A first sandboxed Studio load showed empty `#root` (asset chunks 401); that is an evidence artifact, not a product P0. Overlay “clean” on that blank load is a false negative.
+
+**Visual overlays:** Injection succeeded on a critique-only Studio instance. The overlay reported no anti-patterns. Critique servers were stopped after capture; no user-visible overlay remains in a live tab.
+
+## Overall Impression
+
+The Spec Ledger look is in place: Night Ledger field, Bone CTA, labeled state chips, hairline plates. Operate diagnosis is still hollow. First useful paint is an empty Runs room. The timeline latches onto whoever started first, so a payment failure can sit in a mute Needs attention list while the operator watches the wrong Scenario. The single biggest opportunity is to make the live run a steered instrument: one current area, one armed control, selection that follows the worst cell until the operator pins otherwise.
+
+## What's Working
+
+- **Target matrix is the signature.** Scenario rows, profile columns, state spelled on the cell — not color-only dots. This is the product, not a generic dashboard table.
+- **Needs attention sorts failures first.** Failed and infrastructure-error before Adaptation, matching the diagnosis job.
+- **Palette and type follow the ledger.** Bone action, Inter UI, JetBrains Mono on measurements, no shadows, chips not unlabeled dots.
+
+## Priority Issues
+
+- **[P1] Timeline does not follow failures.** `selectCell` keeps the first started Scenario; a later payment failure only appears as `{name} {state}` in Needs attention. Diagnosis ends on the wrong page of the ledger. **Fix:** Default selection = worst attention cell; pin only on explicit click; highlight the selected matrix cell. **Suggested command:** `$impeccable shape` (selection model) then `$impeccable layout`
+
+- **[P1] No exit from a live run.** Start remains the only control; a second click resets the view. **Fix:** Swap to a destructive Cancel while `running`; disable a second start; `aria-busy` on the run region. **Suggested command:** `$impeccable harden`
+
+- **[P1] Stub nav is a fake IA.** Specifications is first in the row; three of four areas dump “will be available in a later Studio slice.” Jordan hits a dead door before Start. **Fix:** One current area (Runs) as selected; other three `aria-disabled` or a single Later disclosure until those slices exist. **Suggested command:** `$impeccable distill`
+
+- **[P2] High-stakes rows are visually mute.** Attention is unstyled left-text; Adaptation is outline in the matrix, amber only on the header chip. **Fix:** Reuse failed/adaptation badges in the list; one recovery line (“Open step timeline”). **Suggested command:** `$impeccable colorize`
+
+- **[P2] Idle chrome without a pre-run ledger.** Empty Needs attention, empty matrix headers, `idle` chip, no suite/profile shown before Start. The operator cannot see what will run. **Fix:** Show known profiles (and suite names if already loaded) as the empty matrix; drop or collapse empty attention until a cell exists; replace `idle` with “Ready” or omit the chip. **Suggested command:** `$impeccable onboard`
+
+## Persona Red Flags
+
+Primary action: start a test run and diagnose a failure.
+
+**Alex (Power User):** One-click Start is right; then no shortcut, no rerun-failed, no cancel, no run id to copy. Will double-start or leave.
+
+**Jordan (First-Timer):** Specifications is the first link and a dead end. `idle` unexplained. “Start a test run to watch…” does not say what will run. Adaptation is jargon with no gloss.
+
+**Sam (Keyboard / SR):** Native links/buttons, `role="status"` on the badge, matrix `aria-label`s exist. No `aria-live` on activity/attention, no `aria-busy`, screenshot `alt` is `kind` only, live list rebuilds can move focus.
+
+**Quinn (QA author, local failing payment Scenario):** Start runs the whole suite. Timeline latches onto the first starter. Payment appears as a mute attention row without profile emphasis. Plans is a stub, so she cannot promote an Adaptation. She still has to know to click the failure.
+
+## Minor Observations
+
+`idle` chip on first load; empty matrix headers with no rows; timeline `null` causes layout jump; artifact links use Bone (`text-primary`); opening/error states are unstyled `p-8`; hash nav does not restore area; no visible selected-cell state; no reduced-motion treatment.
+
+## Questions to Consider
+
+- If Runs is the only real room, why is Specifications the first door?
+- Should the timeline be a lock on the worst cell, not a souvenir of whoever started first?
+- Where is the page number of this test run — the identity a ledger owes an operator?

--- a/.impeccable/design.json
+++ b/.impeccable/design.json
@@ -1,0 +1,378 @@
+{
+  "schemaVersion": 2,
+  "generatedAt": "2026-08-16T13:45:00.000Z",
+  "title": "Design System: Pickle Spec Studio",
+  "extensions": {
+    "colorMeta": {
+      "night-ledger": {
+        "role": "neutral",
+        "displayName": "Night Ledger",
+        "canonical": "oklch(0.145 0.012 250)",
+        "tonalRamp": [
+          "oklch(0.12 0.01 250)",
+          "oklch(0.145 0.012 250)",
+          "oklch(0.18 0.012 250)",
+          "oklch(0.28 0.012 250)",
+          "oklch(0.45 0.01 250)",
+          "oklch(0.62 0.01 250)",
+          "oklch(0.78 0.008 250)",
+          "oklch(0.93 0.006 250)"
+        ]
+      },
+      "raised-plate": {
+        "role": "neutral",
+        "displayName": "Raised Plate",
+        "canonical": "oklch(0.18 0.012 250)",
+        "tonalRamp": [
+          "oklch(0.14 0.01 250)",
+          "oklch(0.18 0.012 250)",
+          "oklch(0.22 0.012 250)",
+          "oklch(0.3 0.012 250)",
+          "oklch(0.48 0.01 250)",
+          "oklch(0.64 0.01 250)",
+          "oklch(0.8 0.008 250)",
+          "oklch(0.94 0.005 250)"
+        ]
+      },
+      "bone": {
+        "role": "primary",
+        "displayName": "Bone",
+        "canonical": "oklch(0.93 0.01 250)",
+        "tonalRamp": [
+          "oklch(0.2 0.01 250)",
+          "oklch(0.32 0.01 250)",
+          "oklch(0.45 0.01 250)",
+          "oklch(0.58 0.01 250)",
+          "oklch(0.72 0.01 250)",
+          "oklch(0.82 0.01 250)",
+          "oklch(0.93 0.01 250)",
+          "oklch(0.97 0.005 250)"
+        ]
+      },
+      "ink": {
+        "role": "neutral",
+        "displayName": "Ink",
+        "canonical": "oklch(0.145 0.012 250)",
+        "tonalRamp": [
+          "oklch(0.12 0.01 250)",
+          "oklch(0.145 0.012 250)",
+          "oklch(0.22 0.012 250)",
+          "oklch(0.35 0.01 250)",
+          "oklch(0.5 0.01 250)",
+          "oklch(0.68 0.01 250)",
+          "oklch(0.82 0.008 250)",
+          "oklch(0.94 0.005 250)"
+        ]
+      },
+      "mute": {
+        "role": "neutral",
+        "displayName": "Mute",
+        "canonical": "oklch(0.72 0.015 250)",
+        "tonalRamp": [
+          "oklch(0.28 0.015 250)",
+          "oklch(0.4 0.015 250)",
+          "oklch(0.52 0.015 250)",
+          "oklch(0.62 0.015 250)",
+          "oklch(0.72 0.015 250)",
+          "oklch(0.8 0.01 250)",
+          "oklch(0.88 0.008 250)",
+          "oklch(0.95 0.005 250)"
+        ]
+      },
+      "hairline": {
+        "role": "neutral",
+        "displayName": "Hairline",
+        "canonical": "oklch(0.3 0.012 250)",
+        "tonalRamp": [
+          "oklch(0.16 0.01 250)",
+          "oklch(0.22 0.012 250)",
+          "oklch(0.3 0.012 250)",
+          "oklch(0.4 0.01 250)",
+          "oklch(0.55 0.01 250)",
+          "oklch(0.7 0.008 250)",
+          "oklch(0.84 0.006 250)",
+          "oklch(0.94 0.004 250)"
+        ]
+      },
+      "well": {
+        "role": "neutral",
+        "displayName": "Well",
+        "canonical": "oklch(0.22 0.012 250)",
+        "tonalRamp": [
+          "oklch(0.16 0.01 250)",
+          "oklch(0.22 0.012 250)",
+          "oklch(0.28 0.012 250)",
+          "oklch(0.38 0.01 250)",
+          "oklch(0.52 0.01 250)",
+          "oklch(0.68 0.008 250)",
+          "oklch(0.82 0.006 250)",
+          "oklch(0.94 0.004 250)"
+        ]
+      },
+      "brine-tint": {
+        "role": "secondary",
+        "displayName": "Brine Tint",
+        "canonical": "oklch(0.24 0.025 185)",
+        "tonalRamp": [
+          "oklch(0.16 0.02 185)",
+          "oklch(0.24 0.025 185)",
+          "oklch(0.34 0.04 185)",
+          "oklch(0.46 0.06 185)",
+          "oklch(0.58 0.07 185)",
+          "oklch(0.7 0.07 185)",
+          "oklch(0.82 0.04 185)",
+          "oklch(0.94 0.015 185)"
+        ]
+      },
+      "brine-teal": {
+        "role": "secondary",
+        "displayName": "Brine Teal",
+        "canonical": "oklch(0.74 0.08 185)",
+        "tonalRamp": [
+          "oklch(0.16 0.03 185)",
+          "oklch(0.28 0.05 185)",
+          "oklch(0.4 0.07 185)",
+          "oklch(0.52 0.08 185)",
+          "oklch(0.64 0.08 185)",
+          "oklch(0.74 0.08 185)",
+          "oklch(0.84 0.05 185)",
+          "oklch(0.94 0.02 185)"
+        ]
+      },
+      "brine-ink": {
+        "role": "secondary",
+        "displayName": "Brine Ink",
+        "canonical": "oklch(0.16 0.03 185)",
+        "tonalRamp": [
+          "oklch(0.14 0.03 185)",
+          "oklch(0.16 0.03 185)",
+          "oklch(0.28 0.04 185)",
+          "oklch(0.42 0.05 185)",
+          "oklch(0.56 0.05 185)",
+          "oklch(0.7 0.04 185)",
+          "oklch(0.84 0.02 185)",
+          "oklch(0.94 0.01 185)"
+        ]
+      },
+      "plan-amber": {
+        "role": "tertiary",
+        "displayName": "Plan Amber",
+        "canonical": "oklch(0.8 0.11 85)",
+        "tonalRamp": [
+          "oklch(0.22 0.05 85)",
+          "oklch(0.34 0.08 85)",
+          "oklch(0.46 0.1 85)",
+          "oklch(0.58 0.11 85)",
+          "oklch(0.7 0.11 85)",
+          "oklch(0.8 0.11 85)",
+          "oklch(0.88 0.07 85)",
+          "oklch(0.95 0.03 85)"
+        ]
+      },
+      "plan-ink": {
+        "role": "tertiary",
+        "displayName": "Plan Ink",
+        "canonical": "oklch(0.22 0.05 85)",
+        "tonalRamp": [
+          "oklch(0.18 0.04 85)",
+          "oklch(0.22 0.05 85)",
+          "oklch(0.34 0.06 85)",
+          "oklch(0.48 0.07 85)",
+          "oklch(0.62 0.07 85)",
+          "oklch(0.76 0.06 85)",
+          "oklch(0.86 0.04 85)",
+          "oklch(0.95 0.02 85)"
+        ]
+      },
+      "failure-oxide": {
+        "role": "primary",
+        "displayName": "Failure Oxide",
+        "canonical": "oklch(0.7 0.14 32)",
+        "tonalRamp": [
+          "oklch(0.16 0.03 32)",
+          "oklch(0.28 0.08 32)",
+          "oklch(0.4 0.12 32)",
+          "oklch(0.52 0.14 32)",
+          "oklch(0.62 0.14 32)",
+          "oklch(0.7 0.14 32)",
+          "oklch(0.82 0.08 32)",
+          "oklch(0.94 0.03 32)"
+        ]
+      },
+      "failure-ink": {
+        "role": "neutral",
+        "displayName": "Failure Ink",
+        "canonical": "oklch(0.16 0.03 32)",
+        "tonalRamp": [
+          "oklch(0.14 0.03 32)",
+          "oklch(0.16 0.03 32)",
+          "oklch(0.28 0.05 32)",
+          "oklch(0.42 0.06 32)",
+          "oklch(0.56 0.06 32)",
+          "oklch(0.7 0.05 32)",
+          "oklch(0.84 0.03 32)",
+          "oklch(0.95 0.01 32)"
+        ]
+      },
+      "focus-ring": {
+        "role": "neutral",
+        "displayName": "Focus Ring",
+        "canonical": "oklch(0.86 0.02 250)",
+        "tonalRamp": [
+          "oklch(0.2 0.02 250)",
+          "oklch(0.35 0.02 250)",
+          "oklch(0.5 0.02 250)",
+          "oklch(0.64 0.02 250)",
+          "oklch(0.74 0.02 250)",
+          "oklch(0.86 0.02 250)",
+          "oklch(0.92 0.015 250)",
+          "oklch(0.97 0.008 250)"
+        ]
+      }
+    },
+    "typographyMeta": {
+      "headline": {
+        "displayName": "Headline",
+        "purpose": "Project name in the Studio header. No display size exists."
+      },
+      "title": {
+        "displayName": "Title",
+        "purpose": "Section titles such as Test run."
+      },
+      "body": {
+        "displayName": "Body",
+        "purpose": "Activity lists, empty copy, and nav items."
+      },
+      "label": {
+        "displayName": "Label",
+        "purpose": "Table headers, timeline headings, and button labels."
+      },
+      "mono": {
+        "displayName": "Mono",
+        "purpose": "Status chips and resolved-action measurements."
+      }
+    },
+    "shadows": [],
+    "motion": [
+      {
+        "name": "color-shift",
+        "value": "transition-colors",
+        "purpose": "Buttons change fill only. No translate, blur, or shadow motion."
+      }
+    ],
+    "breakpoints": [{ "name": "lg", "value": "1024px" }]
+  },
+  "components": [
+    {
+      "name": "Primary Button",
+      "kind": "button",
+      "refersTo": "button-primary",
+      "description": "Bone fill for the next operator action, typically Start test run.",
+      "html": "<button class=\"ds-btn-primary\" type=\"button\">Start test run</button>",
+      "css": ".ds-btn-primary { display: inline-flex; align-items: center; justify-content: center; height: 2.25rem; padding: 0 0.75rem; border: none; border-radius: 0.4rem; background: var(--primary); color: var(--primary-foreground); font-family: \"Inter\", ui-sans-serif, system-ui, sans-serif; font-size: 0.875rem; font-weight: 500; white-space: nowrap; cursor: pointer; transition: background-color 150ms ease; } .ds-btn-primary:hover { background: oklch(0.93 0.01 250 / 0.9); } .ds-btn-primary:focus-visible { outline: 2px solid var(--ring); outline-offset: 2px; } .ds-btn-primary:disabled { opacity: 0.5; pointer-events: none; }"
+    },
+    {
+      "name": "Outline Button",
+      "kind": "button",
+      "refersTo": "button-outline",
+      "description": "Hairline matrix cell for a non-failed result.",
+      "html": "<button class=\"ds-btn-outline\" type=\"button\">passed</button>",
+      "css": ".ds-btn-outline { display: inline-flex; align-items: center; justify-content: center; height: 2rem; padding: 0 0.625rem; border: 1px solid var(--border); border-radius: 0.4rem; background: var(--card); color: var(--card-foreground); font-family: \"Inter\", ui-sans-serif, system-ui, sans-serif; font-size: 0.875rem; font-weight: 500; cursor: pointer; transition: background-color 150ms ease, color 150ms ease; } .ds-btn-outline:hover { background: var(--accent); color: var(--accent-foreground); } .ds-btn-outline:focus-visible { outline: 2px solid var(--ring); outline-offset: 2px; }"
+    },
+    {
+      "name": "Destructive Button",
+      "kind": "button",
+      "refersTo": "button-destructive",
+      "description": "Failed matrix cell. Oxide fill, dark ink.",
+      "html": "<button class=\"ds-btn-destructive\" type=\"button\">failed</button>",
+      "css": ".ds-btn-destructive { display: inline-flex; align-items: center; justify-content: center; height: 2rem; padding: 0 0.625rem; border: none; border-radius: 0.4rem; background: var(--destructive); color: var(--destructive-foreground); font-family: \"Inter\", ui-sans-serif, system-ui, sans-serif; font-size: 0.875rem; font-weight: 500; cursor: pointer; } .ds-btn-destructive:hover { background: oklch(0.7 0.14 32 / 0.9); } .ds-btn-destructive:focus-visible { outline: 2px solid var(--ring); outline-offset: 2px; }"
+    },
+    {
+      "name": "Failed Badge",
+      "kind": "chip",
+      "refersTo": "badge-failed",
+      "description": "Labeled test-result chip for failed and infrastructure-error.",
+      "html": "<span class=\"ds-badge ds-badge-failed\">failed</span>",
+      "css": ".ds-badge { display: inline-flex; align-items: center; border-radius: 0.4rem; padding: 0.125rem 0.5rem; font-family: \"JetBrains Mono\", ui-monospace, monospace; font-size: 0.75rem; font-weight: 500; border: 1px solid transparent; } .ds-badge-failed { background: var(--destructive); color: var(--destructive-foreground); }"
+    },
+    {
+      "name": "Adaptation Badge",
+      "kind": "chip",
+      "refersTo": "badge-adaptation",
+      "description": "Labeled chip for passed-with-adaptation.",
+      "html": "<span class=\"ds-badge ds-badge-adaptation\">passed-with-adaptation</span>",
+      "css": ".ds-badge { display: inline-flex; align-items: center; border-radius: 0.4rem; padding: 0.125rem 0.5rem; font-family: \"JetBrains Mono\", ui-monospace, monospace; font-size: 0.75rem; font-weight: 500; border: 1px solid transparent; } .ds-badge-adaptation { background: var(--adaptation); color: var(--adaptation-foreground); }"
+    },
+    {
+      "name": "Passed Badge",
+      "kind": "chip",
+      "refersTo": "badge-passed",
+      "description": "Labeled chip for a passed result.",
+      "html": "<span class=\"ds-badge ds-badge-passed\">passed</span>",
+      "css": ".ds-badge { display: inline-flex; align-items: center; border-radius: 0.4rem; padding: 0.125rem 0.5rem; font-family: \"JetBrains Mono\", ui-monospace, monospace; font-size: 0.75rem; font-weight: 500; border: 1px solid transparent; } .ds-badge-passed { background: var(--passed); color: var(--passed-foreground); }"
+    },
+    {
+      "name": "Studio Nav",
+      "kind": "nav",
+      "refersTo": "nav-active",
+      "description": "Text-only area nav. Active item sits in a brine tint well.",
+      "html": "<nav class=\"ds-nav\" aria-label=\"Studio\"><a class=\"ds-nav-link\" href=\"#specifications\">Specifications</a><a class=\"ds-nav-link ds-nav-link-active\" href=\"#runs\">Runs</a><a class=\"ds-nav-link\" href=\"#plans\">Plans</a><a class=\"ds-nav-link\" href=\"#settings\">Settings</a></nav>",
+      "css": ".ds-nav { display: flex; gap: 0.25rem; } .ds-nav-link { border-radius: 0.4rem; padding: 0.375rem 0.75rem; font-family: \"Inter\", ui-sans-serif, system-ui, sans-serif; font-size: 0.875rem; color: var(--muted-foreground); text-decoration: none; } .ds-nav-link:hover { background: var(--secondary); } .ds-nav-link-active { background: var(--accent); color: var(--accent-foreground); } .ds-nav-link:focus-visible { outline: 2px solid var(--ring); outline-offset: 2px; }"
+    },
+    {
+      "name": "Ledger Plate",
+      "kind": "card",
+      "refersTo": "card",
+      "description": "Raised plate for the target matrix and timeline entries. Hairline only.",
+      "html": "<section class=\"ds-plate\"><h3 class=\"ds-plate-title\">Pay for the order · chrome</h3><p class=\"ds-plate-body\">Then payment is captured</p></section>",
+      "css": ".ds-plate { background: var(--card); color: var(--card-foreground); border: 1px solid var(--border); border-radius: 0.5rem; padding: 0.75rem 1rem; } .ds-plate-title { margin: 0 0 0.5rem; font-family: \"Inter\", ui-sans-serif, system-ui, sans-serif; font-size: 0.875rem; font-weight: 500; } .ds-plate-body { margin: 0; font-family: \"Inter\", ui-sans-serif, system-ui, sans-serif; font-size: 0.875rem; }"
+    }
+  ],
+  "narrative": {
+    "northStar": "The Spec Ledger",
+    "overview": "Studio is a bound technical ledger that happens to run on a screen. Feature files are the page; test results are the ink; an adaptation is a distinct mark, never a silent rewrite. The operator sits in a dark room with a local project, reading live state the way one reads a night-shift instrument — not a marketing dashboard.\n\nThe atmosphere is clinical lab, executed at the craft level of dark developer tools (Vercel, Cursor): near-black cool field, hairline plates, one light primary action, and color reserved for result state. Density is high. Chrome is thin. Empty space is leftover work, not a lifestyle.",
+    "keyCharacteristics": [
+      "Dark cool field with one-step raised plates, never a drop shadow",
+      "Bone-white primary action; teal, amber, and oxide only name a test-result state",
+      "Inter for UI, JetBrains Mono for measurements and resolved actions",
+      "Compact 8px corners, 9px controls, hairline borders",
+      "Status is a labeled chip, never a color-only dot"
+    ],
+    "rules": [
+      {
+        "name": "The Bone Rule",
+        "body": "The light fill is the primary action. Do not paint navigation, tables, or idle chips with Bone.",
+        "section": "colors"
+      },
+      {
+        "name": "The State Ink Rule",
+        "body": "Teal, amber, and oxide appear only on labeled result chips or a failed matrix cell. They do not tint the page.",
+        "section": "colors"
+      },
+      {
+        "name": "The Measurement Mono Rule",
+        "body": "Monospace is for data. Do not set headings, nav, or body copy in JetBrains Mono to look technical.",
+        "section": "typography"
+      },
+      {
+        "name": "The Flat Ledger Rule",
+        "body": "Surfaces are flat at rest and in motion. Do not add drop shadows, glows, or stacked cards to fake hierarchy.",
+        "section": "elevation"
+      }
+    ],
+    "dos": [
+      "Do keep the canvas dark and cool (Night Ledger) with one-step Raised Plates.",
+      "Do put the next operator action on a Bone button.",
+      "Do spell the test-result state on every chip and matrix cell.",
+      "Do use JetBrains Mono for resolved actions and status, Inter for everything else.",
+      "Do keep corners at 0.4–0.5rem and borders at 1px Hairline."
+    ],
+    "donts": [
+      "Don't add a tracked uppercase kicker above the project name.",
+      "Don't introduce drop shadows, glass, or neon status dots.",
+      "Don't spend Brine Teal on chrome or marketing blocks.",
+      "Don't invent a second source of truth in the UI — feature files and Git remain off-canvas systems of record.",
+      "Don't use Cucumber, Playwright, or \"self-healing\" visual language."
+    ]
+  }
+}

--- a/.impeccable/live/config.json
+++ b/.impeccable/live/config.json
@@ -1,0 +1,6 @@
+{
+  "files": ["packages/studio/src/index.html"],
+  "insertBefore": "</body>",
+  "commentSyntax": "html",
+  "cspChecked": true
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,6 +10,7 @@ This repository is a Bun + Turborepo monorepo:
 - `packages/runner` — scheduling, run events, and test results
 - `packages/web` — Stagehand execution-target adapter
 - `packages/cli` — executable package composition
+- `packages/studio` — local Studio UI
 - `apps/example` — sample Specifications
 
 Use `bun run lint`, `bun run typecheck`, and `bun run test` from the repo root. Typecheck and test run through Turborepo. Lint and format use Biome from the repo root.
@@ -138,6 +139,20 @@ Then, run index.ts
 ```sh
 bun --hot ./index.ts
 ```
+
+## Studio UI
+
+Studio lives in `packages/studio`. Visual style is shadcn Mira on Base UI (`style: "base-mira"` in `packages/studio/components.json`).
+
+Every UI control must be a shadcn Mira primitive (or compose those primitives). Do not hand-roll a styled `<button>`, `<a>`, `<span>`, table chrome, or layout block that duplicates a registry component. Wrapping `@base-ui/react` yourself is not a substitute for adding the shadcn primitive — Mira only applies when the component comes from the registry.
+
+Before creating a new component or block:
+
+1. Search the shadcn registry for an existing primitive (`search_items_in_registries` / `view_items_in_registries`, or `bunx shadcn@latest search <name>` from `packages/studio`).
+2. If it exists, add it with `bunx shadcn@latest add <name>` from `packages/studio` so Mira is applied.
+3. Extend the generated file in `packages/studio/src/components/ui` only when the product needs a domain variant (for example result-state chips). Do not fork a parallel component.
+
+Product screens in `frontend.tsx` import from `./components/ui/*`. They do not invent a second button, badge, or control vocabulary.
 
 For more information, read the Bun API docs in `node_modules/bun-types/docs/**.mdx`.
 

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1,0 +1,267 @@
+---
+name: Pickle Spec Studio
+description: Dark Spec Ledger — a clinical local instrument for diagnosing test runs.
+colors:
+  night-ledger: "oklch(0.145 0.012 250)"
+  raised-plate: "oklch(0.18 0.012 250)"
+  bone: "oklch(0.93 0.01 250)"
+  ink: "oklch(0.145 0.012 250)"
+  mute: "oklch(0.72 0.015 250)"
+  hairline: "oklch(0.72 0.008 250 / 0.16)"
+  well: "oklch(0.22 0.012 250)"
+  brine-tint: "oklch(0.24 0.025 185)"
+  brine-teal: "oklch(0.74 0.08 185)"
+  brine-ink: "oklch(0.16 0.03 185)"
+  plan-amber: "oklch(0.8 0.11 85)"
+  plan-ink: "oklch(0.22 0.05 85)"
+  failure-oxide: "oklch(0.7 0.14 32)"
+  failure-ink: "oklch(0.16 0.03 32)"
+  focus-ring: "oklch(0.72 0.008 250 / 0.4)"
+typography:
+  headline:
+    fontFamily: "Inter, ui-sans-serif, system-ui, sans-serif"
+    fontSize: "1.25rem"
+    fontWeight: 600
+    lineHeight: 1.25
+    letterSpacing: "-0.025em"
+  title:
+    fontFamily: "Inter, ui-sans-serif, system-ui, sans-serif"
+    fontSize: "1.125rem"
+    fontWeight: 500
+    lineHeight: 1.4
+    letterSpacing: "normal"
+  body:
+    fontFamily: "Inter, ui-sans-serif, system-ui, sans-serif"
+    fontSize: "0.875rem"
+    fontWeight: 400
+    lineHeight: 1.5
+    letterSpacing: "normal"
+  label:
+    fontFamily: "Inter, ui-sans-serif, system-ui, sans-serif"
+    fontSize: "0.875rem"
+    fontWeight: 500
+    lineHeight: 1.4
+    letterSpacing: "normal"
+  mono:
+    fontFamily: "JetBrains Mono, ui-monospace, monospace"
+    fontSize: "0.625rem"
+    fontWeight: 500
+    lineHeight: 1.4
+    letterSpacing: "normal"
+rounded:
+  sm: "0.25rem"
+  md: "0.375rem"
+  lg: "0.5rem"
+  pill: "9999px"
+spacing:
+  sm: "0.5rem"
+  md: "0.75rem"
+  lg: "1rem"
+  xl: "1.5rem"
+components:
+  button-primary:
+    backgroundColor: "{colors.bone}"
+    textColor: "{colors.ink}"
+    rounded: "{rounded.md}"
+    padding: "0 0.5rem"
+    height: "1.75rem"
+    typography: "{typography.label}"
+  button-primary-hover:
+    backgroundColor: "oklch(0.93 0.01 250 / 0.8)"
+    textColor: "{colors.ink}"
+    rounded: "{rounded.md}"
+    padding: "0 0.5rem"
+    height: "1.75rem"
+  button-outline:
+    backgroundColor: "oklch(0.72 0.008 250 / 0.08)"
+    textColor: "{colors.bone}"
+    rounded: "{rounded.md}"
+    padding: "0 0.5rem"
+    height: "1.5rem"
+  button-destructive:
+    backgroundColor: "oklch(0.7 0.14 32 / 0.2)"
+    textColor: "{colors.failure-oxide}"
+    rounded: "{rounded.md}"
+    padding: "0 0.5rem"
+    height: "1.75rem"
+  button-passed:
+    backgroundColor: "oklch(0.74 0.08 185 / 0.2)"
+    textColor: "{colors.brine-teal}"
+    rounded: "{rounded.md}"
+    padding: "0 0.5rem"
+    height: "1.5rem"
+  badge-default:
+    backgroundColor: "{colors.well}"
+    textColor: "{colors.bone}"
+    rounded: "{rounded.pill}"
+    padding: "0.125rem 0.5rem"
+    typography: "{typography.mono}"
+  badge-failed:
+    backgroundColor: "oklch(0.7 0.14 32 / 0.2)"
+    textColor: "{colors.failure-oxide}"
+    rounded: "{rounded.pill}"
+    padding: "0.125rem 0.5rem"
+    typography: "{typography.mono}"
+  badge-adaptation:
+    backgroundColor: "oklch(0.8 0.11 85 / 0.2)"
+    textColor: "{colors.plan-amber}"
+    rounded: "{rounded.pill}"
+    padding: "0.125rem 0.5rem"
+    typography: "{typography.mono}"
+  badge-passed:
+    backgroundColor: "oklch(0.74 0.08 185 / 0.2)"
+    textColor: "{colors.brine-teal}"
+    rounded: "{rounded.pill}"
+    padding: "0.125rem 0.5rem"
+    typography: "{typography.mono}"
+  badge-running:
+    backgroundColor: "{colors.brine-tint}"
+    textColor: "{colors.bone}"
+    rounded: "{rounded.pill}"
+    padding: "0.125rem 0.5rem"
+    typography: "{typography.mono}"
+  nav-active:
+    backgroundColor: "{colors.brine-tint}"
+    textColor: "{colors.bone}"
+    rounded: "{rounded.md}"
+    padding: "0.375rem 0.75rem"
+    typography: "{typography.body}"
+  card:
+    backgroundColor: "{colors.raised-plate}"
+    textColor: "{colors.bone}"
+    rounded: "{rounded.lg}"
+    padding: "0.75rem 1rem"
+---
+
+# Design System: Pickle Spec Studio
+
+## Overview
+
+**Creative North Star: "The Spec Ledger"**
+
+Studio is a bound technical ledger that happens to run on a screen. Feature files are the page; test results are the ink; an adaptation is a distinct mark, never a silent rewrite. The operator sits in a dark room with a local project, reading live state the way one reads a night-shift instrument — not a marketing dashboard.
+
+The atmosphere is clinical lab, executed at the craft level of dark developer tools (Vercel, Cursor): near-black cool field, hairline plates, one light primary action, and color reserved for result state. Density is high. Chrome is thin. Empty space is leftover work, not a lifestyle.
+
+**Key Characteristics:**
+- Dark cool field with one-step raised plates, never a drop shadow
+- Bone-white primary action; teal, amber, and oxide only name a test-result state
+- Inter for UI, JetBrains Mono for measurements and resolved actions
+- Compact 8px corners, 9px controls, hairline borders
+- Status is a labeled chip, never a color-only dot
+
+## Colors
+
+A restrained night palette: cool neutrals plus one light action, with three semantic inks for failed, adapted, and passed.
+
+### Primary
+- **Bone**: The only large action fill. Used on "Start test run" so the operator can find the next move without scanning for teal.
+
+### Secondary
+- **Brine Teal**: Passed results and the selected nav tint. It is not the product accent for chrome.
+
+### Tertiary
+- **Plan Amber**: `passed-with-adaptation` chips. The ledger's distinct mark that a plan changed and still needs a human.
+
+### Neutral
+- **Night Ledger**: Canvas behind the whole Studio.
+- **Raised Plate**: Header, cards, matrix, timeline entries.
+- **Well**: Secondary fills and idle chips.
+- **Hairline**: Thin light-gray borders and table rules.
+- **Mute**: Secondary text on Night Ledger (must remain ≥4.5:1).
+
+### Named Rules
+**The Bone Rule.** The light fill is the primary action. Do not paint navigation, tables, or idle chips with Bone.
+
+**The State Ink Rule.** Teal, amber, and oxide appear only on labeled result chips or a failed matrix cell. They do not tint the page.
+
+## Typography
+
+**Display Font:** Inter (with ui-sans-serif, system-ui)
+**Body Font:** Inter (with ui-sans-serif, system-ui)
+**Label/Mono Font:** JetBrains Mono (with ui-monospace)
+
+**Character:** Inter carries the ledger at developer-tool density. JetBrains Mono is reserved for values — resolved actions, status chips, identifiers — not for atmosphere.
+
+### Hierarchy
+- **Headline** (600, 1.25rem, tight tracking): Project name in the header. There is no display size.
+- **Title** (500, 1.125rem): Section titles such as "Test run".
+- **Label** (500, 0.875rem): Table headers, timeline headings, attention items.
+- **Body** (400, 0.875rem, 1.5): Activity lists, empty-state copy, nav items.
+- **Mono** (500, 0.625rem): Status chips. Resolved-action lines stay JetBrains Mono at 0.75rem.
+
+### Named Rules
+**The Measurement Mono Rule.** Monospace is for data. Do not set headings, nav, or body copy in JetBrains Mono to look technical.
+
+## Layout
+
+A full-height column: header, then a single-row area nav, then a master-detail ledger. The left rail (16rem) lists Specifications. The main pane holds the selected Specification, its Scenario table (profile columns plus a per-row Run), Needs attention, and the step timeline. Padding is 1.5rem in the main stage, 0.75rem in the header, 0.25rem in the nav. Rhythm is 1rem inside a rail, 1.5rem between table and timeline.
+
+There is no marketing container or max-width. Studio is an app shell. Specifications is the current room. Runs, Plans, and Settings remain in the area nav as a disabled product map.
+
+## Elevation & Depth
+
+No shadows. Depth is Night Ledger behind Raised Plate, separated by a 1px light-gray Hairline. Selected nav is a Brine Tint well, not a lift.
+
+### Named Rules
+**The Flat Ledger Rule.** Surfaces are flat at rest and in motion. Do not add drop shadows, glows, or stacked cards to fake hierarchy.
+
+## Shapes
+
+Mira density: small instrument corners, 0.5rem on plates and the Scenario table, `rounded-md` on buttons, pills only on status chips. Borders are 1px Hairline. No clipped hero shapes. Tables share the plate radius; inner rows use only a bottom hairline.
+
+## Components
+
+Quiet Mira instrument controls. Color names a result; geometry stays compact so the Scenario table can carry the screen.
+
+### Buttons
+- **Style:** shadcn Mira (`base-mira`). `text-xs/relaxed`, height 1.75rem default / 1.5rem small, `rounded-md`, no shadow. Pressed state scales to 0.98 in 100ms. Focus is a 1px current-color hairline, never a ring.
+- **Primary:** Bone fill, Ink text. Hover is Bone at 80% opacity. Used for Run Specification on the selected file.
+- **Outline:** Hairline border, translucent input fill. Used for pending and running matrix cells, per-Scenario Run, and Run all Specifications.
+- **Passed:** Brine Teal tint and ink, with a Tick. Used for a passed matrix cell.
+- **Adaptation:** Plan Amber tint and ink. Used for `passed-with-adaptation` matrix cells.
+- **Destructive:** Failure Oxide tint and ink (not a solid fill). Used for a failed matrix cell and for Cancel during a live run.
+
+### Chips
+- **Style:** Mira pills, JetBrains Mono 0.625rem, height 1.25rem. Variants: Ready Well, failed Oxide tint, adaptation Amber tint, passed Teal tint, running Brine Tint.
+- **State:** The chip text is the domain state word (`failed`, `passed-with-adaptation`, `running`) except idle, which reads Ready. Color never stands alone. A live run uses Beautiful UI’s Loading State Drive grid: a 3×3 pixel wavefront, a shimmering `running` label, and a mono elapsed timer in the header. Matrix cells carry the same grid beside the spelled state. A finished chip or matrix cell adds a Tick (Brine Teal, or Plan Amber for Adaptation) or a Cancel mark (Failure Oxide). `prefers-reduced-motion` freezes the grid and shimmer; the timer still ticks.
+
+### Cards / Containers
+- **Corner Style:** 0.5rem
+- **Background:** Raised Plate
+- **Shadow Strategy:** none (see Flat Ledger Rule)
+- **Border:** 1px Hairline
+- **Internal Padding:** 0.75rem–1rem
+
+### Navigation
+- Mira-sized text links: height 1.75rem, `text-xs/relaxed`, `rounded-md`. Active is Brine Tint with Bone text. Unavailable areas are Mute at 60% opacity, `aria-disabled`, and not in the tab order. No icons. Areas are Specifications, Runs, Plans, Settings.
+
+### Specification list
+Left rail, 16rem. Group label is 2rem tall at `text-xs`. Each Specification is a Mira sidebar menu item (`h-8`, `text-xs`, `p-2`) with the Scenario count in JetBrains Mono. The selected item is a Brine Tint well.
+
+### Scenario table
+Signature component: a bordered plate table for the selected Specification. Row headers are Scenario names; columns are execution target profiles, then a per-row Run. Before a run, profile cells read pending. A result cell is a small button whose label is the result state, with the Drive pixel grid while running and a Tick or Cancel mark when finished. The selected cell uses a stronger hairline, not a ring; the timeline follows the worst Needs attention cell until the operator pins one.
+
+### Needs attention
+Hidden until a failed, infrastructure-error, or Adaptation cell exists. Each row is a plate button with the Scenario name, a state chip, the profile, and “Open step timeline.”
+
+### Step timeline
+A vertical list of Hairline plates. Step intent in Sans; resolved actions in Mono; errors in Failure Oxide text; screenshots as bordered images, max height 16rem.
+
+## Do's and Don'ts
+
+### Do:
+- **Do** keep the canvas dark and cool (Night Ledger) with one-step Raised Plates.
+- **Do** put the next operator action on a Bone button (Run Specification), and swap it for Cancel while a test run is live.
+- **Do** spell the test-result state on every chip and matrix cell, with the Drive pixel grid while running and a Tick or Cancel mark when the cell finishes.
+- **Do** use JetBrains Mono for resolved actions and status, Inter for everything else.
+- **Do** keep Mira density on controls (compact type, no shadow) and Hairline plates on the ledger.
+
+### Don't:
+- **Don't** add a tracked uppercase kicker above the project name.
+- **Don't** introduce drop shadows, glass, or neon status dots.
+- **Don't** use a focus ring on buttons. Focus is a 1px current-color hairline.
+- **Don't** replace a spelled result state with a color-only icon.
+- **Don't** spend Brine Teal on chrome or marketing blocks.
+- **Don't** invent a second source of truth in the UI — feature files and Git remain off-canvas systems of record.
+- **Don't** use Cucumber, Playwright, or "self-healing" visual language.

--- a/PRODUCT.md
+++ b/PRODUCT.md
@@ -1,0 +1,76 @@
+# Product
+
+<!-- impeccable:product-schema 1 -->
+
+## Platform
+
+web
+
+## Users
+
+The primary Studio user is a QA professional or test author sitting with a local project: they browse Specifications, run a Scenario or a Specification, and diagnose failures and adaptations before the run is trusted.
+
+Developers and CI operators use `pickle run` without Studio. Test leads reuse suites, execution target profiles, and plan promotion, but Studio UI is optimized for the authoring-and-diagnosis job first.
+
+## Product Purpose
+
+Pickle Spec is a local-first test automation and management platform. It covers the full lifecycle of Specifications: authoring, execution against an execution target, live result diagnosis, and explicit execution-plan promotion.
+
+Success is that a team can keep Gherkin in Git, run the same Scenarios locally and in CI, and understand a failed or adapted result without leaving the project.
+
+## Positioning
+
+Feature files remain the source of truth. Collaboration and approval happen in Git and pull requests, not inside Studio.
+
+Scenarios are independent of Stagehand and other adapters. Adaptive mode resolves actions while a Scenario runs and writes a candidate plan. Replay mode uses an approved, reviewable plan. Adaptations never silently replace that plan.
+
+A neighboring runner could copy model-driven clicks. It could not truthfully claim Gherkin-as-source, adapter-neutral Scenarios, and explicit plan promotion in one local product.
+
+## Operating Context
+
+- `pickle studio` starts the local Studio on loopback and opens the configured project.
+- `pickle run` is the non-interactive CI and scripting surface. It can export a self-contained HTML report.
+- Specifications live as Gherkin feature files in the repository. Approved execution plans belong in Git under `.pickle/plans/`.
+- Immutable test runs live under `.pickle/runs/<run-id>/` as an event stream, a materialized manifest, and separate test artifacts. They stay out of Git.
+- Studio navigation uses Specifications, Runs, Plans, and Settings as stable primary areas. Specifications is the current working room; Runs, Plans, and Settings remain visible as a disabled product map.
+- The current Studio slice lists Specifications and Scenarios, starts a scoped test run (one Specification, one Scenario, or all Specifications), streams live progress, and diagnoses results in the Scenario table, Needs attention list, and step timeline. Authoring, Git, plan promotion, and history land in later slices.
+
+## Capabilities and Constraints
+
+- Domain language follows `CONTEXT.md`. Use Specification, Scenario, test run, test result, execution target, execution target profile, Adaptive mode, Replay mode, Adaptation, candidate plan, run event, test artifact, and Studio. Do not substitute Cucumber, Playwright, or “self-healing” vocabulary.
+- Studio binds to `127.0.0.1`, requires a session token, and validates request origins. Remote access requires an explicit option and warning.
+- Studio uses shadcn-owned Mira components (`base-mira`) backed by `@base-ui/react` primitives.
+- The first version documents a future hosted synchronization path and contains no cloud API, hosted storage, or hosted authentication.
+- Studio never pushes Git automatically. It must not duplicate repository permissions, comments, or approvals.
+- Execution plans are per Scenario revision, execution target profile, plan-format version, and application revision. A plan does not transfer across profiles.
+- Custom adapters are imported explicitly. The first version does not discover plugins dynamically.
+- Mobile execution targets (Android Emulator, iOS Simulator) are in the product direction and out of the current Studio slice.
+- The current package can replace public shapes without a compatibility layer; the repository has no external users yet.
+
+## Brand Commitments
+
+The product name is Pickle Spec. Voice is precise and technical: state what the system does, in the domain terms above, without marketing fluff.
+
+No logo, illustration, or third-party brand system is binding beyond the name and that voice.
+
+## Evidence on Hand
+
+- Domain glossary: `CONTEXT.md`
+- Architecture decisions: `docs/adr/`
+- Product spec: GitHub issue #10
+- Sample Specifications: `apps/example`
+- Studio UI source: `packages/studio/src/`
+
+There are no external customers, testimonials, benchmarks for marketing use, or press assets. Future work must not invent them.
+
+## Product Principles
+
+- Keep feature files and Git as the system of record; Studio is a local operator, not a second source of truth.
+- Make diagnosis possible while a test run is still in progress; do not wait on a finished report file.
+- Never change an approved execution plan, Specification, or remote repository without an explicit user action.
+- Keep Scenarios adapter-neutral so the same behavior can run on web now and other execution targets later.
+- Say exactly what happened: failed, adapted, cancelled, skipped, infrastructure error, or flaky — not a collapsed “broken test.”
+
+## Accessibility & Inclusion
+
+Studio must meet WCAG 2.2 AA, support complete keyboard navigation, honor reduced motion, and preserve focus during live updates.

--- a/apps/example/package.json
+++ b/apps/example/package.json
@@ -6,7 +6,8 @@
     "run:example": "pickle run",
     "migrate": "pickle migrate",
     "smoke": "pickle run --suite google --profile web",
-    "export": "pickle export 83c9a5e9-0384-466e-ae38-bc623214b9c3 --html report.html"
+    "export": "pickle export 83c9a5e9-0384-466e-ae38-bc623214b9c3 --html report.html",
+    "studio": "pickle studio"
   },
   "dependencies": {
     "@pickle-spec/cli": "workspace:*"

--- a/biome.json
+++ b/biome.json
@@ -44,6 +44,11 @@
       "semicolons": "asNeeded"
     }
   },
+  "css": {
+    "parser": {
+      "tailwindDirectives": true
+    }
+  },
   "assist": {
     "enabled": true,
     "actions": {

--- a/bun.lock
+++ b/bun.lock
@@ -26,12 +26,14 @@
       "dependencies": {
         "@pickle-spec/runner": "workspace:*",
         "@pickle-spec/spec": "workspace:*",
+        "@pickle-spec/studio": "workspace:*",
         "@pickle-spec/web": "workspace:*",
         "@types/bun": "catalog:",
         "@typescript/typescript6": "catalog:",
         "zod": "catalog:",
       },
       "devDependencies": {
+        "playwright": "^1.55.0",
         "typescript": "catalog:",
       },
     },
@@ -57,6 +59,29 @@
       },
       "devDependencies": {
         "@types/bun": "catalog:",
+        "typescript": "catalog:",
+      },
+    },
+    "packages/studio": {
+      "name": "@pickle-spec/studio",
+      "version": "1.0.2",
+      "dependencies": {
+        "@base-ui/react": "^1.0.0",
+        "@pickle-spec/runner": "workspace:*",
+        "@types/bun": "catalog:",
+        "@typescript/typescript6": "catalog:",
+        "bun-plugin-tailwind": "^0.1.2",
+        "class-variance-authority": "^0.7.1",
+        "clsx": "^2.1.1",
+        "react": "^19.1.1",
+        "react-dom": "^19.1.1",
+        "tailwind-merge": "^3.3.1",
+        "tailwindcss": "^4.1.12",
+        "tw-animate-css": "^1.3.8",
+      },
+      "devDependencies": {
+        "@types/react": "^19.1.12",
+        "@types/react-dom": "^19.1.9",
         "typescript": "catalog:",
       },
     },
@@ -87,6 +112,12 @@
     "zod": "^4",
   },
   "packages": {
+    "@babel/runtime": ["@babel/runtime@7.29.7", "", {}, "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw=="],
+
+    "@base-ui/react": ["@base-ui/react@1.7.0", "", { "dependencies": { "@babel/runtime": "^7.29.2", "@base-ui/utils": "0.3.2", "@floating-ui/react-dom": "^2.1.9", "@floating-ui/utils": "^0.2.12", "use-sync-external-store": "^1.6.0" }, "peerDependencies": { "@date-fns/tz": "^1.2.0", "@types/react": "^17 || ^18 || ^19", "date-fns": "^4.0.0", "react": "^17 || ^18 || ^19", "react-dom": "^17 || ^18 || ^19" }, "optionalPeers": ["@date-fns/tz", "@types/react", "date-fns"] }, "sha512-j+8QjX44C32jrXD/qyEAGpFr70FRpGL2CY61mQd9nBPWN737CK0xxD1ceJ055rW4RtdvFDT1e7otzdlfxvsYug=="],
+
+    "@base-ui/utils": ["@base-ui/utils@0.3.2", "", { "dependencies": { "@babel/runtime": "^7.29.2", "@floating-ui/utils": "^0.2.12", "reselect": "^5.2.0", "use-sync-external-store": "^1.6.0" }, "peerDependencies": { "@types/react": "^17 || ^18 || ^19", "react": "^17 || ^18 || ^19", "react-dom": "^17 || ^18 || ^19" }, "optionalPeers": ["@types/react"] }, "sha512-oWy1aq/I2GmYjpl4PhEAhzflF8VPGKgZeq0xAWTbfD5KBWyxcN0ZP2+WHSUm/5Z6lVMBDLReLcoXwSYoRc/zNQ=="],
+
     "@biomejs/biome": ["@biomejs/biome@2.5.8", "", { "optionalDependencies": { "@biomejs/cli-darwin-arm64": "2.5.8", "@biomejs/cli-darwin-x64": "2.5.8", "@biomejs/cli-linux-arm64": "2.5.8", "@biomejs/cli-linux-arm64-musl": "2.5.8", "@biomejs/cli-linux-x64": "2.5.8", "@biomejs/cli-linux-x64-musl": "2.5.8", "@biomejs/cli-win32-arm64": "2.5.8", "@biomejs/cli-win32-x64": "2.5.8" }, "bin": { "biome": "bin/biome" } }, "sha512-aeAeeJB9fSDc7Gq+2GqpQxA0qBj6gj1k2R6L1cYqGePKP/baIq1WX8y6B+D+nRsO5ViQL22K/8IwbqERW0q1nw=="],
 
     "@biomejs/cli-darwin-arm64": ["@biomejs/cli-darwin-arm64@2.5.8", "", { "os": "darwin", "cpu": "arm64" }, "sha512-mk1QON9PHllvvLN5gU3f4rMxeh4syK5p9OvKyWH6/W8ueh04uaC8TUXXByhGufWf/y5mQc03ZLM45zU+cmqMjA=="],
@@ -113,11 +144,51 @@
 
     "@cucumber/messages": ["@cucumber/messages@26.0.1", "", { "dependencies": { "@types/uuid": "10.0.0", "class-transformer": "0.5.1", "reflect-metadata": "0.2.2", "uuid": "10.0.0" } }, "sha512-DIxSg+ZGariumO+Lq6bn4kOUIUET83A4umrnWmidjGFl8XxkBieUZtsmNbLYgH/gnsmP07EfxxdTr0hOchV1Sg=="],
 
+    "@floating-ui/core": ["@floating-ui/core@1.8.0", "", { "dependencies": { "@floating-ui/utils": "^0.2.12" } }, "sha512-0CIZ5itps/8x7BG8dEIhs53BvCUH2PCoogtakwRTut+Arm58sJooJ0AuZhLw2HJYIR5cMLNPBSS728sPho2khQ=="],
+
+    "@floating-ui/dom": ["@floating-ui/dom@1.8.0", "", { "dependencies": { "@floating-ui/core": "^1.8.0", "@floating-ui/utils": "^0.2.12" } }, "sha512-yXSrzeHZBTZadLOlfyhCkJHNeLJnHRnRInwdZ40L7ZiaAtrBwoYlsDrX3v5zB1Utk7CLfzcOVnVVWoXEky7Ceg=="],
+
+    "@floating-ui/react-dom": ["@floating-ui/react-dom@2.1.9", "", { "dependencies": { "@floating-ui/dom": "^1.8.0" }, "peerDependencies": { "react": ">=16.8.0", "react-dom": ">=16.8.0" } }, "sha512-JDjEFGCpImxDCA7JJKviA0M9+RtmJdj0m/NVU5IMgBK+AmZouAQQ7/+2GLH0GXXY0YMw9oXPB8hKdbPYg5QLYg=="],
+
+    "@floating-ui/utils": ["@floating-ui/utils@0.2.12", "", {}, "sha512-HpCo8tmWzLVad5s2d19EhAz5zqrrQ6s69qd6moPMQvkOuSwDT1YgRfWSVuc4ennqrgv3OHppiOGMQ7oC13yIww=="],
+
     "@opentelemetry/api": ["@opentelemetry/api@1.9.1", "", {}, "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q=="],
 
     "@opentelemetry/core": ["@opentelemetry/core@2.9.0", "", { "dependencies": { "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.0.0 <1.10.0" } }, "sha512-m2nckMT80NnmjTYSPjJQObBJ+8dgkoajEOUbznL8AHZ3T3yHRk2P7gI1PhEBc1+lOnrYE9UWrWHqJDsmqjmNbw=="],
 
     "@opentelemetry/semantic-conventions": ["@opentelemetry/semantic-conventions@1.43.0", "", {}, "sha512-eSYWTm620tTk45EKSedaUL8MFYI8hW164hIXsgIHyxu3VobUB3fFCu5t0hQby6OoWRPsG1KkKUG2M5UadiLiVg=="],
+
+    "@oven/bun-darwin-aarch64": ["@oven/bun-darwin-aarch64@1.3.14", "", { "os": "darwin", "cpu": "arm64" }, "sha512-Omj20SuiHBOUjUBIyqtkNjSUIjOtEOJwmbix/ZyFH4BaQ6OZTaaRWIR4TjHVz0yadHgli6lLTiAh1uarnvD49A=="],
+
+    "@oven/bun-darwin-x64": ["@oven/bun-darwin-x64@1.3.14", "", { "os": "darwin", "cpu": "x64" }, "sha512-FFj3QdU/OhlDyZOJ8CWfN5eWLpRlT4qjZg7lMQi7jA6GuoY5ajlO1zWLP/MuHYRSbXQUvV52RejNi8DVnAp13w=="],
+
+    "@oven/bun-darwin-x64-baseline": ["@oven/bun-darwin-x64-baseline@1.3.14", "", { "os": "darwin", "cpu": "x64" }, "sha512-OSfsTZstc898HHElhU4NccaBGOSSDn5VfahiVTnidZ9B/+wb7WTyfZJaBeJcfjwJ9H2W9uTh2TGtl3UfcXgV9g=="],
+
+    "@oven/bun-freebsd-aarch64": ["@oven/bun-freebsd-aarch64@1.3.14", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-LIKrXaFxAHybVO5Pf+9XP2FHUj/5APvXTUKk9dqHm5iFz4oH+W24cmhjkJirNujh9hKeTyrpWSe3no9JZKowIw=="],
+
+    "@oven/bun-freebsd-x64": ["@oven/bun-freebsd-x64@1.3.14", "", { "os": "freebsd", "cpu": "x64" }, "sha512-uwD+fGUH1ADpIF3B1U2jWzzb20QwRLZfj5QZ28GUCGrAJ/nTmWrD6YYGsblCY1wuhldRez3lU40AyuvSCyLYmw=="],
+
+    "@oven/bun-linux-aarch64": ["@oven/bun-linux-aarch64@1.3.14", "", { "os": "linux", "cpu": "arm64" }, "sha512-X5SsPZHs+iYO8R/efIcRtc7gT2Q2DgPfliCxEkx4cXBumwkw0c/EsHMNwH3EgGpCDaZ7IYVPhpCG/xBOQHEwZw=="],
+
+    "@oven/bun-linux-aarch64-android": ["@oven/bun-linux-aarch64-android@1.3.14", "", { "os": "android", "cpu": "arm64" }, "sha512-y4kq5b85lsrmFb9Xvi4w9mA5IEFJkLMrSmYn06q24KjL9rUWDWO3VFZEtteZxUN5+ec3Zm5S8OnJw1umaCbVjA=="],
+
+    "@oven/bun-linux-aarch64-musl": ["@oven/bun-linux-aarch64-musl@1.3.14", "", { "os": "linux", "cpu": "arm64" }, "sha512-jmqOA92Cd1NL/1XBd4bFkJLxQ86K0RW7ohxS2qzzAvuitO4JiIxjjTeCspoU44zCozH72HpfZfUE2On31OjnWA=="],
+
+    "@oven/bun-linux-x64": ["@oven/bun-linux-x64@1.3.14", "", { "os": "linux", "cpu": "x64" }, "sha512-7OVTAKvwfPmSbIV1HpdOoVVx5VRc427GuPPne93N6vk4eQBPId9nXmZDh9/zGaKPdbVjVtQSZafWQoUjx38Utw=="],
+
+    "@oven/bun-linux-x64-android": ["@oven/bun-linux-x64-android@1.3.14", "", { "os": "android", "cpu": "x64" }, "sha512-qe9e1d+3VAEU7nAA2ol9Jvmy/o99PVMSgZhHn7Q/9O3YcDrfEqyQ8zm4zoe5qTEo8HZH0dN03Le0Ys2eQPs7eg=="],
+
+    "@oven/bun-linux-x64-baseline": ["@oven/bun-linux-x64-baseline@1.3.14", "", { "os": "linux", "cpu": "x64" }, "sha512-q/8EdOC0yUE8FPeoOVq8/Pw5I9/tJaYmUfO/uDUAREx8IUnOJH1RJ5A3BjFqre8pvJoiZA9AovPJq5FnNNjSxA=="],
+
+    "@oven/bun-linux-x64-musl": ["@oven/bun-linux-x64-musl@1.3.14", "", { "os": "linux", "cpu": "x64" }, "sha512-GBCB/k/sIqcr06eTNgg7g46qiUv35Jasx4XiccJ/n7RGqrE4RWUD/XJBbWFprVPjvqd59+QtSnS99XGqvftHfg=="],
+
+    "@oven/bun-linux-x64-musl-baseline": ["@oven/bun-linux-x64-musl-baseline@1.3.14", "", { "os": "linux", "cpu": "x64" }, "sha512-n6iE71G4lQE4XkrZhQQcL5YUlxDbnq6nqV7zeQi33PMsLT/0kYE+RvHOtBWZ3w0wMdXZfINmp63hIb9ijUBGtw=="],
+
+    "@oven/bun-windows-aarch64": ["@oven/bun-windows-aarch64@1.3.14", "", { "os": "win32", "cpu": "arm64" }, "sha512-T7s3x/BsVKQObGU6QDkZeI6wKynzqGbBH1yI77jrrj5siElclxr3DQrDIk8CV4G5/SJq2HHq4kpLyYY2DKCSmA=="],
+
+    "@oven/bun-windows-x64": ["@oven/bun-windows-x64@1.3.14", "", { "os": "win32", "cpu": "x64" }, "sha512-mUFWL3BoYkNpjd8e9PqROiFF/1Xeotq20mABJsiQH62jM1g5zqWh4khw1RZ6bX8Q8fWvlPaxG1PjofkmjUi3vg=="],
+
+    "@oven/bun-windows-x64-baseline": ["@oven/bun-windows-x64-baseline@1.3.14", "", { "os": "win32", "cpu": "x64" }, "sha512-uIjLUC1S9DWgICzuoMba7vurBJnBruE4S5CxnvmZkdqWVXRzx1Rgu636HoH+k0qeaQCFh3jeG3JQ1y6fRHv0sw=="],
 
     "@pickle-spec/cli": ["@pickle-spec/cli@workspace:packages/cli"],
 
@@ -126,6 +197,8 @@
     "@pickle-spec/runner": ["@pickle-spec/runner@workspace:packages/runner"],
 
     "@pickle-spec/spec": ["@pickle-spec/spec@workspace:packages/spec"],
+
+    "@pickle-spec/studio": ["@pickle-spec/studio@workspace:packages/studio"],
 
     "@pickle-spec/web": ["@pickle-spec/web@workspace:packages/web"],
 
@@ -146,6 +219,10 @@
     "@types/node": ["@types/node@25.3.0", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-4K3bqJpXpqfg2XKGK9bpDTc6xO/xoUP/RBWS7AtRMug6zZFaRekiLzjVtAoZMquxoAbzBvy5nxQ7veS5eYzf8A=="],
 
     "@types/node-fetch": ["@types/node-fetch@2.6.13", "", { "dependencies": { "@types/node": "*", "form-data": "^4.0.4" } }, "sha512-QGpRVpzSaUs30JBSGPjOg4Uveu384erbHBoT1zeONvyCfwQxIkUshLAOqN/k9EjGviPRmWTTe6aH2qySWKTVSw=="],
+
+    "@types/react": ["@types/react@19.2.18", "", { "dependencies": { "csstype": "^3.2.2" } }, "sha512-AnzbBERsrLKtk2XSfTbYRLjQPdy116Sty4q+T+Bp3IC4l6jNBvreVPAHmpq9qhXQM7CXZPjLVmGMw9sy+hxQ3w=="],
+
+    "@types/react-dom": ["@types/react-dom@19.2.4", "", { "peerDependencies": { "@types/react": "^19.2.0" } }, "sha512-Bsc+QHgp+P/F02XDzNCY9jnZNCUuLki36KT7VKrTXXLdHf+vHMNZnW1rVu5DNW/rCK+fya3DATySbLM4yhtKUw=="],
 
     "@types/uuid": ["@types/uuid@10.0.0", "", {}, "sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ=="],
 
@@ -199,6 +276,10 @@
 
     "asynckit": ["asynckit@0.4.0", "", {}, "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="],
 
+    "bun": ["bun@1.3.14", "", { "optionalDependencies": { "@oven/bun-darwin-aarch64": "1.3.14", "@oven/bun-darwin-x64": "1.3.14", "@oven/bun-darwin-x64-baseline": "1.3.14", "@oven/bun-freebsd-aarch64": "1.3.14", "@oven/bun-freebsd-x64": "1.3.14", "@oven/bun-linux-aarch64": "1.3.14", "@oven/bun-linux-aarch64-android": "1.3.14", "@oven/bun-linux-aarch64-musl": "1.3.14", "@oven/bun-linux-x64": "1.3.14", "@oven/bun-linux-x64-android": "1.3.14", "@oven/bun-linux-x64-baseline": "1.3.14", "@oven/bun-linux-x64-musl": "1.3.14", "@oven/bun-linux-x64-musl-baseline": "1.3.14", "@oven/bun-windows-aarch64": "1.3.14", "@oven/bun-windows-x64": "1.3.14", "@oven/bun-windows-x64-baseline": "1.3.14" }, "os": [ "!aix", "!sunos", "!openbsd", ], "cpu": [ "x64", "arm64", ], "bin": { "bun": "bin/bun.exe", "bunx": "bin/bunx.exe" } }, "sha512-aB6GVd42x1Y5ie1K16SF+oLGtgSkwX9hgoDdIW88pjvfTccU8F1vfpoOt34QLv0dZ1v3XimtaxPlZUG81Gx9Zg=="],
+
+    "bun-plugin-tailwind": ["bun-plugin-tailwind@0.1.2", "", { "peerDependencies": { "bun": ">=1.0.0" } }, "sha512-41jNC1tZRSK3s1o7pTNrLuQG8kL/0vR/JgiTmZAJ1eHwe0w5j6HFPKeqEk0WAD13jfrUC7+ULuewFBBCoADPpg=="],
+
     "bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
 
     "call-bind-apply-helpers": ["call-bind-apply-helpers@1.0.2", "", { "dependencies": { "es-errors": "^1.3.0", "function-bind": "^1.1.2" } }, "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ=="],
@@ -207,7 +288,13 @@
 
     "class-transformer": ["class-transformer@0.5.1", "", {}, "sha512-SQa1Ws6hUbfC98vKGxZH3KFY0Y1lm5Zm0SY8XX9zbK7FJCyVEac3ATW0RIpwzW+oOfmHE5PMPufDG9hCfoEOMw=="],
 
+    "class-variance-authority": ["class-variance-authority@0.7.1", "", { "dependencies": { "clsx": "^2.1.1" } }, "sha512-Ka+9Trutv7G8M6WT6SeiRWz792K5qEqIGEGzXKhAE6xOWAY6pPH8U+9IY3oCMv6kqTmLsv7Xh/2w2RigkePMsg=="],
+
+    "clsx": ["clsx@2.1.1", "", {}, "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA=="],
+
     "combined-stream": ["combined-stream@1.0.8", "", { "dependencies": { "delayed-stream": "~1.0.0" } }, "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg=="],
+
+    "csstype": ["csstype@3.2.3", "", {}, "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ=="],
 
     "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
 
@@ -232,6 +319,8 @@
     "form-data-encoder": ["form-data-encoder@1.7.2", "", {}, "sha512-qfqtYan3rxrnCk1VYaA4H+Ms9xdpPqvLZa6xmMgFvhO32x7/3J/ExcTd6qpxM0vH2GdMI+poehyBZvqfMTto8A=="],
 
     "formdata-node": ["formdata-node@4.4.1", "", { "dependencies": { "node-domexception": "1.0.0", "web-streams-polyfill": "4.0.0-beta.3" } }, "sha512-0iirZp3uVDjVGt9p49aTaqjk84TrglENEDuqfdlZQ1roC9CWlPk6Avf8EEnZNcAqPonwkG35x4n3ww/1THYAeQ=="],
+
+    "fsevents": ["fsevents@2.3.2", "", { "os": "darwin" }, "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA=="],
 
     "function-bind": ["function-bind@1.1.2", "", {}, "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="],
 
@@ -269,15 +358,35 @@
 
     "node-fetch": ["node-fetch@2.7.0", "", { "dependencies": { "whatwg-url": "^5.0.0" }, "peerDependencies": { "encoding": "^0.1.0" }, "optionalPeers": ["encoding"] }, "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A=="],
 
+    "playwright": ["playwright@1.62.1", "", { "dependencies": { "playwright-core": "1.62.1" }, "optionalDependencies": { "fsevents": "2.3.2" }, "bin": { "playwright": "cli.js" } }, "sha512-0M+L3LAD8/nm554LOla9Ayx0j0tmFZ0FBcoQ7F1VuVHpM/XpiC8RcDzBQB8W5+hA8L22THxELzeF+2WcUzvcLg=="],
+
+    "playwright-core": ["playwright-core@1.62.1", "", { "bin": { "playwright-core": "cli.js" } }, "sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw=="],
+
+    "react": ["react@19.2.8", "", {}, "sha512-PWaYA1L/q9u2u7xYQi+Y3L3Yfnie7XyLeaJICV1MGD6LprsBxcAqGjYyr0eY3p+QdsA+x/Irkt4Qif8D63+Sbw=="],
+
+    "react-dom": ["react-dom@19.2.8", "", { "dependencies": { "scheduler": "^0.27.0" }, "peerDependencies": { "react": "^19.2.8" } }, "sha512-rVprimfGBG3DR+Tq0IQG2DT5PxKth1WIGDmj5yPmlzr4YBe7uyE+Du4oVqTDXZSHGGGXRtTJEGSSePyQCMBglQ=="],
+
     "reflect-metadata": ["reflect-metadata@0.2.2", "", {}, "sha512-urBwgfrvVP/eAyXx4hluJivBKzuEbSQs9rKWCrCkbSxNv8mxPcUZKeuoF3Uy4mJl3Lwprp6yy5/39VWigZ4K6Q=="],
+
+    "reselect": ["reselect@5.2.0", "", {}, "sha512-AgZ3UOZm3YndfrJ4OYjgrT7bmCm/1iqkjvEfH/oYjzh6PD2qw4QuT3jjnXIrpdt4MTpMXclMT3lXbmRY+XRakw=="],
+
+    "scheduler": ["scheduler@0.27.0", "", {}, "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q=="],
+
+    "tailwind-merge": ["tailwind-merge@3.6.0", "", {}, "sha512-uxL7qAVQriqRQPAyK3pj66VqskWqoZ37PW94jwOTwNfq/z9oyu1V+eqrZqtR2+fCiXdYOZe/Modt8GtvqNzu+w=="],
+
+    "tailwindcss": ["tailwindcss@4.3.3", "", {}, "sha512-gOhV3P7ufE62QDGg1zVaTgCR+EtPv92k2nIhVcVKcLmxT1sUBsQGhnZj175j+MqRt4zLF7ic+sCYjfhxMxj7YQ=="],
 
     "tr46": ["tr46@0.0.3", "", {}, "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="],
 
     "turbo": ["turbo@2.10.10", "", { "optionalDependencies": { "@turbo/darwin-64": "2.10.10", "@turbo/darwin-arm64": "2.10.10", "@turbo/linux-64": "2.10.10", "@turbo/linux-arm64": "2.10.10", "@turbo/windows-64": "2.10.10", "@turbo/windows-arm64": "2.10.10" }, "bin": { "turbo": "bin/turbo" } }, "sha512-/90KTW+USzvYOPmafRZHVKLBsHXQ5810Ao/HdtJYAqguIhZ+XruS6eIUjqJUDtrSxaZYynNFht68qckGKAOWTA=="],
 
+    "tw-animate-css": ["tw-animate-css@1.4.0", "", {}, "sha512-7bziOlRqH0hJx80h/3mbicLW7o8qLsH5+RaLR2t+OHM3D0JlWGODQKQ4cxbK7WlvmUxpcj6Kgu6EKqjrGFe3QQ=="],
+
     "typescript": ["typescript@7.0.2", "", { "optionalDependencies": { "@typescript/typescript-aix-ppc64": "7.0.2", "@typescript/typescript-darwin-arm64": "7.0.2", "@typescript/typescript-darwin-x64": "7.0.2", "@typescript/typescript-freebsd-arm64": "7.0.2", "@typescript/typescript-freebsd-x64": "7.0.2", "@typescript/typescript-linux-arm": "7.0.2", "@typescript/typescript-linux-arm64": "7.0.2", "@typescript/typescript-linux-loong64": "7.0.2", "@typescript/typescript-linux-mips64el": "7.0.2", "@typescript/typescript-linux-ppc64": "7.0.2", "@typescript/typescript-linux-riscv64": "7.0.2", "@typescript/typescript-linux-s390x": "7.0.2", "@typescript/typescript-linux-x64": "7.0.2", "@typescript/typescript-netbsd-arm64": "7.0.2", "@typescript/typescript-netbsd-x64": "7.0.2", "@typescript/typescript-openbsd-arm64": "7.0.2", "@typescript/typescript-openbsd-x64": "7.0.2", "@typescript/typescript-sunos-x64": "7.0.2", "@typescript/typescript-win32-arm64": "7.0.2", "@typescript/typescript-win32-x64": "7.0.2" }, "bin": { "tsc": "bin/tsc" } }, "sha512-8FYau96o3NKOhbjKi/qNvG/W5jhzxkbdm5sj9AbZ/5T5sWqn3hJgLfGx27sRKZWTvyzCP8dLRBTf5tBTSRVUNA=="],
 
     "undici-types": ["undici-types@7.18.2", "", {}, "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w=="],
+
+    "use-sync-external-store": ["use-sync-external-store@1.6.0", "", { "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w=="],
 
     "uuid": ["uuid@10.0.0", "", { "bin": { "uuid": "dist/bin/uuid" } }, "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -67,6 +67,8 @@
       "version": "1.0.2",
       "dependencies": {
         "@base-ui/react": "^1.0.0",
+        "@hugeicons/core-free-icons": "^4.2.3",
+        "@hugeicons/react": "^1.1.9",
         "@pickle-spec/runner": "workspace:*",
         "@types/bun": "catalog:",
         "@typescript/typescript6": "catalog:",
@@ -151,6 +153,10 @@
     "@floating-ui/react-dom": ["@floating-ui/react-dom@2.1.9", "", { "dependencies": { "@floating-ui/dom": "^1.8.0" }, "peerDependencies": { "react": ">=16.8.0", "react-dom": ">=16.8.0" } }, "sha512-JDjEFGCpImxDCA7JJKviA0M9+RtmJdj0m/NVU5IMgBK+AmZouAQQ7/+2GLH0GXXY0YMw9oXPB8hKdbPYg5QLYg=="],
 
     "@floating-ui/utils": ["@floating-ui/utils@0.2.12", "", {}, "sha512-HpCo8tmWzLVad5s2d19EhAz5zqrrQ6s69qd6moPMQvkOuSwDT1YgRfWSVuc4ennqrgv3OHppiOGMQ7oC13yIww=="],
+
+    "@hugeicons/core-free-icons": ["@hugeicons/core-free-icons@4.2.3", "", {}, "sha512-fpiU0qFZkv4ABi23xJ2m4qNr0BBfuIaYjPboN8WDA6aj9D+OzXa7eykxKOpACZRuGbDz1U9S5DsNx1d5KNnsgA=="],
+
+    "@hugeicons/react": ["@hugeicons/react@1.1.9", "", { "peerDependencies": { "react": ">=16.0.0" } }, "sha512-O+lWSWjbijoAvMCxn4K2bQWCGN5+mP1y5j+X99j23mXMj+s0X25fs71T6t9YJLaBodwmZdaewD27dzS/PiboQw=="],
 
     "@opentelemetry/api": ["@opentelemetry/api@1.9.1", "", {}, "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q=="],
 

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
     "test": "turbo run test",
     "lint": "biome check .",
     "format": "biome check --write .",
-    "run:example": "turbo run run:example --filter=@pickle-spec/example"
+    "run:example": "turbo run run:example --filter=@pickle-spec/example",
+    "studio": "turbo run studio --filter=@pickle-spec/example"
   },
   "devDependencies": {
     "@biomejs/biome": "catalog:",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -20,12 +20,14 @@
   "dependencies": {
     "@pickle-spec/runner": "workspace:*",
     "@pickle-spec/spec": "workspace:*",
+    "@pickle-spec/studio": "workspace:*",
     "@pickle-spec/web": "workspace:*",
     "@types/bun": "catalog:",
     "@typescript/typescript6": "catalog:",
     "zod": "catalog:"
   },
   "devDependencies": {
+    "playwright": "^1.55.0",
     "typescript": "catalog:"
   }
 }

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -1,52 +1,22 @@
 #!/usr/bin/env bun
 
-import { join, relative, resolve } from 'node:path'
-import { pathToFileURL } from 'node:url'
-import type {
-  ExecutionTargetAdapter,
-  ExecutionTargetProfile,
-  RunExtensions,
-  TestResult,
-} from '@pickle-spec/runner'
+import { basename, resolve } from 'node:path'
 import {
   compareTestRuns,
-  createFilePlanStore,
   formatHtml,
   formatJson,
   formatJunit,
   formatNdjson,
   importRunArchive,
-  latestHistoricalDurations,
   openTestRunStore,
-  resolveRunConfiguration,
-  runScenarios,
-  selectRerunResults,
-  validateTargetSelection,
   writeRunArchive,
 } from '@pickle-spec/runner'
-import {
-  parseSpecification,
-  resolveScenarioId,
-  type SelectionOptions,
-  type SpecificationState,
-  selectScenarios,
-  validateSpecificationMetadata,
-} from '@pickle-spec/spec'
-import {
-  createWebAdapter,
-  screenshotModes,
-  type WebAdapterOptions,
-} from '@pickle-spec/web'
-import {
-  defaultExtensionsFile,
-  defaultSpecificationGlob,
-  loadConfig,
-  type PickleConfig,
-  runConfigurationFrom,
-} from './config'
-import type { Extensions } from './extensions'
+import type { SelectionOptions, SpecificationState } from '@pickle-spec/spec'
+import { startStudio } from '@pickle-spec/studio'
+import { screenshotModes, type WebAdapterOptions } from '@pickle-spec/web'
+import { loadConfig } from './config'
+import { loadPersistedRun, startProjectRun } from './execute-run'
 import { checkProject, initializeProject, migrateProject } from './project'
-import { startServer } from './server'
 
 interface RunArguments {
   pattern?: string
@@ -204,322 +174,30 @@ function parseRunArguments(argv: string[]): RunArguments {
   return args
 }
 
-async function loadExtensions(path?: string): Promise<Extensions> {
-  const selectedPath = path ?? defaultExtensionsFile
-  const absolutePath = resolve(selectedPath)
-  if (!(await Bun.file(absolutePath).exists())) {
-    if (!path) return {}
-    throw new Error(`Extensions file not found: ${selectedPath}`)
-  }
-  return ((await import(pathToFileURL(absolutePath).href)).default ??
-    {}) as Extensions
-}
-
-async function discoverSpecifications(
-  patterns: string | string[],
-  language?: string,
-) {
-  const paths = new Set<string>()
-  for (const pattern of Array.isArray(patterns) ? patterns : [patterns]) {
-    const glob = new Bun.Glob(pattern)
-    for await (const path of glob.scan({ cwd: process.cwd(), absolute: true }))
-      paths.add(path)
-  }
-  if (paths.size === 0) {
-    const description = Array.isArray(patterns) ? patterns.join(', ') : patterns
-    throw new Error(`No specifications found matching: ${description}`)
-  }
-  const files = await Promise.all(
-    [...paths].sort().map(async (path) => ({
-      uri: relative(process.cwd(), path),
-      source: await Bun.file(path).text(),
-    })),
-  )
-  validateSpecificationMetadata(files, language)
-  return files.map((file) =>
-    parseSpecification({
-      source: file.source,
-      uri: file.uri,
-      language,
-    }),
-  )
-}
-
-function configuredWebOptions(
-  config: PickleConfig,
-  args: RunArguments,
-  profileId?: string,
-): WebAdapterOptions | undefined {
-  const web =
-    (profileId
-      ? config.executionTargetProfiles?.[profileId]?.web
-      : undefined) ?? config.web
-  if (!web) return undefined
-  return {
-    ...web,
-    ...(args.fast ? { profile: 'fast' as const } : {}),
-    browser: {
-      ...web.browser,
-      ...(args.headed ? { headless: false } : {}),
-    },
-    screenshots: {
-      ...web.screenshots,
-      ...(args.screenshotMode ? { mode: args.screenshotMode } : {}),
-    },
-  }
-}
-
-function configuredAdapter(
-  extensions: Extensions,
-  web: WebAdapterOptions | undefined,
-): ExecutionTargetAdapter {
-  if (extensions.adapter) return extensions.adapter
-  if (!web)
-    throw new Error(
-      'Configure web.baseUrl or export an adapter from pickle.extensions.ts',
-    )
-  return createWebAdapter(web, extensions.webAutomationFactory)
-}
-
-function configuredRunExtensions(
-  extensions: Extensions,
-  config: PickleConfig,
-  args: RunArguments,
-  profiles: readonly ExecutionTargetProfile[],
-): RunExtensions {
-  const adapters: Record<string, ExecutionTargetAdapter> = {
-    ...extensions.adapters,
-  }
-  if (extensions.adapter) adapters.custom ??= extensions.adapter
-
-  for (const profile of profiles) {
-    if (profile.adapter !== 'web' || adapters[profile.id]) continue
-    const web = configuredWebOptions(config, args, profile.id)
-    if (adapters.web) {
-      adapters[profile.id] = adapters.web
-      continue
-    }
-    if (!web) {
-      throw new Error(
-        'Configure web.baseUrl or export an adapter from pickle.extensions.ts',
-      )
-    }
-    adapters[profile.id] = createWebAdapter(
-      web,
-      extensions.webAutomationFactory,
-    )
-  }
-
-  return {
-    adapter: profiles.some((profile) => profile.adapter)
-      ? extensions.adapter
-      : configuredAdapter(extensions, configuredWebOptions(config, args)),
-    adapters,
-  }
-}
-
-async function disposeAdapters(
-  targets: ReturnType<typeof resolveRunConfiguration>['targets'],
-): Promise<void> {
-  const seen = new Set<ExecutionTargetAdapter>()
-  for (const target of targets) {
-    if (seen.has(target.adapter)) continue
-    seen.add(target.adapter)
-    await target.adapter.dispose?.()
-  }
-}
-
-function scenarioSelectionId(selection: {
-  specification: { source: { uri: string }; name: string }
-  scenario: { name: string; id?: string; tags: string[] }
-}): string {
-  return (
-    selection.scenario.id ??
-    resolveScenarioId(
-      selection.specification.source.uri,
-      selection.specification.name,
-      selection.scenario.name,
-      selection.scenario.tags,
-    )
-  )
-}
-
-function selectionMatchesResult(
-  selection: {
-    specification: { source: { uri: string }; name: string }
-    scenario: { name: string; id?: string; tags: string[] }
-  },
-  result: TestResult,
-): boolean {
-  return (
-    scenarioSelectionId(selection) ===
-      (result.scenario.id ?? result.scenario.name) ||
-    selection.scenario.name === result.scenario.name
-  )
-}
-
 async function run(argv: string[]): Promise<number> {
   const args = parseRunArguments(argv)
   const config = await loadConfig(args.configPath)
   const controller = new AbortController()
   const onSigint = () => controller.abort()
   process.on('SIGINT', onSigint)
-  let server: Awaited<ReturnType<typeof startServer>>
-  let resolvedConfiguration:
-    | ReturnType<typeof resolveRunConfiguration>
-    | undefined
-
   try {
-    const specifications = await discoverSpecifications(
-      args.pattern ?? config.specifications ?? defaultSpecificationGlob,
-      args.language ?? config.language,
-    )
-    const suiteSelection = args.suite ? config.suites?.[args.suite] : undefined
-    if (args.suite && !suiteSelection) {
-      throw new Error(`Unknown test suite "${args.suite}"`)
-    }
-    const baseSelection = suiteSelection ?? config.selection
-    const store = openTestRunStore({
+    const started = await startProjectRun({
       root: process.cwd(),
-      artifactCapture: config.artifacts?.capture,
-    })
-    const shardSelection = args.selection.shard ?? baseSelection?.shard
-    const historicalDurations = shardSelection
-      ? await latestHistoricalDurations(store)
-      : undefined
-
-    let selections = selectScenarios(
-      specifications,
-      {
-        ...baseSelection,
-        ...args.selection,
-        shard: shardSelection,
-      },
-      historicalDurations ? { historicalDurations } : {},
-    )
-    let profileIds = args.profiles
-    let sourceRunId: string | undefined
-    let selectedResults: TestResult[] | undefined
-
-    if (args.rerunId) {
-      const { manifest: sourceManifest } = await loadPersistedRun(args.rerunId)
-      selectedResults = selectRerunResults(sourceManifest, {
-        failures: args.failures,
-        adaptations: args.adaptations,
-        ...(args.selection.scenarioName
-          ? { scenarioNames: [args.selection.scenarioName] }
-          : {}),
-        ...(args.profiles?.length ? { profileIds: args.profiles } : {}),
-      })
-      if (selectedResults.length === 0) {
-        throw new Error('No results match the current rerun selection')
-      }
-      selections = selectScenarios(
-        specifications,
-        {
-          ...baseSelection,
-          ...args.selection,
-          scenarioName: undefined,
-          shard: shardSelection,
-        },
-        historicalDurations ? { historicalDurations } : {},
-      ).filter((selection) =>
-        selectedResults!.some((result) =>
-          selectionMatchesResult(selection, result),
-        ),
-      )
-      if (selections.length === 0) {
-        throw new Error('No Scenarios match the current rerun selection')
-      }
-      profileIds = args.profiles?.length
-        ? args.profiles
-        : config.executionTargetProfiles
-          ? [
-              ...new Set(
-                selectedResults.map(
-                  (result) => result.executionTargetProfile.id,
-                ),
-              ),
-            ]
-          : undefined
-      sourceRunId = args.rerunId
-    }
-
-    if (selections.length === 0)
-      throw new Error('No Scenarios match the current selection')
-
-    const extensions = await loadExtensions(args.extensionsPath)
-    const runConfiguration = {
-      ...runConfigurationFrom(config, profileIds),
-      concurrency: args.concurrency ?? config.concurrency,
-      applicationRevision:
-        args.applicationRevision ?? config.applicationRevision,
-      execution: {
-        infrastructureRetries:
-          args.retries ?? config.execution?.infrastructureRetries,
-        functionalRetries: config.execution?.functionalRetries,
-        stepTimeoutMs: args.stepTimeoutMs ?? config.execution?.stepTimeoutMs,
-        scenarioTimeoutMs:
-          args.scenarioTimeoutMs ?? config.execution?.scenarioTimeoutMs,
-      },
-    }
-    resolvedConfiguration = resolveRunConfiguration(
-      runConfiguration,
-      configuredRunExtensions(
-        extensions,
-        config,
-        args,
-        runConfiguration.executionTargetProfiles ?? [],
-      ),
-    )
-    validateTargetSelection(selections, resolvedConfiguration.targets)
-    server = await startServer({
-      ...config.server,
-      ...(args.reuseServer ? { reuseExisting: true } : {}),
-    })
-    const testRun = await store.create(
-      sourceRunId ? { sourceRunId } : undefined,
-    )
-    const onEvent = async (
-      event: Parameters<
-        NonNullable<Parameters<typeof runScenarios>[0]['onEvent']>
-      >[0],
-    ) => {
-      const persisted = await testRun.append(event)
-      if (event.type === 'scenario-finished') {
-        await testRun.materialize({ finished: false })
-      }
-      console.log(JSON.stringify({ kind: 'run-event', event: persisted }))
-    }
-
-    const planStore = createFilePlanStore(process.cwd())
-    const shared = {
-      plans: planStore,
-      ci: Boolean(process.env.CI),
+      config,
+      options: args,
       signal: controller.signal,
-      onEvent,
-    }
-    const runs = selectedResults
-      ? await runSelectedResultPairs({
-          selectedResults,
-          selections,
-          targets: resolvedConfiguration.targets,
-          retry: resolvedConfiguration.retry,
-          timeout: resolvedConfiguration.timeout,
-          concurrency: resolvedConfiguration.concurrency,
-          applicationRevision: resolvedConfiguration.applicationRevision,
-          ...shared,
-        })
-      : await runScenarios({
-          selections,
-          ...resolvedConfiguration,
-          ...shared,
-        })
-    const manifest = await testRun.materialize()
+      onEvent: (event) => {
+        if (event.type === 'run-started') return
+        console.log(JSON.stringify({ kind: 'run-event', event }))
+      },
+    })
+    const { runs, manifest } = await started.done
+    const store = openTestRunStore({ root: process.cwd() })
     if (args.junitPath) await Bun.write(args.junitPath, formatJunit(manifest))
     if (args.jsonPath) await Bun.write(args.jsonPath, formatJson(manifest))
     if (args.ndjsonPath) {
-      await Bun.write(args.ndjsonPath, formatNdjson(await testRun.events()))
+      const persisted = await store.open(started.id)
+      await Bun.write(args.ndjsonPath, formatNdjson(await persisted.events()))
     }
     await store.applyRetention({
       maxAgeMs: config.retention?.days
@@ -546,40 +224,7 @@ async function run(argv: string[]): Promise<number> {
     return 0
   } finally {
     process.off('SIGINT', onSigint)
-    server?.stop()
-    if (resolvedConfiguration) {
-      await disposeAdapters(resolvedConfiguration.targets)
-    }
   }
-}
-
-async function runSelectedResultPairs(
-  input: {
-    selectedResults: readonly TestResult[]
-    selections: ReturnType<typeof selectScenarios>
-    targets: ReturnType<typeof resolveRunConfiguration>['targets']
-  } & Omit<Parameters<typeof runScenarios>[0], 'selections' | 'targets'>,
-) {
-  const runs = []
-  for (const target of input.targets) {
-    const profileId = target.executionTargetProfile.id
-    const profileSelections = input.selections.filter((selection) =>
-      input.selectedResults.some(
-        (result) =>
-          result.executionTargetProfile.id === profileId &&
-          selectionMatchesResult(selection, result),
-      ),
-    )
-    if (profileSelections.length === 0) continue
-    runs.push(
-      ...(await runScenarios({
-        ...input,
-        selections: profileSelections,
-        targets: [target],
-      })),
-    )
-  }
-  return runs
 }
 
 function projectOptions(argv: string[]): {
@@ -611,32 +256,12 @@ function migrateOptions(argv: string[]): {
   return options
 }
 
-async function loadPersistedRun(runId: string) {
-  const store = openTestRunStore({ root: process.cwd() })
-  const run = await store.open(runId)
-  const events = await run.events()
-  if (events.length === 0) throw new Error(`Unknown test run "${runId}"`)
-  const manifestPath = join(
-    process.cwd(),
-    '.pickle',
-    'runs',
-    runId,
-    'manifest.json',
-  )
-  const manifest = (await Bun.file(manifestPath).exists())
-    ? ((await Bun.file(manifestPath).json()) as Awaited<
-        ReturnType<typeof run.materialize>
-      >)
-    : await run.materialize({ finished: false })
-  return { manifest, events }
-}
-
 async function compare(argv: string[]): Promise<number> {
   if (argv.length !== 3) {
     throw new Error('Usage: pickle compare <baseline-id> <candidate-id>')
   }
-  const baseline = await loadPersistedRun(argv[1]!)
-  const candidate = await loadPersistedRun(argv[2]!)
+  const baseline = await loadPersistedRun(process.cwd(), argv[1]!)
+  const candidate = await loadPersistedRun(process.cwd(), argv[2]!)
   console.log(
     JSON.stringify(
       compareTestRuns(baseline.manifest, candidate.manifest),
@@ -695,7 +320,7 @@ async function exportRun(argv: string[]): Promise<number> {
     return 0
   }
 
-  const { manifest } = await loadPersistedRun(runId)
+  const { manifest } = await loadPersistedRun(process.cwd(), runId)
   const html = await formatHtml(manifest, {
     artifacts: allArtifacts ? 'all' : 'failures-and-adaptations',
   })
@@ -710,11 +335,96 @@ async function exportRun(argv: string[]): Promise<number> {
   return 0
 }
 
+function parseStudioArguments(argv: string[]): {
+  configPath?: string
+  extensionsPath?: string
+  open: boolean
+  port?: number
+} {
+  if (argv[0] !== 'studio') throw new Error('Usage: pickle studio [options]')
+  const options: {
+    configPath?: string
+    extensionsPath?: string
+    open: boolean
+    port?: number
+  } = { open: true }
+  for (let index = 1; index < argv.length; index++) {
+    const flag = argv[index]!
+    if (flag === '--no-open') options.open = false
+    else if (flag === '--port')
+      options.port = integer(valueAfter(argv, index++), flag, 0)
+    else if (flag === '--config') options.configPath = valueAfter(argv, index++)
+    else if (flag === '--extensions')
+      options.extensionsPath = valueAfter(argv, index++)
+    else throw new Error(`Unknown option: ${flag}`)
+  }
+  return options
+}
+
+async function studio(argv: string[]): Promise<number> {
+  const args = parseStudioArguments(argv)
+  const root = process.cwd()
+  const config = await loadConfig(args.configPath)
+  const profiles = config.executionTargetProfiles
+    ? Object.keys(config.executionTargetProfiles)
+    : [config.executionTargetProfile?.id ?? (config.web ? 'web' : 'custom')]
+  const controller = new AbortController()
+  const server = await startStudio({
+    project: {
+      name: basename(root),
+      root,
+      profiles,
+      suites: Object.keys(config.suites ?? {}),
+    },
+    gateway: {
+      async start(request, onEvent) {
+        const started = await startProjectRun({
+          root,
+          config,
+          options: {
+            extensionsPath: args.extensionsPath,
+            suite: request?.suite,
+            profiles: request?.profiles ? [...request.profiles] : undefined,
+          },
+          signal: controller.signal,
+          onEvent,
+        })
+        void started.done.catch((error) => {
+          console.error(error instanceof Error ? error.message : String(error))
+        })
+        return { id: started.id, done: started.done }
+      },
+      async snapshot(id) {
+        const { events, manifest } = await loadPersistedRun(root, id)
+        return { id, events, manifest }
+      },
+    },
+    open: args.open,
+    port: args.port,
+  })
+  console.log(`Studio ${server.url}`)
+  await new Promise<void>((resolve) => {
+    const stop = () => {
+      process.off('SIGINT', stop)
+      process.off('SIGTERM', stop)
+      controller.abort()
+      server.stop()
+      resolve()
+    }
+    process.on('SIGINT', stop)
+    process.on('SIGTERM', stop)
+  })
+  return 0
+}
+
 async function main(argv: string[]): Promise<number> {
   if (argv[0] === 'init') {
     if (argv.length > 1) throw new Error('Usage: pickle init')
     await initializeProject()
     return 0
+  }
+  if (argv[0] === 'studio') {
+    return studio(argv)
   }
   if (argv[0] === 'check') {
     await checkProject({ ...projectOptions(argv), report: console.log })

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -11,11 +11,20 @@ import {
   openTestRunStore,
   writeRunArchive,
 } from '@pickle-spec/runner'
-import type { SelectionOptions, SpecificationState } from '@pickle-spec/spec'
+import type {
+  SelectionOptions,
+  Specification,
+  SpecificationState,
+} from '@pickle-spec/spec'
+import type { StudioRunRequest, StudioSpecification } from '@pickle-spec/studio'
 import { startStudio } from '@pickle-spec/studio'
 import { screenshotModes, type WebAdapterOptions } from '@pickle-spec/web'
-import { loadConfig } from './config'
-import { loadPersistedRun, startProjectRun } from './execute-run'
+import { defaultSpecificationGlob, loadConfig } from './config'
+import {
+  loadPersistedRun,
+  loadProjectSpecifications,
+  startProjectRun,
+} from './execute-run'
 import { checkProject, initializeProject, migrateProject } from './project'
 
 interface RunArguments {
@@ -335,6 +344,30 @@ async function exportRun(argv: string[]): Promise<number> {
   return 0
 }
 
+function studioCatalog(
+  specifications: readonly Specification[],
+): StudioSpecification[] {
+  return specifications.map((specification) => ({
+    id: specification.id ?? specification.source.uri,
+    name: specification.name,
+    uri: specification.source.uri,
+    scenarios: specification.scenarios.map((scenario) => ({
+      id: scenario.id ?? scenario.name,
+      name: scenario.name,
+    })),
+  }))
+}
+
+function studioRunSelection(
+  request: StudioRunRequest | undefined,
+): SelectionOptions | undefined {
+  if (!request?.paths?.length && !request?.scenarioName) return undefined
+  return {
+    ...(request.paths?.length ? { paths: [...request.paths] } : {}),
+    ...(request.scenarioName ? { scenarioName: request.scenarioName } : {}),
+  }
+}
+
 function parseStudioArguments(argv: string[]): {
   configPath?: string
   extensionsPath?: string
@@ -368,16 +401,30 @@ async function studio(argv: string[]): Promise<number> {
   const profiles = config.executionTargetProfiles
     ? Object.keys(config.executionTargetProfiles)
     : [config.executionTargetProfile?.id ?? (config.web ? 'web' : 'custom')]
+  const specifications = studioCatalog(
+    await loadProjectSpecifications(
+      config.specifications ?? defaultSpecificationGlob,
+      config.language,
+      root,
+    ),
+  )
   const controller = new AbortController()
+  const activeRuns = new Map<string, AbortController>()
   const server = await startStudio({
     project: {
       name: basename(root),
       root,
       profiles,
       suites: Object.keys(config.suites ?? {}),
+      specifications,
     },
     gateway: {
       async start(request, onEvent) {
+        const runController = new AbortController()
+        const onProcessAbort = () => runController.abort()
+        controller.signal.addEventListener('abort', onProcessAbort, {
+          once: true,
+        })
         const started = await startProjectRun({
           root,
           config,
@@ -385,18 +432,30 @@ async function studio(argv: string[]): Promise<number> {
             extensionsPath: args.extensionsPath,
             suite: request?.suite,
             profiles: request?.profiles ? [...request.profiles] : undefined,
+            selection: studioRunSelection(request),
           },
-          signal: controller.signal,
+          signal: runController.signal,
           onEvent,
         })
-        void started.done.catch((error) => {
-          console.error(error instanceof Error ? error.message : String(error))
-        })
+        activeRuns.set(started.id, runController)
+        void started.done
+          .catch((error) => {
+            console.error(
+              error instanceof Error ? error.message : String(error),
+            )
+          })
+          .finally(() => {
+            activeRuns.delete(started.id)
+            controller.signal.removeEventListener('abort', onProcessAbort)
+          })
         return { id: started.id, done: started.done }
       },
       async snapshot(id) {
         const { events, manifest } = await loadPersistedRun(root, id)
         return { id, events, manifest }
+      },
+      async cancel(id) {
+        activeRuns.get(id)?.abort()
       },
     },
     open: args.open,

--- a/packages/cli/src/execute-run.ts
+++ b/packages/cli/src/execute-run.ts
@@ -1,0 +1,454 @@
+import { relative, resolve } from 'node:path'
+import { pathToFileURL } from 'node:url'
+import type {
+  ExecutionTargetAdapter,
+  ExecutionTargetProfile,
+  RunEvent,
+  RunExtensions,
+  ScenarioRun,
+  TestResult,
+  TestRunManifest,
+} from '@pickle-spec/runner'
+import {
+  createFilePlanStore,
+  latestHistoricalDurations,
+  openTestRunStore,
+  resolveRunConfiguration,
+  runScenarios,
+  selectRerunResults,
+  validateTargetSelection,
+} from '@pickle-spec/runner'
+import {
+  parseSpecification,
+  resolveScenarioId,
+  type SelectionOptions,
+  selectScenarios,
+  validateSpecificationMetadata,
+} from '@pickle-spec/spec'
+import { createWebAdapter, type WebAdapterOptions } from '@pickle-spec/web'
+import {
+  defaultExtensionsFile,
+  defaultSpecificationGlob,
+  type PickleConfig,
+  runConfigurationFrom,
+} from './config'
+import type { Extensions } from './extensions'
+import { startServer } from './server'
+
+export interface ProjectRunOptions {
+  pattern?: string
+  extensionsPath?: string
+  suite?: string
+  profiles?: string[]
+  selection?: SelectionOptions
+  retries?: number
+  concurrency?: number
+  language?: string
+  scenarioTimeoutMs?: number
+  stepTimeoutMs?: number
+  reuseServer?: boolean
+  headed?: boolean
+  screenshotMode?: NonNullable<WebAdapterOptions['screenshots']>['mode']
+  applicationRevision?: string
+  rerunId?: string
+  failures?: boolean
+  adaptations?: boolean
+  fast?: boolean
+}
+
+export interface StartedProjectRun {
+  id: string
+  done: Promise<{
+    runs: ScenarioRun[]
+    manifest: TestRunManifest
+  }>
+}
+
+export async function loadExtensions(
+  path?: string,
+  root = process.cwd(),
+): Promise<Extensions> {
+  const selectedPath = path ?? defaultExtensionsFile
+  const absolutePath = resolve(root, selectedPath)
+  if (!(await Bun.file(absolutePath).exists())) {
+    if (!path) return {}
+    throw new Error(`Extensions file not found: ${selectedPath}`)
+  }
+  return ((await import(pathToFileURL(absolutePath).href)).default ??
+    {}) as Extensions
+}
+
+async function discoverSpecifications(
+  patterns: string | string[],
+  language: string | undefined,
+  root: string,
+) {
+  const paths = new Set<string>()
+  for (const pattern of Array.isArray(patterns) ? patterns : [patterns]) {
+    const glob = new Bun.Glob(pattern)
+    for await (const path of glob.scan({
+      cwd: root,
+      absolute: true,
+      onlyFiles: true,
+    }))
+      paths.add(path)
+  }
+  if (paths.size === 0) {
+    const description = Array.isArray(patterns) ? patterns.join(', ') : patterns
+    throw new Error(`No specifications found matching: ${description}`)
+  }
+  const files = await Promise.all(
+    [...paths].sort().map(async (path) => ({
+      uri: relative(root, path),
+      source: await Bun.file(path).text(),
+    })),
+  )
+  validateSpecificationMetadata(files, language)
+  return files.map((file) =>
+    parseSpecification({
+      source: file.source,
+      uri: file.uri,
+      language,
+    }),
+  )
+}
+
+function configuredWebOptions(
+  config: PickleConfig,
+  args: ProjectRunOptions,
+  profileId?: string,
+): WebAdapterOptions | undefined {
+  const web =
+    (profileId
+      ? config.executionTargetProfiles?.[profileId]?.web
+      : undefined) ?? config.web
+  if (!web) return undefined
+  return {
+    ...web,
+    ...(args.fast ? { profile: 'fast' as const } : {}),
+    browser: {
+      ...web.browser,
+      ...(args.headed ? { headless: false } : {}),
+    },
+    screenshots: {
+      ...web.screenshots,
+      ...(args.screenshotMode ? { mode: args.screenshotMode } : {}),
+    },
+  }
+}
+
+function configuredAdapter(
+  extensions: Extensions,
+  web: WebAdapterOptions | undefined,
+): ExecutionTargetAdapter {
+  if (extensions.adapter) return extensions.adapter
+  if (!web)
+    throw new Error(
+      'Configure web.baseUrl or export an adapter from pickle.extensions.ts',
+    )
+  return createWebAdapter(web, extensions.webAutomationFactory)
+}
+
+function configuredRunExtensions(
+  extensions: Extensions,
+  config: PickleConfig,
+  args: ProjectRunOptions,
+  profiles: readonly ExecutionTargetProfile[],
+): RunExtensions {
+  const adapters: Record<string, ExecutionTargetAdapter> = {
+    ...extensions.adapters,
+  }
+  if (extensions.adapter) adapters.custom ??= extensions.adapter
+
+  for (const profile of profiles) {
+    if (profile.adapter !== 'web' || adapters[profile.id]) continue
+    const web = configuredWebOptions(config, args, profile.id)
+    if (adapters.web) {
+      adapters[profile.id] = adapters.web
+      continue
+    }
+    if (!web) {
+      throw new Error(
+        'Configure web.baseUrl or export an adapter from pickle.extensions.ts',
+      )
+    }
+    adapters[profile.id] = createWebAdapter(
+      web,
+      extensions.webAutomationFactory,
+    )
+  }
+
+  return {
+    adapter: profiles.some((profile) => profile.adapter)
+      ? extensions.adapter
+      : configuredAdapter(extensions, configuredWebOptions(config, args)),
+    adapters,
+  }
+}
+
+async function disposeAdapters(
+  targets: ReturnType<typeof resolveRunConfiguration>['targets'],
+): Promise<void> {
+  const seen = new Set<ExecutionTargetAdapter>()
+  for (const target of targets) {
+    if (seen.has(target.adapter)) continue
+    seen.add(target.adapter)
+    await target.adapter.dispose?.()
+  }
+}
+
+function scenarioSelectionId(selection: {
+  specification: { source: { uri: string }; name: string }
+  scenario: { name: string; id?: string; tags: string[] }
+}): string {
+  return (
+    selection.scenario.id ??
+    resolveScenarioId(
+      selection.specification.source.uri,
+      selection.specification.name,
+      selection.scenario.name,
+      selection.scenario.tags,
+    )
+  )
+}
+
+function selectionMatchesResult(
+  selection: {
+    specification: { source: { uri: string }; name: string }
+    scenario: { name: string; id?: string; tags: string[] }
+  },
+  result: TestResult,
+): boolean {
+  return (
+    scenarioSelectionId(selection) ===
+      (result.scenario.id ?? result.scenario.name) ||
+    selection.scenario.name === result.scenario.name
+  )
+}
+
+async function runSelectedResultPairs(
+  input: {
+    selectedResults: readonly TestResult[]
+    selections: ReturnType<typeof selectScenarios>
+    targets: ReturnType<typeof resolveRunConfiguration>['targets']
+  } & Omit<Parameters<typeof runScenarios>[0], 'selections' | 'targets'>,
+) {
+  const runs = []
+  for (const target of input.targets) {
+    const profileId = target.executionTargetProfile.id
+    const profileSelections = input.selections.filter((selection) =>
+      input.selectedResults.some(
+        (result) =>
+          result.executionTargetProfile.id === profileId &&
+          selectionMatchesResult(selection, result),
+      ),
+    )
+    if (profileSelections.length === 0) continue
+    runs.push(
+      ...(await runScenarios({
+        ...input,
+        selections: profileSelections,
+        targets: [target],
+      })),
+    )
+  }
+  return runs
+}
+
+export async function loadPersistedRun(root: string, runId: string) {
+  const store = openTestRunStore({ root })
+  const run = await store.open(runId)
+  const events = await run.events()
+  if (events.length === 0) throw new Error(`Unknown test run "${runId}"`)
+  const manifestPath = resolve(root, '.pickle', 'runs', runId, 'manifest.json')
+  const manifest = (await Bun.file(manifestPath).exists())
+    ? ((await Bun.file(manifestPath).json()) as TestRunManifest)
+    : await run.materialize({ finished: false })
+  return { manifest, events }
+}
+
+export async function startProjectRun(input: {
+  root: string
+  config: PickleConfig
+  options?: ProjectRunOptions
+  signal?: AbortSignal
+  onEvent?: (event: RunEvent) => void | Promise<void>
+}): Promise<StartedProjectRun> {
+  const args = input.options ?? {}
+  const root = input.root
+  const store = openTestRunStore({
+    root,
+    artifactCapture: input.config.artifacts?.capture,
+  })
+  const testRun = await store.create(
+    args.rerunId ? { sourceRunId: args.rerunId } : undefined,
+  )
+
+  const done = new Promise<{
+    runs: ScenarioRun[]
+    manifest: TestRunManifest
+  }>((resolve, reject) => {
+    setTimeout(() => {
+      void runWork().then(resolve, reject)
+    }, 0)
+  })
+
+  async function runWork() {
+    let resolvedConfiguration:
+      | ReturnType<typeof resolveRunConfiguration>
+      | undefined
+    let server: Awaited<ReturnType<typeof startServer>> | undefined
+    try {
+      const specifications = await discoverSpecifications(
+        args.pattern ?? input.config.specifications ?? defaultSpecificationGlob,
+        args.language ?? input.config.language,
+        root,
+      )
+      const suiteSelection = args.suite
+        ? input.config.suites?.[args.suite]
+        : undefined
+      if (args.suite && !suiteSelection) {
+        throw new Error(`Unknown test suite "${args.suite}"`)
+      }
+      const baseSelection = suiteSelection ?? input.config.selection
+      const shardSelection = args.selection?.shard ?? baseSelection?.shard
+      const historicalDurations = shardSelection
+        ? await latestHistoricalDurations(store)
+        : undefined
+
+      let selections = selectScenarios(
+        specifications,
+        {
+          ...baseSelection,
+          ...args.selection,
+          shard: shardSelection,
+        },
+        historicalDurations ? { historicalDurations } : {},
+      )
+      let profileIds = args.profiles
+      let selectedResults: TestResult[] | undefined
+
+      if (args.rerunId) {
+        const { manifest: sourceManifest } = await loadPersistedRun(
+          root,
+          args.rerunId,
+        )
+        selectedResults = selectRerunResults(sourceManifest, {
+          failures: args.failures,
+          adaptations: args.adaptations,
+          ...(args.selection?.scenarioName
+            ? { scenarioNames: [args.selection.scenarioName] }
+            : {}),
+          ...(args.profiles?.length ? { profileIds: args.profiles } : {}),
+        })
+        if (selectedResults.length === 0) {
+          throw new Error('No results match the current rerun selection')
+        }
+        selections = selectScenarios(
+          specifications,
+          {
+            ...baseSelection,
+            ...args.selection,
+            scenarioName: undefined,
+            shard: shardSelection,
+          },
+          historicalDurations ? { historicalDurations } : {},
+        ).filter((selection) =>
+          selectedResults!.some((result) =>
+            selectionMatchesResult(selection, result),
+          ),
+        )
+        if (selections.length === 0) {
+          throw new Error('No Scenarios match the current rerun selection')
+        }
+        profileIds = args.profiles?.length
+          ? args.profiles
+          : input.config.executionTargetProfiles
+            ? [
+                ...new Set(
+                  selectedResults.map(
+                    (result) => result.executionTargetProfile.id,
+                  ),
+                ),
+              ]
+            : undefined
+      }
+
+      if (selections.length === 0)
+        throw new Error('No Scenarios match the current selection')
+
+      const extensions = await loadExtensions(args.extensionsPath, root)
+      const runConfiguration = {
+        ...runConfigurationFrom(input.config, profileIds),
+        concurrency: args.concurrency ?? input.config.concurrency,
+        applicationRevision:
+          args.applicationRevision ?? input.config.applicationRevision,
+        execution: {
+          infrastructureRetries:
+            args.retries ?? input.config.execution?.infrastructureRetries,
+          functionalRetries: input.config.execution?.functionalRetries,
+          stepTimeoutMs:
+            args.stepTimeoutMs ?? input.config.execution?.stepTimeoutMs,
+          scenarioTimeoutMs:
+            args.scenarioTimeoutMs ?? input.config.execution?.scenarioTimeoutMs,
+        },
+      }
+      resolvedConfiguration = resolveRunConfiguration(
+        runConfiguration,
+        configuredRunExtensions(
+          extensions,
+          input.config,
+          args,
+          runConfiguration.executionTargetProfiles ?? [],
+        ),
+      )
+      validateTargetSelection(selections, resolvedConfiguration.targets)
+      server = await startServer({
+        ...input.config.server,
+        ...(args.reuseServer ? { reuseExisting: true } : {}),
+      })
+      const onEvent = async (event: RunEvent) => {
+        const persisted = await testRun.append(event)
+        if (event.type === 'scenario-finished') {
+          await testRun.materialize({ finished: false })
+        }
+        await input.onEvent?.(persisted)
+      }
+      for (const event of await testRun.events()) {
+        await input.onEvent?.(event)
+      }
+      const planStore = createFilePlanStore(root)
+      const shared = {
+        plans: planStore,
+        ci: Boolean(process.env.CI),
+        signal: input.signal,
+        onEvent,
+      }
+      const runs = selectedResults
+        ? await runSelectedResultPairs({
+            selectedResults,
+            selections,
+            targets: resolvedConfiguration.targets,
+            retry: resolvedConfiguration.retry,
+            timeout: resolvedConfiguration.timeout,
+            concurrency: resolvedConfiguration.concurrency,
+            applicationRevision: resolvedConfiguration.applicationRevision,
+            ...shared,
+          })
+        : await runScenarios({
+            selections,
+            ...resolvedConfiguration,
+            ...shared,
+          })
+      const manifest = await testRun.materialize()
+      return { runs, manifest }
+    } finally {
+      server?.stop()
+      if (resolvedConfiguration) {
+        await disposeAdapters(resolvedConfiguration.targets)
+      }
+    }
+  }
+
+  return { id: testRun.id, done }
+}

--- a/packages/cli/src/execute-run.ts
+++ b/packages/cli/src/execute-run.ts
@@ -78,7 +78,7 @@ export async function loadExtensions(
     {}) as Extensions
 }
 
-async function discoverSpecifications(
+export async function loadProjectSpecifications(
   patterns: string | string[],
   language: string | undefined,
   root: string,
@@ -93,10 +93,7 @@ async function discoverSpecifications(
     }))
       paths.add(path)
   }
-  if (paths.size === 0) {
-    const description = Array.isArray(patterns) ? patterns.join(', ') : patterns
-    throw new Error(`No specifications found matching: ${description}`)
-  }
+  if (paths.size === 0) return []
   const files = await Promise.all(
     [...paths].sort().map(async (path) => ({
       uri: relative(root, path),
@@ -111,6 +108,23 @@ async function discoverSpecifications(
       language,
     }),
   )
+}
+
+async function discoverSpecifications(
+  patterns: string | string[],
+  language: string | undefined,
+  root: string,
+) {
+  const specifications = await loadProjectSpecifications(
+    patterns,
+    language,
+    root,
+  )
+  if (specifications.length === 0) {
+    const description = Array.isArray(patterns) ? patterns.join(', ') : patterns
+    throw new Error(`No specifications found matching: ${description}`)
+  }
+  return specifications
 }
 
 function configuredWebOptions(

--- a/packages/cli/src/studio.test.ts
+++ b/packages/cli/src/studio.test.ts
@@ -148,6 +148,14 @@ export default {
 
   test('pickle studio starts a local application and opens the configured project', async () => {
     const project = await createStudioProject('opened-project')
+    await Bun.write(
+      join(project, 'features', 'search.feature'),
+      `@pickle:id:specsearchaaaaaaa @pickle:state:active
+Feature: Search
+  @pickle:id:scnquerybbbbbbbb
+  Scenario: Query the catalog
+    Then results are shown`,
+    )
     const { child, url } = await startStudio(project)
     const page = await browser.newPage()
     try {
@@ -160,9 +168,56 @@ export default {
       expect(
         await page.getByRole('link', { name: 'Specifications' }).count(),
       ).toBe(1)
-      expect(await page.getByRole('link', { name: 'Runs' }).count()).toBe(1)
-      expect(await page.getByRole('link', { name: 'Plans' }).count()).toBe(1)
-      expect(await page.getByRole('link', { name: 'Settings' }).count()).toBe(1)
+      expect(
+        await page.getByRole('link', { name: 'Runs', disabled: true }).count(),
+      ).toBe(1)
+      expect(
+        await page.getByRole('link', { name: 'Plans', disabled: true }).count(),
+      ).toBe(1)
+      expect(
+        await page
+          .getByRole('link', { name: 'Settings', disabled: true })
+          .count(),
+      ).toBe(1)
+      expect(
+        await page.getByRole('status').filter({ hasText: 'Ready' }).count(),
+      ).toBe(1)
+      const catalog = page.getByRole('navigation', { name: 'Specifications' })
+      expect(
+        await catalog.getByRole('button', { name: 'Checkout' }).count(),
+      ).toBe(1)
+      expect(
+        await catalog.getByRole('button', { name: 'Search' }).count(),
+      ).toBe(1)
+      expect(
+        await page.getByRole('heading', { name: 'Checkout' }).count(),
+      ).toBe(1)
+      expect(
+        await page.getByRole('button', { name: 'Run Specification' }).count(),
+      ).toBe(1)
+      expect(
+        await page.getByRole('button', { name: 'Start test run' }).count(),
+      ).toBe(0)
+      expect(
+        await page.getByRole('heading', { name: 'Needs attention' }).count(),
+      ).toBe(0)
+      const scenarios = page.getByRole('table', { name: 'Scenarios' })
+      expect(
+        await scenarios.getByRole('columnheader', { name: 'chrome' }).count(),
+      ).toBe(1)
+      expect(
+        await scenarios.getByRole('columnheader', { name: 'firefox' }).count(),
+      ).toBe(1)
+      expect(
+        await scenarios
+          .getByRole('rowheader', { name: 'Pay for the order' })
+          .count(),
+      ).toBe(1)
+      expect(
+        await page
+          .getByRole('button', { name: 'Run Scenario Pay for the order' })
+          .count(),
+      ).toBe(1)
       expect(new URL(url).hostname).toBe('127.0.0.1')
     } finally {
       await page.close()
@@ -182,63 +237,139 @@ export default {
     const page = await browser.newPage()
     try {
       await page.goto(url)
-      await page.getByRole('button', { name: 'Start test run' }).click()
-      await page.getByRole('status').filter({ hasText: 'running' }).waitFor()
+      await page.getByRole('button', { name: 'Run Specification' }).click()
+      const running = page.getByRole('status').filter({ hasText: 'running' })
+      await running.waitFor()
+      expect(await running.locator('[data-slot="spinner"]').count()).toBe(1)
+      await page.getByRole('button', { name: 'Cancel test run' }).waitFor()
       await page
         .getByRole('button', { name: 'Pay for the order chrome running' })
         .waitFor()
-      expect(await finishedManifestCount(project)).toBe(0)
-      await page
-        .getByRole('button', { name: 'Pay for the order chrome running' })
-        .click()
       expect(
-        await page.getByRole('list', { name: 'Step timeline' }).textContent(),
-      ).toContain('Then payment is captured')
+        await page
+          .getByRole('button', { name: 'Pay for the order chrome running' })
+          .locator('[data-slot="spinner"]')
+          .count(),
+      ).toBe(1)
+      expect(await finishedManifestCount(project)).toBe(0)
       await Bun.write(gate, 'continue')
-      await page.getByRole('status').filter({ hasText: 'failed' }).waitFor({
+      const failed = page.getByRole('status').filter({ hasText: 'failed' })
+      await failed.waitFor({
         timeout: 20_000,
       })
+      expect(await failed.locator('svg').count()).toBe(1)
+      expect(
+        await page
+          .getByRole('button', { name: 'Pay for the order chrome failed' })
+          .locator('svg')
+          .count(),
+      ).toBe(1)
       const attention = page.getByRole('list', { name: 'Needs attention' })
       const items = attention.getByRole('listitem')
       expect(await items.count()).toBe(2)
       expect(await items.nth(0).textContent()).toContain('Pay for the order')
       expect(await items.nth(0).textContent()).toContain('failed')
+      expect(await items.nth(0).textContent()).toContain('Open step timeline')
       expect(await items.nth(1).textContent()).toContain('Adapt the purchase')
       expect(await items.nth(1).textContent()).toContain(
         'passed-with-adaptation',
       )
-      const matrix = page.getByRole('table', { name: 'Target matrix' })
+      const timeline = page.getByRole('list', { name: 'Step timeline' })
+      expect(await timeline.textContent()).toContain('Then payment is captured')
+      expect(await timeline.textContent()).toContain('Payment was declined')
+      const scenarios = page.getByRole('table', { name: 'Scenarios' })
       expect(
-        await matrix.getByRole('columnheader', { name: 'chrome' }).count(),
+        await scenarios.getByRole('columnheader', { name: 'chrome' }).count(),
       ).toBe(1)
       expect(
-        await matrix.getByRole('columnheader', { name: 'firefox' }).count(),
+        await scenarios.getByRole('columnheader', { name: 'firefox' }).count(),
       ).toBe(1)
       expect(
-        await matrix
+        await scenarios
           .getByRole('rowheader', { name: 'Pay for the order' })
           .count(),
       ).toBe(1)
       expect(
-        await matrix
+        await scenarios
           .getByRole('rowheader', { name: 'Adapt the purchase' })
           .count(),
       ).toBe(1)
       expect(
-        await matrix
+        await scenarios
           .getByRole('rowheader', { name: 'Complete a purchase' })
           .count(),
       ).toBe(1)
       await page
         .getByRole('button', { name: 'Pay for the order chrome failed' })
         .click()
-      const timeline = page.getByRole('list', { name: 'Step timeline' })
       expect(await timeline.textContent()).toContain('Then payment is captured')
       expect(await timeline.textContent()).toContain('Click pay on chrome')
       expect(await timeline.textContent()).toContain('Payment was declined')
-      expect(await page.getByRole('img', { name: 'screenshot' }).count()).toBe(
+      expect(await page.getByRole('img', { name: /screenshot/ }).count()).toBe(
         1,
       )
+    } finally {
+      await page.close()
+      child.kill()
+      await child.exited
+    }
+  }, 60_000)
+
+  test('Studio cancels a live test run without starting another', async () => {
+    const project = await createStudioProject('cancel-run')
+    const marker = join(project, 'step-started.txt')
+    const gate = join(project, 'continue.txt')
+    const { child, url } = await startStudio(project, {
+      PICKLE_STUDIO_STEP_MARKER: marker,
+      PICKLE_STUDIO_CONTINUE: gate,
+    })
+    const page = await browser.newPage()
+    try {
+      await page.goto(url)
+      await page.getByRole('button', { name: 'Run Specification' }).click()
+      await page.getByRole('button', { name: 'Cancel test run' }).waitFor()
+      await page.getByRole('button', { name: 'Run Specification' }).waitFor({
+        state: 'hidden',
+      })
+      await page.getByRole('button', { name: 'Cancel test run' }).click()
+      await page.getByRole('button', { name: 'Run Specification' }).waitFor({
+        timeout: 20_000,
+      })
+    } finally {
+      await page.close()
+      child.kill()
+      await child.exited
+    }
+  }, 60_000)
+
+  test('Studio runs a single Scenario without the rest of the Specification', async () => {
+    const project = await createStudioProject('single-scenario')
+    const marker = join(project, 'step-started.txt')
+    const gate = join(project, 'continue.txt')
+    const { child, url } = await startStudio(project, {
+      PICKLE_STUDIO_STEP_MARKER: marker,
+      PICKLE_STUDIO_CONTINUE: gate,
+    })
+    const page = await browser.newPage()
+    try {
+      await page.goto(url)
+      await page
+        .getByRole('button', { name: 'Run Scenario Pay for the order' })
+        .click()
+      await page.getByRole('status').filter({ hasText: 'running' }).waitFor()
+      await page
+        .getByRole('button', { name: 'Pay for the order chrome running' })
+        .waitFor()
+      await Bun.write(gate, 'continue')
+      await page.getByRole('status').filter({ hasText: 'failed' }).waitFor({
+        timeout: 20_000,
+      })
+      const attention = page.getByRole('list', { name: 'Needs attention' })
+      expect(await attention.getByRole('listitem').count()).toBe(1)
+      expect(await attention.textContent()).toContain('Pay for the order')
+      expect(await attention.textContent()).not.toContain('Adapt the purchase')
+      const scenarios = page.getByRole('table', { name: 'Scenarios' })
+      expect(await scenarios.textContent()).toContain('pending')
     } finally {
       await page.close()
       child.kill()

--- a/packages/cli/src/studio.test.ts
+++ b/packages/cli/src/studio.test.ts
@@ -1,0 +1,292 @@
+import { afterAll, beforeAll, describe, expect, test } from 'bun:test'
+import { mkdir, mkdtemp, rm, symlink } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join, resolve } from 'node:path'
+import { type Browser, chromium } from 'playwright'
+
+type CliPackageManifest = {
+  bin: { pickle: string }
+}
+
+type TestRunManifestFile = {
+  finishedAt?: string
+}
+
+describe('Studio browser seam', () => {
+  let workspace: string
+  let pickleCommand: string
+  let browser: Browser
+
+  async function createStudioProject(name: string): Promise<string> {
+    const project = join(workspace, name)
+    const screenshot = join(project, 'failure.png')
+    await mkdir(join(project, 'features'), { recursive: true })
+    await Bun.write(screenshot, Buffer.from([137, 80, 78, 71, 13, 10, 26, 10]))
+    await Bun.write(
+      join(project, 'pickle.config.jsonc'),
+      JSON.stringify({
+        schemaVersion: 1,
+        specifications: 'features/**/*.feature',
+        executionTargetProfiles: {
+          chrome: { adapter: 'custom' },
+          firefox: { adapter: 'custom' },
+        },
+      }),
+    )
+    await Bun.write(
+      join(project, 'features', 'checkout.feature'),
+      `@pickle:id:speccheckaaaaaaaa @pickle:state:active
+Feature: Checkout
+  @pickle:id:scnpaybbbbbbbbbb
+  Scenario: Pay for the order
+    Then payment is captured
+  @pickle:id:scnadaptcccccccc
+  Scenario: Adapt the purchase
+    Then the basket adapts
+  @pickle:id:scnpassdddddddd
+  Scenario: Complete a purchase
+    Then the purchase succeeds`,
+    )
+    await Bun.write(
+      join(project, 'pickle.extensions.ts'),
+      `
+export default {
+  adapter: {
+    async openSession(input) {
+      return {
+        async executeStep(step, signal) {
+          const marker = process.env.PICKLE_STUDIO_STEP_MARKER
+          const gate = process.env.PICKLE_STUDIO_CONTINUE
+          if (marker && !(await Bun.file(marker).exists())) {
+            await Bun.write(marker, 'started')
+          }
+          if (gate) {
+            while (!(await Bun.file(gate).exists())) {
+              if (signal?.aborted) {
+                throw new DOMException('Scenario cancelled', 'AbortError')
+              }
+              await Bun.sleep(10)
+            }
+          }
+          const profile = input.executionTargetProfile.id
+          const scenario = input.scenario.name
+          if (scenario === 'Pay for the order' && profile === 'chrome') {
+            return {
+              state: 'failed',
+              message: 'Payment was declined',
+              resolvedActions: [{ description: \`Click pay on \${profile}\` }],
+              artifacts: [{
+                kind: 'screenshot',
+                path: ${JSON.stringify(screenshot)},
+                mediaType: 'image/png',
+              }],
+            }
+          }
+          if (scenario === 'Adapt the purchase' && profile === 'chrome') {
+            return {
+              state: 'passed-with-adaptation',
+              resolvedActions: [{ description: \`Adapt basket on \${profile}\` }],
+            }
+          }
+          return {
+            state: 'passed',
+            resolvedActions: [{ description: \`Complete \${scenario} on \${profile}\` }],
+          }
+        },
+        async close() {},
+      }
+    },
+  },
+}
+`,
+    )
+    return project
+  }
+
+  async function startStudio(
+    project: string,
+    env: Record<string, string> = {},
+  ) {
+    const child = Bun.spawn({
+      cmd: [pickleCommand, 'studio', '--no-open'],
+      cwd: project,
+      env: { ...Bun.env, ...env },
+      stdout: 'pipe',
+      stderr: 'pipe',
+    })
+    const stdout = collectStream(child.stdout)
+    const stderr = collectStream(child.stderr)
+    const url = await stdout.waitFor(
+      /Studio (http:\/\/127\.0\.0\.1:\d+\S*)/,
+      15_000,
+    )
+    return { child, url, stdout, stderr }
+  }
+
+  beforeAll(async () => {
+    workspace = await mkdtemp(join(tmpdir(), 'pickle-spec-studio-'))
+    const packageDirectory = resolve(import.meta.dir, '..')
+    const packageManifest = (await Bun.file(
+      join(packageDirectory, 'package.json'),
+    ).json()) as CliPackageManifest
+    pickleCommand = join(workspace, 'node_modules', '.bin', 'pickle')
+    await mkdir(join(workspace, 'node_modules', '.bin'), { recursive: true })
+    await symlink(
+      resolve(packageDirectory, packageManifest.bin.pickle),
+      pickleCommand,
+    )
+    browser = await chromium.launch({
+      headless: true,
+      channel: 'chrome',
+    })
+  })
+
+  afterAll(async () => {
+    await browser?.close()
+    await rm(workspace, { recursive: true, force: true })
+  })
+
+  test('pickle studio starts a local application and opens the configured project', async () => {
+    const project = await createStudioProject('opened-project')
+    const { child, url } = await startStudio(project)
+    const page = await browser.newPage()
+    try {
+      await page.goto(url)
+      expect(
+        await page
+          .getByRole('heading', { name: 'opened-project' })
+          .textContent(),
+      ).toBe('opened-project')
+      expect(
+        await page.getByRole('link', { name: 'Specifications' }).count(),
+      ).toBe(1)
+      expect(await page.getByRole('link', { name: 'Runs' }).count()).toBe(1)
+      expect(await page.getByRole('link', { name: 'Plans' }).count()).toBe(1)
+      expect(await page.getByRole('link', { name: 'Settings' }).count()).toBe(1)
+      expect(new URL(url).hostname).toBe('127.0.0.1')
+    } finally {
+      await page.close()
+      child.kill()
+      await child.exited
+    }
+  }, 30_000)
+
+  test('Studio starts a web test run and diagnoses live results', async () => {
+    const project = await createStudioProject('live-diagnosis')
+    const marker = join(project, 'step-started.txt')
+    const gate = join(project, 'continue.txt')
+    const { child, url } = await startStudio(project, {
+      PICKLE_STUDIO_STEP_MARKER: marker,
+      PICKLE_STUDIO_CONTINUE: gate,
+    })
+    const page = await browser.newPage()
+    try {
+      await page.goto(url)
+      await page.getByRole('button', { name: 'Start test run' }).click()
+      await page.getByRole('status').filter({ hasText: 'running' }).waitFor()
+      await page
+        .getByRole('button', { name: 'Pay for the order chrome running' })
+        .waitFor()
+      expect(await finishedManifestCount(project)).toBe(0)
+      await page
+        .getByRole('button', { name: 'Pay for the order chrome running' })
+        .click()
+      expect(
+        await page.getByRole('list', { name: 'Step timeline' }).textContent(),
+      ).toContain('Then payment is captured')
+      await Bun.write(gate, 'continue')
+      await page.getByRole('status').filter({ hasText: 'failed' }).waitFor({
+        timeout: 20_000,
+      })
+      const attention = page.getByRole('list', { name: 'Needs attention' })
+      const items = attention.getByRole('listitem')
+      expect(await items.count()).toBe(2)
+      expect(await items.nth(0).textContent()).toContain('Pay for the order')
+      expect(await items.nth(0).textContent()).toContain('failed')
+      expect(await items.nth(1).textContent()).toContain('Adapt the purchase')
+      expect(await items.nth(1).textContent()).toContain(
+        'passed-with-adaptation',
+      )
+      const matrix = page.getByRole('table', { name: 'Target matrix' })
+      expect(
+        await matrix.getByRole('columnheader', { name: 'chrome' }).count(),
+      ).toBe(1)
+      expect(
+        await matrix.getByRole('columnheader', { name: 'firefox' }).count(),
+      ).toBe(1)
+      expect(
+        await matrix
+          .getByRole('rowheader', { name: 'Pay for the order' })
+          .count(),
+      ).toBe(1)
+      expect(
+        await matrix
+          .getByRole('rowheader', { name: 'Adapt the purchase' })
+          .count(),
+      ).toBe(1)
+      expect(
+        await matrix
+          .getByRole('rowheader', { name: 'Complete a purchase' })
+          .count(),
+      ).toBe(1)
+      await page
+        .getByRole('button', { name: 'Pay for the order chrome failed' })
+        .click()
+      const timeline = page.getByRole('list', { name: 'Step timeline' })
+      expect(await timeline.textContent()).toContain('Then payment is captured')
+      expect(await timeline.textContent()).toContain('Click pay on chrome')
+      expect(await timeline.textContent()).toContain('Payment was declined')
+      expect(await page.getByRole('img', { name: 'screenshot' }).count()).toBe(
+        1,
+      )
+    } finally {
+      await page.close()
+      child.kill()
+      await child.exited
+    }
+  }, 60_000)
+})
+
+function collectStream(stream: ReadableStream<Uint8Array>) {
+  const chunks: string[] = []
+  const reader = stream.getReader()
+  const decoder = new TextDecoder()
+  void (async () => {
+    while (true) {
+      const { done, value } = await reader.read()
+      if (done) break
+      chunks.push(decoder.decode(value, { stream: true }))
+    }
+  })()
+  return {
+    text() {
+      return chunks.join('')
+    },
+    async waitFor(pattern: RegExp, timeoutMs: number) {
+      const deadline = Date.now() + timeoutMs
+      while (Date.now() < deadline) {
+        const match = chunks.join('').match(pattern)
+        if (match?.[1]) return match[1]
+        await Bun.sleep(25)
+      }
+      throw new Error(
+        `Studio did not print a loopback URL.\n${chunks.join('')}`,
+      )
+    },
+  }
+}
+
+async function finishedManifestCount(project: string): Promise<number> {
+  const manifests = new Bun.Glob('*/manifest.json').scan({
+    cwd: join(project, '.pickle', 'runs'),
+    onlyFiles: true,
+  })
+  let finished = 0
+  for await (const relativePath of manifests) {
+    const manifest = (await Bun.file(
+      join(project, '.pickle', 'runs', relativePath),
+    ).json()) as TestRunManifestFile
+    if (manifest.finishedAt) finished++
+  }
+  return finished
+}

--- a/packages/cli/src/studio.test.ts
+++ b/packages/cli/src/studio.test.ts
@@ -138,13 +138,14 @@ export default {
     browser = await chromium.launch({
       headless: true,
       channel: 'chrome',
+      timeout: 60_000,
     })
-  })
+  }, 60_000)
 
   afterAll(async () => {
     await browser?.close()
     await rm(workspace, { recursive: true, force: true })
-  })
+  }, 15_000)
 
   test('pickle studio starts a local application and opens the configured project', async () => {
     const project = await createStudioProject('opened-project')

--- a/packages/runner/src/run-scenario.ts
+++ b/packages/runner/src/run-scenario.ts
@@ -121,9 +121,23 @@ export type RunEventPayload =
       type: 'run-started'
       run: { id: string; startedAt: string; sourceRunId?: string }
     }
-  | { type: 'scenario-started'; scenario: TestResult['scenario'] }
-  | { type: 'step-started'; step: ScenarioStep }
-  | { type: 'step-finished'; result: TestStepResult }
+  | {
+      type: 'scenario-started'
+      scenario: TestResult['scenario']
+      executionTargetProfile?: ExecutionTargetProfile
+    }
+  | {
+      type: 'step-started'
+      step: ScenarioStep
+      scenario?: TestResult['scenario']
+      executionTargetProfile?: ExecutionTargetProfile
+    }
+  | {
+      type: 'step-finished'
+      result: TestStepResult
+      scenario?: TestResult['scenario']
+      executionTargetProfile?: ExecutionTargetProfile
+    }
   | { type: 'scenario-finished'; result: TestResult; scheduleIndex?: number }
 
 export type RunEvent = RunEventEnvelope & RunEventPayload
@@ -327,6 +341,16 @@ function createTestResult(
   }
 }
 
+function attemptIdentity(input: ScenarioAttemptInput) {
+  return {
+    scenario: {
+      name: input.scenario.name,
+      id: planQuery(input).scenarioId,
+    },
+    executionTargetProfile: input.executionTargetProfile,
+  }
+}
+
 async function runScenarioAttempt(
   input: ScenarioAttemptInput,
 ): Promise<ScenarioRun> {
@@ -361,10 +385,7 @@ async function runScenarioAttempt(
 
   await emit({
     type: 'scenario-started',
-    scenario: {
-      name: input.scenario.name,
-      id: planQuery(input).scenarioId,
-    },
+    ...attemptIdentity(input),
   })
 
   if (input.scenario.tags.includes(ignoreTag)) {
@@ -402,7 +423,7 @@ async function runScenarioAttempt(
   const steps: TestStepResult[] = []
   const recordStep = async (result: TestStepResult): Promise<void> => {
     steps.push(result)
-    await emit({ type: 'step-finished', result })
+    await emit({ type: 'step-finished', result, ...attemptIdentity(input) })
   }
   let state: TestResultState = input.signal?.aborted ? 'cancelled' : 'passed'
   let message: string | undefined = input.signal?.aborted
@@ -417,7 +438,7 @@ async function runScenarioAttempt(
         break
       }
 
-      await emit({ type: 'step-started', step })
+      await emit({ type: 'step-started', step, ...attemptIdentity(input) })
       let execution: StepExecution
       try {
         const deadline = stepDeadline(input.timeout, scenarioStartedAt)
@@ -501,9 +522,15 @@ export async function runScenario(
       ...input,
       mode: selected.mode,
       ...(selected.plan ? { plan: selected.plan } : {}),
-      // Collect attempt events locally so retries can be resequenced.
-      onEvent: undefined,
-      // Attempts own one logical session; retries are orchestrated here.
+      onEvent: async (event) => {
+        if (event.type === 'scenario-finished') return
+        const versionedEvent = {
+          ...event,
+          sequence: events.length + 1,
+        } as RunEvent
+        events.push(versionedEvent)
+        await input.onEvent?.(versionedEvent)
+      },
       retry: undefined,
     })
     const shouldRetryInfrastructure =
@@ -518,12 +545,11 @@ export async function runScenario(
     const result = withAttemptMetadata(run.result, attempt)
 
     for (const event of run.events) {
+      if (event.type !== 'scenario-finished') continue
       const versionedEvent = {
         ...event,
         sequence: events.length + 1,
-        ...(event.type === 'scenario-finished' && !shouldRetry
-          ? { result }
-          : {}),
+        ...(shouldRetry ? {} : { result }),
       } as RunEvent
       events.push(versionedEvent)
       await input.onEvent?.(versionedEvent)

--- a/packages/studio/components.json
+++ b/packages/studio/components.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "https://ui.shadcn.com/schema.json",
+  "style": "base-mira",
+  "rsc": false,
+  "tsx": true,
+  "tailwind": {
+    "config": "",
+    "css": "src/styles.css",
+    "baseColor": "neutral",
+    "cssVariables": true
+  },
+  "iconLibrary": "hugeicons",
+  "aliases": {
+    "components": "@/components",
+    "utils": "@/lib/utils",
+    "ui": "@/components/ui",
+    "lib": "@/lib"
+  }
+}

--- a/packages/studio/index.ts
+++ b/packages/studio/index.ts
@@ -4,6 +4,8 @@ export type {
   StudioRunGateway,
   StudioRunRequest,
   StudioRunSnapshot,
+  StudioScenario,
   StudioServer,
+  StudioSpecification,
 } from './src/server'
 export { startStudio } from './src/server'

--- a/packages/studio/index.ts
+++ b/packages/studio/index.ts
@@ -1,0 +1,9 @@
+export type {
+  StudioOptions,
+  StudioProject,
+  StudioRunGateway,
+  StudioRunRequest,
+  StudioRunSnapshot,
+  StudioServer,
+} from './src/server'
+export { startStudio } from './src/server'

--- a/packages/studio/package.json
+++ b/packages/studio/package.json
@@ -1,0 +1,35 @@
+{
+  "name": "@pickle-spec/studio",
+  "version": "1.0.2",
+  "type": "module",
+  "exports": {
+    ".": "./index.ts"
+  },
+  "files": [
+    "index.ts",
+    "src",
+    "!src/*.test.ts"
+  ],
+  "scripts": {
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@base-ui/react": "^1.0.0",
+    "@pickle-spec/runner": "workspace:*",
+    "@types/bun": "catalog:",
+    "@typescript/typescript6": "catalog:",
+    "bun-plugin-tailwind": "^0.1.2",
+    "class-variance-authority": "^0.7.1",
+    "clsx": "^2.1.1",
+    "react": "^19.1.1",
+    "react-dom": "^19.1.1",
+    "tailwind-merge": "^3.3.1",
+    "tailwindcss": "^4.1.12",
+    "tw-animate-css": "^1.3.8"
+  },
+  "devDependencies": {
+    "@types/react": "^19.1.12",
+    "@types/react-dom": "^19.1.9",
+    "typescript": "catalog:"
+  }
+}

--- a/packages/studio/package.json
+++ b/packages/studio/package.json
@@ -11,10 +11,13 @@
     "!src/*.test.ts"
   ],
   "scripts": {
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "test": "bun test"
   },
   "dependencies": {
     "@base-ui/react": "^1.0.0",
+    "@hugeicons/core-free-icons": "^4.2.3",
+    "@hugeicons/react": "^1.1.9",
     "@pickle-spec/runner": "workspace:*",
     "@types/bun": "catalog:",
     "@typescript/typescript6": "catalog:",

--- a/packages/studio/src/components/ui/badge.tsx
+++ b/packages/studio/src/components/ui/badge.tsx
@@ -1,0 +1,37 @@
+import { useRender } from '@base-ui/react/use-render'
+import { cva, type VariantProps } from 'class-variance-authority'
+import type { ComponentProps } from 'react'
+import { cn } from '../../lib/utils'
+
+const badgeVariants = cva(
+  'inline-flex items-center rounded-md border px-2 py-0.5 font-mono text-xs font-medium',
+  {
+    variants: {
+      variant: {
+        default: 'border-transparent bg-secondary text-secondary-foreground',
+        failed: 'border-transparent bg-destructive text-destructive-foreground',
+        adaptation:
+          'border-transparent bg-adaptation text-adaptation-foreground',
+        passed: 'border-transparent bg-primary/15 text-primary',
+        running: 'border-transparent bg-accent text-accent-foreground',
+      },
+    },
+    defaultVariants: {
+      variant: 'default',
+    },
+  },
+)
+
+type BadgeProps = ComponentProps<'span'> & VariantProps<typeof badgeVariants>
+
+function Badge({ className, variant, ...props }: BadgeProps) {
+  return useRender({
+    defaultTagName: 'span',
+    props: {
+      ...props,
+      className: cn(badgeVariants({ variant }), className),
+    },
+  })
+}
+
+export { Badge, badgeVariants }

--- a/packages/studio/src/components/ui/badge.tsx
+++ b/packages/studio/src/components/ui/badge.tsx
@@ -4,16 +4,15 @@ import type { ComponentProps } from 'react'
 import { cn } from '../../lib/utils'
 
 const badgeVariants = cva(
-  'inline-flex items-center rounded-md border px-2 py-0.5 font-mono text-xs font-medium',
+  'group/badge inline-flex h-5 w-fit shrink-0 items-center justify-center gap-1 overflow-hidden rounded-full border border-transparent px-2 py-0.5 font-mono text-[0.625rem] font-medium whitespace-nowrap outline-none transition-[background-color,border-color,color] duration-150 ease-[cubic-bezier(0.23,1,0.32,1)] focus-visible:border-current/35 aria-invalid:border-destructive motion-reduce:transition-none',
   {
     variants: {
       variant: {
-        default: 'border-transparent bg-secondary text-secondary-foreground',
-        failed: 'border-transparent bg-destructive text-destructive-foreground',
-        adaptation:
-          'border-transparent bg-adaptation text-adaptation-foreground',
-        passed: 'border-transparent bg-primary/15 text-primary',
-        running: 'border-transparent bg-accent text-accent-foreground',
+        default: 'bg-secondary text-secondary-foreground',
+        failed: 'bg-destructive/10 text-destructive dark:bg-destructive/20',
+        adaptation: 'bg-adaptation/10 text-adaptation dark:bg-adaptation/20',
+        passed: 'bg-passed/10 text-passed dark:bg-passed/20',
+        running: 'bg-accent text-accent-foreground',
       },
     },
     defaultVariants: {

--- a/packages/studio/src/components/ui/button.tsx
+++ b/packages/studio/src/components/ui/button.tsx
@@ -4,19 +4,32 @@ import type { ComponentProps } from 'react'
 import { cn } from '../../lib/utils'
 
 const buttonVariants = cva(
-  'inline-flex items-center justify-center gap-2 rounded-md text-sm font-medium whitespace-nowrap transition-colors outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50',
+  "group/button inline-flex shrink-0 items-center justify-center rounded-md border border-transparent bg-clip-padding text-xs/relaxed font-medium whitespace-nowrap outline-none select-none transition-[transform,background-color,border-color,color,opacity] duration-150 ease-[cubic-bezier(0.23,1,0.32,1)] hover:duration-150 active:not-aria-[haspopup]:scale-[0.98] active:duration-100 disabled:pointer-events-none disabled:opacity-50 focus-visible:border-current/35 aria-pressed:border-foreground/25 aria-invalid:border-destructive [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 motion-reduce:transition-none motion-reduce:active:scale-100",
   {
     variants: {
       variant: {
-        default: 'bg-primary text-primary-foreground hover:bg-primary/90',
+        default: 'bg-primary text-primary-foreground hover:bg-primary/80',
         outline:
-          'border border-border bg-card hover:bg-accent hover:text-accent-foreground',
+          'border-border hover:border-foreground/20 hover:bg-input/40 hover:text-foreground aria-expanded:bg-muted aria-expanded:text-foreground dark:bg-input/20',
+        secondary:
+          'bg-secondary text-secondary-foreground hover:bg-[color-mix(in_oklch,var(--secondary),var(--foreground)_5%)] aria-expanded:bg-secondary aria-expanded:text-secondary-foreground',
+        ghost:
+          'hover:bg-muted hover:text-foreground aria-expanded:bg-muted aria-expanded:text-foreground dark:hover:bg-muted/50',
         destructive:
-          'bg-destructive text-destructive-foreground hover:bg-destructive/90',
+          'border-destructive/20 bg-destructive/10 text-destructive hover:border-destructive/35 hover:bg-destructive/20 dark:bg-destructive/20 dark:hover:bg-destructive/30',
+        link: 'text-primary underline-offset-4 hover:underline',
+        adaptation:
+          'border-adaptation/20 bg-adaptation/10 text-adaptation hover:border-adaptation/35 hover:bg-adaptation/20 dark:bg-adaptation/20 dark:hover:bg-adaptation/30',
+        passed:
+          'border-passed/20 bg-passed/10 text-passed hover:border-passed/35 hover:bg-passed/20 dark:bg-passed/20 dark:hover:bg-passed/30',
       },
       size: {
-        default: 'h-9 px-3',
-        sm: 'h-8 px-2.5',
+        default:
+          "h-7 gap-1 px-2 text-xs/relaxed has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5 [&_svg:not([class*='size-'])]:size-3.5",
+        xs: "h-5 gap-1 rounded-sm px-2 text-[0.625rem] has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5 [&_svg:not([class*='size-'])]:size-2.5",
+        sm: "h-6 gap-1 px-2 text-xs/relaxed has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5 [&_svg:not([class*='size-'])]:size-3",
+        lg: "h-8 gap-1 px-2.5 text-xs/relaxed has-data-[icon=inline-end]:pr-2 has-data-[icon=inline-start]:pl-2 [&_svg:not([class*='size-'])]:size-4",
+        icon: "size-7 [&_svg:not([class*='size-'])]:size-3.5",
       },
     },
     defaultVariants: {
@@ -29,7 +42,12 @@ const buttonVariants = cva(
 type ButtonProps = ComponentProps<typeof ButtonPrimitive> &
   VariantProps<typeof buttonVariants>
 
-function Button({ className, variant, size, ...props }: ButtonProps) {
+function Button({
+  className,
+  variant = 'default',
+  size = 'default',
+  ...props
+}: ButtonProps) {
   return (
     <ButtonPrimitive
       data-slot="button"

--- a/packages/studio/src/components/ui/button.tsx
+++ b/packages/studio/src/components/ui/button.tsx
@@ -1,0 +1,42 @@
+import { Button as ButtonPrimitive } from '@base-ui/react/button'
+import { cva, type VariantProps } from 'class-variance-authority'
+import type { ComponentProps } from 'react'
+import { cn } from '../../lib/utils'
+
+const buttonVariants = cva(
+  'inline-flex items-center justify-center gap-2 rounded-md text-sm font-medium whitespace-nowrap transition-colors outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50',
+  {
+    variants: {
+      variant: {
+        default: 'bg-primary text-primary-foreground hover:bg-primary/90',
+        outline:
+          'border border-border bg-card hover:bg-accent hover:text-accent-foreground',
+        destructive:
+          'bg-destructive text-destructive-foreground hover:bg-destructive/90',
+      },
+      size: {
+        default: 'h-9 px-3',
+        sm: 'h-8 px-2.5',
+      },
+    },
+    defaultVariants: {
+      variant: 'default',
+      size: 'default',
+    },
+  },
+)
+
+type ButtonProps = ComponentProps<typeof ButtonPrimitive> &
+  VariantProps<typeof buttonVariants>
+
+function Button({ className, variant, size, ...props }: ButtonProps) {
+  return (
+    <ButtonPrimitive
+      data-slot="button"
+      className={cn(buttonVariants({ variant, size, className }))}
+      {...props}
+    />
+  )
+}
+
+export { Button, buttonVariants }

--- a/packages/studio/src/components/ui/loading-state.tsx
+++ b/packages/studio/src/components/ui/loading-state.tsx
@@ -1,0 +1,43 @@
+import { useEffect, useState } from 'react'
+import { cn } from '../../lib/utils'
+import { Spinner } from './spinner'
+
+type LoadingStateProps = {
+  label?: string
+  className?: string
+}
+
+function formatElapsed(deciseconds: number) {
+  const total = deciseconds / 10
+  if (total < 60) return `${total.toFixed(1)}s`
+  return `${Math.floor(total / 60)}m ${(total % 60).toFixed(1)}s`
+}
+
+function useElapsed() {
+  const [deciseconds, setDeciseconds] = useState(0)
+  useEffect(() => {
+    const timer = setInterval(() => setDeciseconds((value) => value + 1), 100)
+    return () => clearInterval(timer)
+  }, [])
+  return formatElapsed(deciseconds)
+}
+
+function LoadingState({ label = 'running', className }: LoadingStateProps) {
+  const elapsed = useElapsed()
+  return (
+    <div className={cn('flex w-fit items-center gap-2.5', className)}>
+      <span role="status" className="flex items-center gap-2.5">
+        <Spinner />
+        <span className="shimmer-label text-xs font-medium">{label}</span>
+      </span>
+      <span
+        aria-hidden="true"
+        className="font-mono text-[0.625rem] text-muted-foreground tabular-nums"
+      >
+        {elapsed}
+      </span>
+    </div>
+  )
+}
+
+export { LoadingState }

--- a/packages/studio/src/components/ui/result-mark.tsx
+++ b/packages/studio/src/components/ui/result-mark.tsx
@@ -1,0 +1,56 @@
+import { Cancel01Icon, Tick02Icon } from '@hugeicons/core-free-icons'
+import { HugeiconsIcon } from '@hugeicons/react'
+import { cn } from '../../lib/utils'
+import { Spinner } from './spinner'
+
+export type ResultMarkState =
+  | 'idle'
+  | 'running'
+  | 'passed'
+  | 'passed-with-adaptation'
+  | 'failed'
+  | 'skipped'
+  | 'cancelled'
+  | 'infrastructure-error'
+
+const settleClass =
+  'size-3.5 origin-center animate-in fade-in zoom-in-95 duration-200 ease-[cubic-bezier(0.23,1,0.32,1)] motion-reduce:animate-none'
+
+function ResultMark(props: { state: ResultMarkState; className?: string }) {
+  if (props.state === 'running') {
+    return <Spinner className={props.className} />
+  }
+  if (props.state === 'passed' || props.state === 'passed-with-adaptation') {
+    return (
+      <HugeiconsIcon
+        icon={Tick02Icon}
+        strokeWidth={2}
+        aria-hidden
+        className={cn(
+          settleClass,
+          props.state === 'passed-with-adaptation'
+            ? 'text-adaptation'
+            : 'text-passed',
+          props.className,
+        )}
+      />
+    )
+  }
+  if (
+    props.state === 'failed' ||
+    props.state === 'infrastructure-error' ||
+    props.state === 'cancelled'
+  ) {
+    return (
+      <HugeiconsIcon
+        icon={Cancel01Icon}
+        strokeWidth={2}
+        aria-hidden
+        className={cn(settleClass, 'text-destructive', props.className)}
+      />
+    )
+  }
+  return null
+}
+
+export { ResultMark }

--- a/packages/studio/src/components/ui/spinner.tsx
+++ b/packages/studio/src/components/ui/spinner.tsx
@@ -1,0 +1,36 @@
+import type { ComponentProps } from 'react'
+import { cn } from '../../lib/utils'
+
+const chevron = Array.from({ length: 9 }, (_, index) => {
+  const row = Math.floor(index / 3)
+  const column = index % 3
+  return (column + Math.abs(row - 1)) * 90
+})
+
+function Spinner({ className, ...props }: ComponentProps<'span'>) {
+  return (
+    <span
+      aria-hidden
+      data-slot="spinner"
+      className={cn('grid grid-cols-[repeat(3,4px)] gap-[1.5px]', className)}
+      {...props}
+    >
+      {chevron.map((delay, index) => {
+        const row = Math.floor(index / 3)
+        const column = index % 3
+        return (
+          <span
+            key={`${row}:${column}`}
+            className="size-1 rounded-px bg-current motion-reduce:animate-none"
+            style={{
+              opacity: 0.15,
+              animation: `pixel-on 650ms ease-in-out ${delay}ms infinite`,
+            }}
+          />
+        )
+      })}
+    </span>
+  )
+}
+
+export { Spinner }

--- a/packages/studio/src/css-modules.d.ts
+++ b/packages/studio/src/css-modules.d.ts
@@ -1,0 +1,1 @@
+declare module '*.css'

--- a/packages/studio/src/frontend.tsx
+++ b/packages/studio/src/frontend.tsx
@@ -2,29 +2,56 @@ import { StrictMode, useEffect, useMemo, useState } from 'react'
 import { createRoot } from 'react-dom/client'
 import { Badge } from './components/ui/badge'
 import { Button } from './components/ui/button'
+import { LoadingState } from './components/ui/loading-state'
+import { ResultMark } from './components/ui/result-mark'
+import { cn } from './lib/utils'
 import {
   attentionCells,
   type ClientEvent,
   cellKey,
   emptyRunView,
+  isSelectedCell,
   type MatrixCell,
+  pinCell,
   type RunView,
   reduceRun,
-  scenarioRows,
   statusLabel,
   type TestResultState,
 } from './run-view'
 import './styles.css'
+
+type StudioScenario = {
+  id: string
+  name: string
+}
+
+type StudioSpecification = {
+  id: string
+  name: string
+  uri: string
+  scenarios: StudioScenario[]
+}
 
 type StudioProject = {
   name: string
   root: string
   profiles: string[]
   suites: string[]
+  specifications: StudioSpecification[]
+}
+
+type StudioRunRequest = {
+  paths?: string[]
+  scenarioName?: string
 }
 
 const token = new URLSearchParams(location.search).get('token') ?? ''
-const areas = ['Specifications', 'Runs', 'Plans', 'Settings'] as const
+const areas = [
+  { name: 'Specifications', available: true },
+  { name: 'Runs', available: false },
+  { name: 'Plans', available: false },
+  { name: 'Settings', available: false },
+] as const
 
 async function api<T>(path: string, init?: RequestInit): Promise<T> {
   const response = await fetch(path, {
@@ -48,21 +75,60 @@ function badgeVariant(state: StatusBadgeState) {
   return 'default'
 }
 
+function statusText(state: StatusBadgeState) {
+  return state === 'idle' ? 'Ready' : state
+}
+
+function StatusBadge(props: { state: StatusBadgeState }) {
+  if (props.state === 'running') {
+    return <LoadingState label="running" />
+  }
+  return (
+    <Badge variant={badgeVariant(props.state)} role="status">
+      <ResultMark key={props.state} state={props.state} />
+      {statusText(props.state)}
+    </Badge>
+  )
+}
+
 function artifactUrl(path: string): string {
   return `/api/artifact?path=${encodeURIComponent(path)}&token=${encodeURIComponent(token)}`
+}
+
+function matrixCellVariant(state: MatrixCell['state']) {
+  if (state === 'failed' || state === 'infrastructure-error') {
+    return 'destructive'
+  }
+  if (state === 'passed-with-adaptation') return 'adaptation'
+  if (state === 'passed') return 'passed'
+  return 'outline'
+}
+
+function reasonMessage(reason: unknown) {
+  return reason instanceof Error ? reason.message : String(reason)
 }
 
 function StudioApp() {
   const [project, setProject] = useState<StudioProject>()
   const [error, setError] = useState<string>()
-  const [area, setArea] = useState<(typeof areas)[number]>('Runs')
   const [runId, setRunId] = useState<string>()
+  const [selectedId, setSelectedId] = useState<string>()
   const [view, setView] = useState<RunView>(emptyRunView)
+  const running = view.phase === 'running'
 
   useEffect(() => {
-    api<StudioProject>('/api/project').then(setProject, (reason: unknown) => {
-      setError(reason instanceof Error ? reason.message : String(reason))
-    })
+    let cancelled = false
+    api<StudioProject>('/api/project').then(
+      (value) => {
+        if (!cancelled) setProject(value)
+      },
+      (reason: unknown) => {
+        if (!cancelled) setError(reasonMessage(reason))
+      },
+    )
+    return () => {
+      cancelled = true
+    }
   }, [])
 
   useEffect(() => {
@@ -79,36 +145,72 @@ function StudioApp() {
   }, [runId])
 
   const attention = useMemo(() => attentionCells(view.cells), [view.cells])
-  const scenarios = useMemo(() => scenarioRows(view.cells), [view.cells])
   const aggregate = statusLabel(view)
+  const selected =
+    project?.specifications.find((item) => item.id === selectedId) ??
+    project?.specifications[0]
 
-  async function startRun() {
+  async function startRun(request: StudioRunRequest) {
+    if (running) return
     setError(undefined)
     setView({ ...emptyRunView(), phase: 'running' })
     try {
       const started = await api<{ id: string }>('/api/runs', {
         method: 'POST',
         headers: { 'content-type': 'application/json' },
-        body: JSON.stringify({}),
+        body: JSON.stringify(request),
       })
       setRunId(started.id)
     } catch (reason) {
       setView(emptyRunView())
-      setError(reason instanceof Error ? reason.message : String(reason))
+      setError(reasonMessage(reason))
+    }
+  }
+
+  async function cancelRun() {
+    if (!runId || !running) return
+    setError(undefined)
+    try {
+      const response = await fetch(
+        `/api/runs/${encodeURIComponent(runId)}/cancel`,
+        {
+          method: 'POST',
+          headers: { Authorization: `Bearer ${token}` },
+        },
+      )
+      if (!response.ok) throw new Error(await response.text())
+    } catch (reason) {
+      setError(reasonMessage(reason))
     }
   }
 
   if (error && !project) {
     return (
-      <main className="p-8">
-        <p role="alert">{error}</p>
+      <main className="flex min-h-screen items-start p-6">
+        <div className="max-w-lg space-y-3 rounded-md border border-border bg-card px-4 py-3">
+          <p role="alert" className="text-sm text-destructive">
+            {error}
+          </p>
+          <Button
+            type="button"
+            onClick={() => {
+              setError(undefined)
+              void api<StudioProject>('/api/project').then(
+                setProject,
+                (reason: unknown) => setError(reasonMessage(reason)),
+              )
+            }}
+          >
+            Try again
+          </Button>
+        </div>
       </main>
     )
   }
   if (!project) {
     return (
-      <main className="p-8">
-        <p>Opening project…</p>
+      <main className="flex min-h-screen items-start p-6">
+        <p className="text-sm text-muted-foreground">Opening project…</p>
       </main>
     )
   }
@@ -116,108 +218,212 @@ function StudioApp() {
   return (
     <div className="flex min-h-screen flex-col">
       <header className="flex items-center justify-between border-b border-border bg-card px-6 py-3">
-        <div>
-          <p className="font-mono text-xs tracking-[0.2em] text-muted-foreground uppercase">
-            Pickle Spec
-          </p>
-          <h1 className="text-xl font-semibold tracking-tight">
-            {project.name}
-          </h1>
-        </div>
-        {area === 'Runs' ? (
-          <Button type="button" onClick={() => void startRun()}>
-            Start test run
-          </Button>
-        ) : null}
+        <h1 className="text-xl font-semibold tracking-tight">{project.name}</h1>
+        <StatusBadge state={aggregate} />
       </header>
       <nav
         aria-label="Studio"
-        className="flex gap-1 border-b border-border px-4 py-2"
+        className="flex gap-px border-b border-border px-2 py-1"
       >
-        {areas.map((name) => (
+        {areas.map((area) => (
           <a
-            key={name}
-            href={`#${name.toLowerCase()}`}
-            className={`rounded-md px-3 py-1.5 text-sm ${
-              area === name
+            key={area.name}
+            href={`#${area.name.toLowerCase()}`}
+            aria-current={area.available ? 'page' : undefined}
+            aria-disabled={area.available ? undefined : true}
+            tabIndex={area.available ? undefined : -1}
+            className={cn(
+              'inline-flex h-7 items-center rounded-md px-2 text-xs/relaxed transition-colors duration-150 ease-[cubic-bezier(0.23,1,0.32,1)] motion-reduce:transition-none',
+              area.available
                 ? 'bg-accent text-accent-foreground'
-                : 'text-muted-foreground hover:bg-secondary'
-            }`}
-            onClick={() => setArea(name)}
+                : 'cursor-not-allowed text-muted-foreground opacity-60',
+            )}
+            onClick={(event) => {
+              if (!area.available) event.preventDefault()
+            }}
           >
-            {name}
+            {area.name}
           </a>
         ))}
       </nav>
-      <main className="grid flex-1 gap-6 p-6 lg:grid-cols-[20rem_1fr]">
-        {area === 'Runs' ? (
-          <>
-            <section className="space-y-4">
-              <div className="flex items-center gap-2">
-                <h2 className="text-lg font-medium">Test run</h2>
-                <Badge variant={badgeVariant(aggregate)} role="status">
-                  {aggregate}
-                </Badge>
+      <div className="grid min-h-0 flex-1 lg:grid-cols-[16rem_1fr]">
+        <SpecificationList
+          specifications={project.specifications}
+          selectedId={selected?.id}
+          running={running}
+          onSelect={setSelectedId}
+          onRunAll={() => void startRun({})}
+        />
+        <main className="min-w-0 space-y-6 p-6" aria-busy={running}>
+          {error ? (
+            <p role="alert" className="text-sm text-destructive">
+              {error}
+            </p>
+          ) : null}
+          {selected ? (
+            <>
+              <div className="flex flex-wrap items-start justify-between gap-3">
+                <div className="min-w-0 space-y-1">
+                  <h2 className="text-lg font-medium">{selected.name}</h2>
+                  <p className="truncate font-mono text-xs text-muted-foreground">
+                    {selected.uri}
+                  </p>
+                </div>
+                {running && runId ? (
+                  <Button
+                    type="button"
+                    variant="destructive"
+                    onClick={() => void cancelRun()}
+                  >
+                    Cancel test run
+                  </Button>
+                ) : (
+                  <Button
+                    type="button"
+                    disabled={running}
+                    onClick={() => void startRun({ paths: [selected.uri] })}
+                  >
+                    Run Specification
+                  </Button>
+                )}
               </div>
-              {error ? <p role="alert">{error}</p> : null}
-              {view.activity.length > 0 ? (
-                <ul className="space-y-1 text-sm">
-                  {view.activity.map((name) => (
-                    <li key={name}>{name}</li>
-                  ))}
-                </ul>
-              ) : (
-                <p className="text-sm text-muted-foreground">
-                  Start a test run to watch live progress, the target matrix,
-                  and step timelines.
-                </p>
-              )}
-              <div>
-                <h3 className="mb-2 text-sm font-medium">Needs attention</h3>
-                <ul aria-label="Needs attention" className="space-y-2">
-                  {attention.map((cell) => (
-                    <li key={cellKey(cell.scenarioId, cell.profileId)}>
-                      <button
-                        type="button"
-                        className="w-full rounded-md border border-border bg-card px-3 py-2 text-left text-sm"
-                        onClick={() =>
-                          setView((current) => ({ ...current, selected: cell }))
-                        }
-                      >
-                        {cell.scenarioName} {cell.state}
-                      </button>
-                    </li>
-                  ))}
-                </ul>
-              </div>
-            </section>
-            <section className="space-y-6">
-              <TargetMatrix
+              <ScenarioTable
                 profiles={project.profiles}
-                scenarios={scenarios}
+                scenarios={selected.scenarios}
                 cells={view.cells}
+                selected={view.selected}
+                running={running}
                 onSelect={(cell) =>
-                  setView((current) => ({ ...current, selected: cell }))
+                  setView((current) => pinCell(current, cell))
+                }
+                onRun={(scenarioName) =>
+                  void startRun({ paths: [selected.uri], scenarioName })
                 }
               />
-              <Timeline cell={view.selected} />
-            </section>
-          </>
-        ) : (
-          <p className="text-sm text-muted-foreground">
-            {area} will be available in a later Studio slice.
-          </p>
-        )}
-      </main>
+            </>
+          ) : (
+            <p className="text-sm text-muted-foreground">
+              No Specifications found. Add a feature file matching the project
+              configuration.
+            </p>
+          )}
+          {attention.length > 0 ? (
+            <div>
+              <h3 className="mb-2 text-sm font-medium">Needs attention</h3>
+              <ul
+                aria-label="Needs attention"
+                aria-live="polite"
+                className="space-y-2"
+              >
+                {attention.map((cell) => (
+                  <li key={cellKey(cell.scenarioId, cell.profileId)}>
+                    <button
+                      type="button"
+                      className={cn(
+                        'flex w-full min-w-0 flex-col gap-1 rounded-md border bg-card px-3 py-2 text-left text-sm outline-none transition-[transform,background-color,border-color] duration-150 ease-[cubic-bezier(0.23,1,0.32,1)] hover:bg-muted/30 active:scale-[0.99] focus-visible:border-foreground/30 motion-reduce:transition-none motion-reduce:active:scale-100',
+                        isSelectedCell(view.selected, cell)
+                          ? 'border-foreground/25'
+                          : 'border-border',
+                      )}
+                      onClick={() =>
+                        setView((current) => pinCell(current, cell))
+                      }
+                    >
+                      <span className="flex min-w-0 items-center gap-2">
+                        <span className="min-w-0 flex-1 truncate">
+                          {cell.scenarioName}
+                        </span>
+                        <Badge variant={badgeVariant(cell.state)}>
+                          <ResultMark key={cell.state} state={cell.state} />
+                          {cell.state}
+                        </Badge>
+                      </span>
+                      <span className="text-xs text-muted-foreground">
+                        {cell.profileId} · Open step timeline
+                      </span>
+                    </button>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          ) : null}
+          <Timeline cell={view.selected} />
+        </main>
+      </div>
     </div>
   )
 }
 
-function TargetMatrix(props: {
+function SpecificationList(props: {
+  specifications: StudioSpecification[]
+  selectedId?: string
+  running: boolean
+  onSelect: (id: string) => void
+  onRunAll: () => void
+}) {
+  return (
+    <nav
+      aria-label="Specifications"
+      className="flex min-h-0 flex-col border-b border-border lg:border-r lg:border-b-0"
+    >
+      <div className="flex h-8 shrink-0 items-center px-2">
+        <h2 className="text-xs text-muted-foreground">Specifications</h2>
+      </div>
+      {props.specifications.length === 0 ? (
+        <p className="px-2 pb-3 text-xs/relaxed text-muted-foreground">
+          None in this project.
+        </p>
+      ) : (
+        <ul className="flex min-h-0 flex-1 flex-col gap-px overflow-auto px-2 pb-2">
+          {props.specifications.map((specification) => {
+            const current = specification.id === props.selectedId
+            return (
+              <li key={specification.id}>
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="lg"
+                  aria-label={specification.name}
+                  aria-current={current ? 'true' : undefined}
+                  className={cn(
+                    'h-8 w-full min-w-0 justify-between p-2 text-left',
+                    current && 'bg-accent font-medium text-accent-foreground',
+                  )}
+                  onClick={() => props.onSelect(specification.id)}
+                >
+                  <span className="min-w-0 truncate">{specification.name}</span>
+                  <span aria-hidden="true" className="font-mono">
+                    {specification.scenarios.length}
+                  </span>
+                </Button>
+              </li>
+            )
+          })}
+        </ul>
+      )}
+      <div className="border-t border-border p-2">
+        <Button
+          type="button"
+          variant="outline"
+          className="w-full"
+          disabled={props.running || props.specifications.length === 0}
+          onClick={props.onRunAll}
+        >
+          Run all Specifications
+        </Button>
+      </div>
+    </nav>
+  )
+}
+
+function ScenarioTable(props: {
   profiles: string[]
-  scenarios: { id: string; name: string }[]
+  scenarios: StudioScenario[]
   cells: MatrixCell[]
+  selected?: MatrixCell
+  running: boolean
   onSelect: (cell: MatrixCell) => void
+  onRun: (scenarioName: string) => void
 }) {
   function cellFor(scenarioId: string, profileId: string) {
     return props.cells.find(
@@ -227,7 +433,7 @@ function TargetMatrix(props: {
 
   return (
     <div className="overflow-auto rounded-lg border border-border bg-card">
-      <table aria-label="Target matrix" className="w-full text-sm">
+      <table aria-label="Scenarios" className="w-full text-sm">
         <thead>
           <tr className="border-b border-border">
             <th scope="col" className="px-3 py-2 text-left font-medium">
@@ -242,42 +448,75 @@ function TargetMatrix(props: {
                 {profile}
               </th>
             ))}
+            <th scope="col" className="px-3 py-2 text-right font-medium">
+              <span className="sr-only">Run</span>
+            </th>
           </tr>
         </thead>
         <tbody>
-          {props.scenarios.map((scenario) => (
-            <tr
-              key={scenario.id}
-              className="border-b border-border last:border-0"
-            >
-              <th scope="row" className="px-3 py-2 text-left font-medium">
-                {scenario.name}
-              </th>
-              {props.profiles.map((profile) => {
-                const cell = cellFor(scenario.id, profile)
-                const label = `${scenario.name} ${profile} ${cell?.state ?? 'pending'}`
-                return (
-                  <td key={profile} className="px-3 py-2">
-                    {cell ? (
-                      <Button
-                        type="button"
-                        size="sm"
-                        variant={
-                          cell.state === 'failed' ? 'destructive' : 'outline'
-                        }
-                        aria-label={label}
-                        onClick={() => props.onSelect(cell)}
-                      >
-                        {cell.state}
-                      </Button>
-                    ) : (
-                      <span className="text-muted-foreground">pending</span>
-                    )}
-                  </td>
-                )
-              })}
+          {props.scenarios.length === 0 ? (
+            <tr>
+              <td
+                colSpan={2 + props.profiles.length}
+                className="px-3 py-6 text-muted-foreground"
+              >
+                This Specification has no Scenarios.
+              </td>
             </tr>
-          ))}
+          ) : (
+            props.scenarios.map((scenario) => (
+              <tr
+                key={scenario.id}
+                className="border-b border-border last:border-0"
+              >
+                <th
+                  scope="row"
+                  className="max-w-56 truncate px-3 py-2 text-left font-medium"
+                >
+                  {scenario.name}
+                </th>
+                {props.profiles.map((profile) => {
+                  const cell = cellFor(scenario.id, profile)
+                  const label = `${scenario.name} ${profile} ${cell?.state ?? 'pending'}`
+                  const selected = cell
+                    ? isSelectedCell(props.selected, cell)
+                    : false
+                  return (
+                    <td key={profile} className="px-3 py-2">
+                      {cell ? (
+                        <Button
+                          type="button"
+                          size="sm"
+                          variant={matrixCellVariant(cell.state)}
+                          aria-label={label}
+                          aria-pressed={selected}
+                          className="animate-in fade-in zoom-in-95 duration-150 motion-reduce:animate-none"
+                          onClick={() => props.onSelect(cell)}
+                        >
+                          <ResultMark key={cell.state} state={cell.state} />
+                          {cell.state}
+                        </Button>
+                      ) : (
+                        <span className="text-muted-foreground">pending</span>
+                      )}
+                    </td>
+                  )
+                })}
+                <td className="px-3 py-2 text-right">
+                  <Button
+                    type="button"
+                    size="sm"
+                    variant="outline"
+                    disabled={props.running}
+                    aria-label={`Run Scenario ${scenario.name}`}
+                    onClick={() => props.onRun(scenario.name)}
+                  >
+                    Run
+                  </Button>
+                </td>
+              </tr>
+            ))
+          )}
         </tbody>
       </table>
     </div>
@@ -296,7 +535,7 @@ function Timeline(props: { cell?: MatrixCell }) {
         {result.steps.map((step) => (
           <li
             key={`${step.step.text}:${step.resolvedActions.map((action) => action.description).join(',')}`}
-            className="rounded-md border border-border bg-card px-4 py-3"
+            className="rounded-md border border-border bg-card px-4 py-3 transition-[border-color] duration-150 ease-[cubic-bezier(0.23,1,0.32,1)] hover:border-foreground/15 motion-reduce:transition-none"
           >
             <p className="font-medium">
               {`${step.step.keyword.trim()} ${step.step.text}`}
@@ -313,7 +552,7 @@ function Timeline(props: { cell?: MatrixCell }) {
               artifact.mediaType?.startsWith('image/') ? (
                 <img
                   key={artifact.path}
-                  alt={artifact.kind}
+                  alt={`${artifact.kind} for ${result.scenario.name}`}
                   src={artifactUrl(artifact.path)}
                   className="mt-3 max-h-64 rounded-md border border-border"
                 />
@@ -321,7 +560,7 @@ function Timeline(props: { cell?: MatrixCell }) {
                 <a
                   key={artifact.path}
                   href={artifactUrl(artifact.path)}
-                  className="mt-2 inline-block text-sm text-primary"
+                  className="mt-2 inline-block text-sm text-primary underline-offset-4 hover:underline"
                 >
                   {artifact.kind}
                 </a>

--- a/packages/studio/src/frontend.tsx
+++ b/packages/studio/src/frontend.tsx
@@ -1,0 +1,343 @@
+import { StrictMode, useEffect, useMemo, useState } from 'react'
+import { createRoot } from 'react-dom/client'
+import { Badge } from './components/ui/badge'
+import { Button } from './components/ui/button'
+import {
+  attentionCells,
+  type ClientEvent,
+  cellKey,
+  emptyRunView,
+  type MatrixCell,
+  type RunView,
+  reduceRun,
+  scenarioRows,
+  statusLabel,
+  type TestResultState,
+} from './run-view'
+import './styles.css'
+
+type StudioProject = {
+  name: string
+  root: string
+  profiles: string[]
+  suites: string[]
+}
+
+const token = new URLSearchParams(location.search).get('token') ?? ''
+const areas = ['Specifications', 'Runs', 'Plans', 'Settings'] as const
+
+async function api<T>(path: string, init?: RequestInit): Promise<T> {
+  const response = await fetch(path, {
+    ...init,
+    headers: {
+      ...(init?.headers ?? {}),
+      Authorization: `Bearer ${token}`,
+    },
+  })
+  if (!response.ok) throw new Error(await response.text())
+  return response.json() as Promise<T>
+}
+
+type StatusBadgeState = TestResultState | 'idle' | 'running'
+
+function badgeVariant(state: StatusBadgeState) {
+  if (state === 'failed' || state === 'infrastructure-error') return 'failed'
+  if (state === 'passed-with-adaptation') return 'adaptation'
+  if (state === 'passed') return 'passed'
+  if (state === 'running') return 'running'
+  return 'default'
+}
+
+function artifactUrl(path: string): string {
+  return `/api/artifact?path=${encodeURIComponent(path)}&token=${encodeURIComponent(token)}`
+}
+
+function StudioApp() {
+  const [project, setProject] = useState<StudioProject>()
+  const [error, setError] = useState<string>()
+  const [area, setArea] = useState<(typeof areas)[number]>('Runs')
+  const [runId, setRunId] = useState<string>()
+  const [view, setView] = useState<RunView>(emptyRunView)
+
+  useEffect(() => {
+    api<StudioProject>('/api/project').then(setProject, (reason: unknown) => {
+      setError(reason instanceof Error ? reason.message : String(reason))
+    })
+  }, [])
+
+  useEffect(() => {
+    if (!runId) return
+    const protocol = location.protocol === 'https:' ? 'wss:' : 'ws:'
+    const socket = new WebSocket(
+      `${protocol}//${location.host}/api/runs/${runId}/events?token=${encodeURIComponent(token)}`,
+    )
+    socket.onmessage = (message) => {
+      const event = JSON.parse(String(message.data)) as ClientEvent
+      setView((current) => reduceRun(current, event))
+    }
+    return () => socket.close()
+  }, [runId])
+
+  const attention = useMemo(() => attentionCells(view.cells), [view.cells])
+  const scenarios = useMemo(() => scenarioRows(view.cells), [view.cells])
+  const aggregate = statusLabel(view)
+
+  async function startRun() {
+    setError(undefined)
+    setView({ ...emptyRunView(), phase: 'running' })
+    try {
+      const started = await api<{ id: string }>('/api/runs', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({}),
+      })
+      setRunId(started.id)
+    } catch (reason) {
+      setView(emptyRunView())
+      setError(reason instanceof Error ? reason.message : String(reason))
+    }
+  }
+
+  if (error && !project) {
+    return (
+      <main className="p-8">
+        <p role="alert">{error}</p>
+      </main>
+    )
+  }
+  if (!project) {
+    return (
+      <main className="p-8">
+        <p>Opening project…</p>
+      </main>
+    )
+  }
+
+  return (
+    <div className="flex min-h-screen flex-col">
+      <header className="flex items-center justify-between border-b border-border bg-card px-6 py-3">
+        <div>
+          <p className="font-mono text-xs tracking-[0.2em] text-muted-foreground uppercase">
+            Pickle Spec
+          </p>
+          <h1 className="text-xl font-semibold tracking-tight">
+            {project.name}
+          </h1>
+        </div>
+        {area === 'Runs' ? (
+          <Button type="button" onClick={() => void startRun()}>
+            Start test run
+          </Button>
+        ) : null}
+      </header>
+      <nav
+        aria-label="Studio"
+        className="flex gap-1 border-b border-border px-4 py-2"
+      >
+        {areas.map((name) => (
+          <a
+            key={name}
+            href={`#${name.toLowerCase()}`}
+            className={`rounded-md px-3 py-1.5 text-sm ${
+              area === name
+                ? 'bg-accent text-accent-foreground'
+                : 'text-muted-foreground hover:bg-secondary'
+            }`}
+            onClick={() => setArea(name)}
+          >
+            {name}
+          </a>
+        ))}
+      </nav>
+      <main className="grid flex-1 gap-6 p-6 lg:grid-cols-[20rem_1fr]">
+        {area === 'Runs' ? (
+          <>
+            <section className="space-y-4">
+              <div className="flex items-center gap-2">
+                <h2 className="text-lg font-medium">Test run</h2>
+                <Badge variant={badgeVariant(aggregate)} role="status">
+                  {aggregate}
+                </Badge>
+              </div>
+              {error ? <p role="alert">{error}</p> : null}
+              {view.activity.length > 0 ? (
+                <ul className="space-y-1 text-sm">
+                  {view.activity.map((name) => (
+                    <li key={name}>{name}</li>
+                  ))}
+                </ul>
+              ) : (
+                <p className="text-sm text-muted-foreground">
+                  Start a test run to watch live progress, the target matrix,
+                  and step timelines.
+                </p>
+              )}
+              <div>
+                <h3 className="mb-2 text-sm font-medium">Needs attention</h3>
+                <ul aria-label="Needs attention" className="space-y-2">
+                  {attention.map((cell) => (
+                    <li key={cellKey(cell.scenarioId, cell.profileId)}>
+                      <button
+                        type="button"
+                        className="w-full rounded-md border border-border bg-card px-3 py-2 text-left text-sm"
+                        onClick={() =>
+                          setView((current) => ({ ...current, selected: cell }))
+                        }
+                      >
+                        {cell.scenarioName} {cell.state}
+                      </button>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            </section>
+            <section className="space-y-6">
+              <TargetMatrix
+                profiles={project.profiles}
+                scenarios={scenarios}
+                cells={view.cells}
+                onSelect={(cell) =>
+                  setView((current) => ({ ...current, selected: cell }))
+                }
+              />
+              <Timeline cell={view.selected} />
+            </section>
+          </>
+        ) : (
+          <p className="text-sm text-muted-foreground">
+            {area} will be available in a later Studio slice.
+          </p>
+        )}
+      </main>
+    </div>
+  )
+}
+
+function TargetMatrix(props: {
+  profiles: string[]
+  scenarios: { id: string; name: string }[]
+  cells: MatrixCell[]
+  onSelect: (cell: MatrixCell) => void
+}) {
+  function cellFor(scenarioId: string, profileId: string) {
+    return props.cells.find(
+      (cell) => cell.scenarioId === scenarioId && cell.profileId === profileId,
+    )
+  }
+
+  return (
+    <div className="overflow-auto rounded-lg border border-border bg-card">
+      <table aria-label="Target matrix" className="w-full text-sm">
+        <thead>
+          <tr className="border-b border-border">
+            <th scope="col" className="px-3 py-2 text-left font-medium">
+              Scenario
+            </th>
+            {props.profiles.map((profile) => (
+              <th
+                key={profile}
+                scope="col"
+                className="px-3 py-2 text-left font-medium"
+              >
+                {profile}
+              </th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {props.scenarios.map((scenario) => (
+            <tr
+              key={scenario.id}
+              className="border-b border-border last:border-0"
+            >
+              <th scope="row" className="px-3 py-2 text-left font-medium">
+                {scenario.name}
+              </th>
+              {props.profiles.map((profile) => {
+                const cell = cellFor(scenario.id, profile)
+                const label = `${scenario.name} ${profile} ${cell?.state ?? 'pending'}`
+                return (
+                  <td key={profile} className="px-3 py-2">
+                    {cell ? (
+                      <Button
+                        type="button"
+                        size="sm"
+                        variant={
+                          cell.state === 'failed' ? 'destructive' : 'outline'
+                        }
+                        aria-label={label}
+                        onClick={() => props.onSelect(cell)}
+                      >
+                        {cell.state}
+                      </Button>
+                    ) : (
+                      <span className="text-muted-foreground">pending</span>
+                    )}
+                  </td>
+                )
+              })}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  )
+}
+
+function Timeline(props: { cell?: MatrixCell }) {
+  const result = props.cell?.result
+  if (!result) return null
+  return (
+    <section className="space-y-3">
+      <h3 className="text-sm font-medium">
+        {result.scenario.name} · {result.executionTargetProfile.id}
+      </h3>
+      <ol aria-label="Step timeline" className="space-y-3">
+        {result.steps.map((step) => (
+          <li
+            key={`${step.step.text}:${step.resolvedActions.map((action) => action.description).join(',')}`}
+            className="rounded-md border border-border bg-card px-4 py-3"
+          >
+            <p className="font-medium">
+              {`${step.step.keyword.trim()} ${step.step.text}`}
+            </p>
+            <ul className="mt-2 space-y-1 font-mono text-xs">
+              {step.resolvedActions.map((action) => (
+                <li key={action.description}>{action.description}</li>
+              ))}
+            </ul>
+            {step.message ? (
+              <p className="mt-2 text-sm text-destructive">{step.message}</p>
+            ) : null}
+            {step.artifacts?.map((artifact) =>
+              artifact.mediaType?.startsWith('image/') ? (
+                <img
+                  key={artifact.path}
+                  alt={artifact.kind}
+                  src={artifactUrl(artifact.path)}
+                  className="mt-3 max-h-64 rounded-md border border-border"
+                />
+              ) : (
+                <a
+                  key={artifact.path}
+                  href={artifactUrl(artifact.path)}
+                  className="mt-2 inline-block text-sm text-primary"
+                >
+                  {artifact.kind}
+                </a>
+              ),
+            )}
+          </li>
+        ))}
+      </ol>
+    </section>
+  )
+}
+
+const root = document.getElementById('root')
+if (!root) throw new Error('Studio root element is missing')
+createRoot(root).render(
+  <StrictMode>
+    <StudioApp />
+  </StrictMode>,
+)

--- a/packages/studio/src/index.html
+++ b/packages/studio/src/index.html
@@ -3,7 +3,14 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="color-scheme" content="dark" />
     <title>Pickle Spec Studio</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:ital,wght@0,400;0,500;0,600&family=JetBrains+Mono:ital,wght@0,400;0,500&display=swap"
+      rel="stylesheet"
+    />
     <link rel="stylesheet" href="./styles.css" />
   </head>
   <body>

--- a/packages/studio/src/index.html
+++ b/packages/studio/src/index.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Pickle Spec Studio</title>
+    <link rel="stylesheet" href="./styles.css" />
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="./frontend.tsx"></script>
+  </body>
+</html>

--- a/packages/studio/src/lib/utils.ts
+++ b/packages/studio/src/lib/utils.ts
@@ -1,0 +1,6 @@
+import { type ClassValue, clsx } from 'clsx'
+import { twMerge } from 'tailwind-merge'
+
+export function cn(...inputs: ClassValue[]) {
+  return twMerge(clsx(inputs))
+}

--- a/packages/studio/src/run-view.test.ts
+++ b/packages/studio/src/run-view.test.ts
@@ -1,0 +1,68 @@
+import { expect, test } from 'bun:test'
+import {
+  type ClientEvent,
+  emptyRunView,
+  pinCell,
+  reduceRun,
+  statusLabel,
+  type TestResult,
+} from './run-view'
+
+function started(name: string, id: string, profileId = 'chrome'): ClientEvent {
+  return {
+    type: 'scenario-started',
+    scenario: { name, id },
+    executionTargetProfile: { id: profileId },
+  }
+}
+
+function finished(
+  name: string,
+  id: string,
+  state: TestResult['state'],
+  profileId = 'chrome',
+): ClientEvent {
+  return {
+    type: 'scenario-finished',
+    result: {
+      scenario: { name, id },
+      executionTargetProfile: { id: profileId },
+      state,
+      steps: [],
+    },
+  }
+}
+
+test('follows the first running cell until a failure needs attention', () => {
+  let view = reduceRun(emptyRunView(), started('Complete a purchase', 'pass'))
+  view = reduceRun(view, started('Pay for the order', 'pay'))
+  expect(view.selected?.scenarioName).toBe('Complete a purchase')
+  view = reduceRun(view, finished('Pay for the order', 'pay', 'failed'))
+  expect(view.selected?.scenarioName).toBe('Pay for the order')
+  expect(view.selected?.state).toBe('failed')
+})
+
+test('keeps a pinned cell when a later failure arrives', () => {
+  let view = reduceRun(emptyRunView(), started('Complete a purchase', 'pass'))
+  view = pinCell(view, view.selected!)
+  view = reduceRun(view, started('Pay for the order', 'pay'))
+  view = reduceRun(view, finished('Pay for the order', 'pay', 'failed'))
+  expect(view.selected?.scenarioName).toBe('Complete a purchase')
+  expect(view.pinned).toBe(true)
+})
+
+test('prefers a failed cell over an Adaptation when unpinned', () => {
+  let view = reduceRun(emptyRunView(), started('Adapt the purchase', 'adapt'))
+  view = reduceRun(
+    view,
+    finished('Adapt the purchase', 'adapt', 'passed-with-adaptation'),
+  )
+  expect(view.selected?.state).toBe('passed-with-adaptation')
+  view = reduceRun(view, started('Pay for the order', 'pay'))
+  view = reduceRun(view, finished('Pay for the order', 'pay', 'failed'))
+  expect(view.selected?.scenarioName).toBe('Pay for the order')
+})
+
+test('status stays idle until a run starts', () => {
+  expect(statusLabel(emptyRunView())).toBe('idle')
+})

--- a/packages/studio/src/run-view.ts
+++ b/packages/studio/src/run-view.ts
@@ -1,0 +1,288 @@
+export type TestResultState =
+  | 'passed'
+  | 'passed-with-adaptation'
+  | 'failed'
+  | 'skipped'
+  | 'cancelled'
+  | 'infrastructure-error'
+
+export type ScenarioRef = { name: string; id?: string }
+export type ResolvedAction = { description: string }
+export type TestArtifact = { kind: string; path: string; mediaType?: string }
+export type StepResult = {
+  step: { keyword: string; text: string }
+  state: TestResultState
+  resolvedActions: ResolvedAction[]
+  message?: string
+  artifacts?: TestArtifact[]
+}
+export type TestResult = {
+  scenario: ScenarioRef
+  executionTargetProfile: { id: string }
+  state: TestResultState
+  steps: StepResult[]
+  message?: string
+}
+
+export type ClientEvent =
+  | { type: 'run-started'; run: { id: string } }
+  | {
+      type: 'scenario-started'
+      scenario: ScenarioRef
+      executionTargetProfile?: { id: string }
+    }
+  | {
+      type: 'step-started'
+      step: { keyword?: string; text: string }
+      scenario?: ScenarioRef
+      executionTargetProfile?: { id: string }
+    }
+  | {
+      type: 'step-finished'
+      result: StepResult
+      scenario?: ScenarioRef
+      executionTargetProfile?: { id: string }
+    }
+  | { type: 'scenario-finished'; result: TestResult }
+  | { type: 'run-finished'; run: { id: string } }
+
+export type MatrixCell = {
+  scenarioId: string
+  scenarioName: string
+  profileId: string
+  state: TestResultState | 'running'
+  result?: TestResult
+}
+
+export type RunView = {
+  phase: 'idle' | 'running' | 'finished'
+  activity: string[]
+  cells: MatrixCell[]
+  selected?: MatrixCell
+}
+
+export function emptyRunView(): RunView {
+  return { phase: 'idle', activity: [], cells: [] }
+}
+
+export function cellKey(scenarioId: string, profileId: string) {
+  return `${scenarioId}:${profileId}`
+}
+
+export function needsAttention(state: TestResultState | 'running'): boolean {
+  return (
+    state === 'failed' ||
+    state === 'infrastructure-error' ||
+    state === 'passed-with-adaptation'
+  )
+}
+
+export function resultPriority(state: TestResultState | 'running'): number {
+  if (state === 'failed' || state === 'infrastructure-error') return 0
+  if (state === 'passed-with-adaptation') return 1
+  if (state === 'cancelled') return 2
+  if (state === 'running') return 3
+  if (state === 'skipped') return 5
+  return 4
+}
+
+export function attentionCells(cells: MatrixCell[]): MatrixCell[] {
+  return [...cells]
+    .filter((cell) => needsAttention(cell.state))
+    .sort(
+      (left, right) =>
+        resultPriority(left.state) - resultPriority(right.state) ||
+        left.scenarioName.localeCompare(right.scenarioName),
+    )
+}
+
+export function scenarioRows(
+  cells: MatrixCell[],
+): { id: string; name: string }[] {
+  const seen = new Set<string>()
+  const rows = []
+  for (const cell of cells) {
+    if (seen.has(cell.scenarioId)) continue
+    seen.add(cell.scenarioId)
+    rows.push({ id: cell.scenarioId, name: cell.scenarioName })
+  }
+  return rows
+}
+
+export function statusLabel(
+  view: RunView,
+): TestResultState | 'idle' | 'running' {
+  if (view.phase === 'idle') return 'idle'
+  if (view.phase === 'running') return 'running'
+  const terminal = view.cells.filter((cell) => cell.state !== 'running')
+  if (terminal.length === 0) return 'idle'
+  const worst = [...terminal].sort(
+    (left, right) => resultPriority(left.state) - resultPriority(right.state),
+  )[0]
+  return worst?.state ?? 'idle'
+}
+
+export function reduceRun(view: RunView, event: ClientEvent): RunView {
+  if (event.type === 'run-finished') return { ...view, phase: 'finished' }
+  if (event.type === 'scenario-started')
+    return applyScenarioStarted(view, event)
+  if (event.type === 'step-started') return applyStepStarted(view, event)
+  if (event.type === 'step-finished') return applyStepFinished(view, event)
+  if (event.type === 'scenario-finished') {
+    return applyScenarioFinished(view, event)
+  }
+  return view
+}
+
+function scenarioIdOf(scenario: ScenarioRef) {
+  return scenario.id ?? scenario.name
+}
+
+function rememberActivity(activity: string[], name: string) {
+  return activity.includes(name) ? activity : [...activity, name]
+}
+
+function replaceCell(cells: MatrixCell[], cell: MatrixCell): MatrixCell[] {
+  const key = cellKey(cell.scenarioId, cell.profileId)
+  return [
+    ...cells.filter((item) => cellKey(item.scenarioId, item.profileId) !== key),
+    cell,
+  ]
+}
+
+function findCell(
+  cells: MatrixCell[],
+  scenario: ScenarioRef | undefined,
+  profileId: string | undefined,
+): MatrixCell | undefined {
+  if (!scenario || !profileId) return undefined
+  const scenarioId = scenarioIdOf(scenario)
+  return cells.find(
+    (cell) => cell.scenarioId === scenarioId && cell.profileId === profileId,
+  )
+}
+
+function selectCell(view: RunView, cell: MatrixCell): MatrixCell {
+  if (!view.selected) return cell
+  if (
+    view.selected.scenarioId === cell.scenarioId &&
+    view.selected.profileId === cell.profileId
+  ) {
+    return cell
+  }
+  return view.selected
+}
+
+function applyScenarioStarted(
+  view: RunView,
+  event: Extract<ClientEvent, { type: 'scenario-started' }>,
+): RunView {
+  const activity = rememberActivity(view.activity, event.scenario.name)
+  const profileId = event.executionTargetProfile?.id
+  if (!profileId) return { ...view, activity }
+  const existing = findCell(view.cells, event.scenario, profileId)
+  if (existing?.state === 'running') return { ...view, activity }
+  const cell: MatrixCell = {
+    scenarioId: scenarioIdOf(event.scenario),
+    scenarioName: event.scenario.name,
+    profileId,
+    state: 'running',
+    result: {
+      scenario: event.scenario,
+      executionTargetProfile: { id: profileId },
+      state: 'passed',
+      steps: existing?.result?.steps ?? [],
+    },
+  }
+  const cells = replaceCell(view.cells, cell)
+  return {
+    ...view,
+    activity,
+    cells,
+    selected: selectCell({ ...view, cells }, cell),
+  }
+}
+
+function applyStepStarted(
+  view: RunView,
+  event: Extract<ClientEvent, { type: 'step-started' }>,
+): RunView {
+  const cell = findCell(
+    view.cells,
+    event.scenario,
+    event.executionTargetProfile?.id,
+  )
+  if (!cell?.result) return view
+  const last = cell.result.steps.at(-1)
+  if (
+    last &&
+    last.step.text === event.step.text &&
+    last.resolvedActions.length === 0 &&
+    !last.message
+  ) {
+    return view
+  }
+  const next: MatrixCell = {
+    ...cell,
+    result: {
+      ...cell.result,
+      steps: [
+        ...cell.result.steps,
+        {
+          step: { keyword: event.step.keyword ?? '', text: event.step.text },
+          state: 'passed',
+          resolvedActions: [],
+        },
+      ],
+    },
+  }
+  const cells = replaceCell(view.cells, next)
+  return { ...view, cells, selected: selectCell(view, next) }
+}
+
+function applyStepFinished(
+  view: RunView,
+  event: Extract<ClientEvent, { type: 'step-finished' }>,
+): RunView {
+  const cell = findCell(
+    view.cells,
+    event.scenario,
+    event.executionTargetProfile?.id,
+  )
+  if (!cell?.result) return view
+  const steps = [...cell.result.steps]
+  const index = steps.findIndex(
+    (step) =>
+      step.step.text === event.result.step.text &&
+      step.resolvedActions.length === 0 &&
+      !step.message,
+  )
+  if (index === -1) steps.push(event.result)
+  else steps[index] = event.result
+  const next: MatrixCell = {
+    ...cell,
+    result: { ...cell.result, steps },
+  }
+  const cells = replaceCell(view.cells, next)
+  return { ...view, cells, selected: selectCell(view, next) }
+}
+
+function applyScenarioFinished(
+  view: RunView,
+  event: Extract<ClientEvent, { type: 'scenario-finished' }>,
+): RunView {
+  const cell: MatrixCell = {
+    scenarioId: scenarioIdOf(event.result.scenario),
+    scenarioName: event.result.scenario.name,
+    profileId: event.result.executionTargetProfile.id,
+    state: event.result.state,
+    result: event.result,
+  }
+  const cells = replaceCell(view.cells, cell)
+  return {
+    ...view,
+    activity: rememberActivity(view.activity, event.result.scenario.name),
+    cells,
+    selected: selectCell({ ...view, cells }, cell),
+  }
+}

--- a/packages/studio/src/run-view.ts
+++ b/packages/studio/src/run-view.ts
@@ -59,10 +59,11 @@ export type RunView = {
   activity: string[]
   cells: MatrixCell[]
   selected?: MatrixCell
+  pinned: boolean
 }
 
 export function emptyRunView(): RunView {
-  return { phase: 'idle', activity: [], cells: [] }
+  return { phase: 'idle', activity: [], cells: [], pinned: false }
 }
 
 export function cellKey(scenarioId: string, profileId: string) {
@@ -122,6 +123,26 @@ export function statusLabel(
   return worst?.state ?? 'idle'
 }
 
+export function pinCell(view: RunView, cell: MatrixCell): RunView {
+  const current =
+    view.cells.find(
+      (item) =>
+        item.scenarioId === cell.scenarioId &&
+        item.profileId === cell.profileId,
+    ) ?? cell
+  return { ...view, selected: current, pinned: true }
+}
+
+export function isSelectedCell(
+  selected: MatrixCell | undefined,
+  cell: MatrixCell,
+) {
+  return (
+    selected?.scenarioId === cell.scenarioId &&
+    selected?.profileId === cell.profileId
+  )
+}
+
 export function reduceRun(view: RunView, event: ClientEvent): RunView {
   if (event.type === 'run-finished') return { ...view, phase: 'finished' }
   if (event.type === 'scenario-started')
@@ -132,6 +153,41 @@ export function reduceRun(view: RunView, event: ClientEvent): RunView {
     return applyScenarioFinished(view, event)
   }
   return view
+}
+
+function followSelection(
+  view: RunView,
+  cells: MatrixCell[],
+): MatrixCell | undefined {
+  if (view.pinned && view.selected) {
+    return (
+      cells.find(
+        (cell) =>
+          cell.scenarioId === view.selected?.scenarioId &&
+          cell.profileId === view.selected?.profileId,
+      ) ?? view.selected
+    )
+  }
+  const [worst] = attentionCells(cells)
+  if (worst) return worst
+  if (view.selected) {
+    const current = cells.find(
+      (cell) =>
+        cell.scenarioId === view.selected?.scenarioId &&
+        cell.profileId === view.selected?.profileId,
+    )
+    if (current) return current
+  }
+  return cells.find((cell) => cell.state === 'running') ?? view.selected
+}
+
+function withCells(
+  view: RunView,
+  cells: MatrixCell[],
+  extras: Partial<RunView> = {},
+): RunView {
+  const next = { ...view, cells, ...extras }
+  return { ...next, selected: followSelection(next, cells) }
 }
 
 function scenarioIdOf(scenario: ScenarioRef) {
@@ -162,17 +218,6 @@ function findCell(
   )
 }
 
-function selectCell(view: RunView, cell: MatrixCell): MatrixCell {
-  if (!view.selected) return cell
-  if (
-    view.selected.scenarioId === cell.scenarioId &&
-    view.selected.profileId === cell.profileId
-  ) {
-    return cell
-  }
-  return view.selected
-}
-
 function applyScenarioStarted(
   view: RunView,
   event: Extract<ClientEvent, { type: 'scenario-started' }>,
@@ -194,13 +239,7 @@ function applyScenarioStarted(
       steps: existing?.result?.steps ?? [],
     },
   }
-  const cells = replaceCell(view.cells, cell)
-  return {
-    ...view,
-    activity,
-    cells,
-    selected: selectCell({ ...view, cells }, cell),
-  }
+  return withCells(view, replaceCell(view.cells, cell), { activity })
 }
 
 function applyStepStarted(
@@ -236,8 +275,7 @@ function applyStepStarted(
       ],
     },
   }
-  const cells = replaceCell(view.cells, next)
-  return { ...view, cells, selected: selectCell(view, next) }
+  return withCells(view, replaceCell(view.cells, next))
 }
 
 function applyStepFinished(
@@ -263,8 +301,7 @@ function applyStepFinished(
     ...cell,
     result: { ...cell.result, steps },
   }
-  const cells = replaceCell(view.cells, next)
-  return { ...view, cells, selected: selectCell(view, next) }
+  return withCells(view, replaceCell(view.cells, next))
 }
 
 function applyScenarioFinished(
@@ -278,11 +315,7 @@ function applyScenarioFinished(
     state: event.result.state,
     result: event.result,
   }
-  const cells = replaceCell(view.cells, cell)
-  return {
-    ...view,
+  return withCells(view, replaceCell(view.cells, cell), {
     activity: rememberActivity(view.activity, event.result.scenario.name),
-    cells,
-    selected: selectCell({ ...view, cells }, cell),
-  }
+  })
 }

--- a/packages/studio/src/server.ts
+++ b/packages/studio/src/server.ts
@@ -1,0 +1,267 @@
+import { mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { basename, join, resolve } from 'node:path'
+import type { RunEvent, TestRunManifest } from '@pickle-spec/runner'
+import tailwind from 'bun-plugin-tailwind'
+
+export interface StudioProject {
+  name: string
+  root: string
+  profiles: readonly string[]
+  suites: readonly string[]
+}
+
+export interface StudioRunRequest {
+  suite?: string
+  profiles?: readonly string[]
+}
+
+export interface StudioRunSnapshot {
+  id: string
+  events: RunEvent[]
+  manifest?: TestRunManifest
+}
+
+export interface StudioRunGateway {
+  start(
+    request: StudioRunRequest | undefined,
+    onEvent: (event: RunEvent) => void,
+  ): Promise<{ id: string; done?: Promise<unknown> }>
+  snapshot(id: string): Promise<StudioRunSnapshot>
+}
+
+export interface StudioOptions {
+  project: StudioProject
+  gateway?: StudioRunGateway
+  hostname?: string
+  port?: number
+  token?: string
+  open?: boolean
+}
+
+export interface StudioServer {
+  url: string
+  token: string
+  stop(): void
+}
+
+type HtmlAsset = {
+  index: string
+  files: Map<string, Blob>
+  outdir: string
+}
+
+type StudioStreamEvent =
+  | RunEvent
+  | { type: 'run-finished'; run: { id: string } }
+
+const sessionCookie = 'pickle_studio_token'
+const loopbackHosts = new Set(['127.0.0.1', 'localhost', '::1'])
+
+const htmlEntry = join(import.meta.dir, 'index.html')
+
+async function buildUi(): Promise<HtmlAsset> {
+  const outdir = await mkdtemp(join(tmpdir(), 'pickle-studio-ui-'))
+  const result = await Bun.build({
+    entrypoints: [htmlEntry],
+    outdir,
+    target: 'browser',
+    plugins: [tailwind],
+  })
+  if (!result.success) {
+    await rm(outdir, { recursive: true, force: true })
+    throw new Error('Studio UI failed to build')
+  }
+  const files = new Map<string, Blob>()
+  for (const output of result.outputs) {
+    const name = basename(output.path)
+    files.set(name, output)
+    files.set(`/${name}`, output)
+  }
+  const index = files.get('index.html')
+  if (!index) {
+    await rm(outdir, { recursive: true, force: true })
+    throw new Error('Studio UI build did not produce index.html')
+  }
+  return { index: await index.text(), files, outdir }
+}
+
+function requestToken(request: Request): string | undefined {
+  const authorization = request.headers.get('authorization')
+  if (authorization?.startsWith('Bearer ')) return authorization.slice(7)
+  const query = new URL(request.url).searchParams.get('token')
+  if (query) return query
+  const cookie = request.headers.get('cookie')
+  if (!cookie) return undefined
+  for (const part of cookie.split(';')) {
+    const [name, ...rest] = part.trim().split('=')
+    if (name === sessionCookie) return decodeURIComponent(rest.join('='))
+  }
+}
+
+function openBrowser(url: string): void {
+  if (process.platform === 'darwin') {
+    Bun.spawn(['open', url], { stdout: 'ignore', stderr: 'ignore' })
+    return
+  }
+  if (process.platform === 'win32') {
+    Bun.spawn(['cmd', '/c', 'start', '', url], {
+      stdout: 'ignore',
+      stderr: 'ignore',
+    })
+    return
+  }
+  Bun.spawn(['xdg-open', url], { stdout: 'ignore', stderr: 'ignore' })
+}
+
+export async function startStudio(
+  options: StudioOptions,
+): Promise<StudioServer> {
+  const hostname = options.hostname ?? '127.0.0.1'
+  if (!loopbackHosts.has(hostname)) {
+    console.warn(
+      `Studio is bound to ${hostname}. Remote access exposes the session token.`,
+    )
+  }
+  const token = options.token ?? crypto.randomUUID()
+  const ui = await buildUi()
+  const listeners = new Map<string, Set<(event: StudioStreamEvent) => void>>()
+  const buffers = new Map<string, StudioStreamEvent[]>()
+
+  function publish(id: string, event: StudioStreamEvent): void {
+    if (!id) return
+    const events = buffers.get(id) ?? []
+    events.push(event)
+    buffers.set(id, events)
+    for (const listener of listeners.get(id) ?? []) listener(event)
+  }
+
+  function authorized(request: Request, origin: string): boolean {
+    if (requestToken(request) !== token) return false
+    const header = request.headers.get('origin')
+    return !header || header === origin
+  }
+
+  const server = Bun.serve<{
+    runId: string
+    listener?: (event: StudioStreamEvent) => void
+  }>({
+    hostname,
+    port: options.port ?? 0,
+    websocket: {
+      open(ws) {
+        const runId = ws.data.runId
+        for (const event of buffers.get(runId) ?? []) {
+          ws.send(JSON.stringify(event))
+        }
+        const listener = (event: StudioStreamEvent) => {
+          ws.send(JSON.stringify(event))
+        }
+        const set = listeners.get(runId) ?? new Set()
+        set.add(listener)
+        listeners.set(runId, set)
+        ws.data = { runId, listener }
+      },
+      message() {},
+      close(ws) {
+        if (!ws.data.listener) return
+        listeners.get(ws.data.runId)?.delete(ws.data.listener)
+      },
+    },
+    async fetch(request, server) {
+      const url = new URL(request.url)
+      const origin = `http://${hostname}:${server.port}`
+      if (url.pathname === '/' || url.pathname === '/index.html') {
+        if (!authorized(request, origin)) {
+          return new Response('Unauthorized', { status: 401 })
+        }
+        return new Response(ui.index, {
+          headers: {
+            'content-type': 'text/html; charset=utf-8',
+            'set-cookie': `${sessionCookie}=${encodeURIComponent(token)}; Path=/; HttpOnly; SameSite=Strict`,
+          },
+        })
+      }
+      const asset =
+        ui.files.get(url.pathname) ?? ui.files.get(basename(url.pathname))
+      if (asset && request.method === 'GET') {
+        if (!authorized(request, origin)) {
+          return new Response('Unauthorized', { status: 401 })
+        }
+        return new Response(asset)
+      }
+      if (!authorized(request, origin)) {
+        return new Response('Unauthorized', { status: 401 })
+      }
+      if (url.pathname === '/api/project' && request.method === 'GET') {
+        return Response.json(options.project)
+      }
+      if (url.pathname === '/api/runs' && request.method === 'POST') {
+        if (!options.gateway) {
+          return new Response('Test runs are unavailable', { status: 501 })
+        }
+        const body = (await request
+          .json()
+          .catch(() => ({}))) as StudioRunRequest
+        let runId = ''
+        try {
+          const started = await options.gateway.start(body, (event) => {
+            if (event.type === 'run-started') runId = event.run.id
+            publish(runId, event)
+          })
+          runId = started.id
+          void started.done?.then(
+            () => publish(runId, { type: 'run-finished', run: { id: runId } }),
+            () => publish(runId, { type: 'run-finished', run: { id: runId } }),
+          )
+          return Response.json({ id: started.id })
+        } catch (error) {
+          const message = error instanceof Error ? error.message : String(error)
+          return new Response(message, { status: 500 })
+        }
+      }
+      if (url.pathname === '/api/artifact' && request.method === 'GET') {
+        const filePath = url.searchParams.get('path')
+        if (!filePath) return new Response('Missing path', { status: 400 })
+        const resolved = resolve(filePath)
+        const allowed = resolve(options.project.root, '.pickle', 'runs')
+        if (resolved !== allowed && !resolved.startsWith(`${allowed}/`)) {
+          return new Response('Forbidden', { status: 403 })
+        }
+        const file = Bun.file(resolved)
+        if (!(await file.exists()))
+          return new Response('Not found', { status: 404 })
+        return new Response(file)
+      }
+      const eventsMatch = url.pathname.match(/^\/api\/runs\/([^/]+)\/events$/)
+      if (eventsMatch && request.method === 'GET') {
+        const runId = decodeURIComponent(eventsMatch[1]!)
+        const upgraded = server.upgrade(request, { data: { runId } })
+        if (upgraded) return
+        return new Response('WebSocket upgrade failed', { status: 400 })
+      }
+      const runMatch = url.pathname.match(/^\/api\/runs\/([^/]+)$/)
+      if (runMatch && request.method === 'GET') {
+        if (!options.gateway) {
+          return new Response('Test runs are unavailable', { status: 501 })
+        }
+        return Response.json(
+          await options.gateway.snapshot(decodeURIComponent(runMatch[1]!)),
+        )
+      }
+      return new Response('Not found', { status: 404 })
+    },
+  })
+
+  const url = `http://${hostname}:${server.port}/?token=${token}`
+  if (options.open) openBrowser(url)
+
+  return {
+    url,
+    token,
+    stop() {
+      server.stop(true)
+      void rm(ui.outdir, { recursive: true, force: true })
+    },
+  }
+}

--- a/packages/studio/src/server.ts
+++ b/packages/studio/src/server.ts
@@ -4,16 +4,31 @@ import { basename, join, resolve } from 'node:path'
 import type { RunEvent, TestRunManifest } from '@pickle-spec/runner'
 import tailwind from 'bun-plugin-tailwind'
 
+export interface StudioScenario {
+  id: string
+  name: string
+}
+
+export interface StudioSpecification {
+  id: string
+  name: string
+  uri: string
+  scenarios: readonly StudioScenario[]
+}
+
 export interface StudioProject {
   name: string
   root: string
   profiles: readonly string[]
   suites: readonly string[]
+  specifications: readonly StudioSpecification[]
 }
 
 export interface StudioRunRequest {
   suite?: string
   profiles?: readonly string[]
+  paths?: readonly string[]
+  scenarioName?: string
 }
 
 export interface StudioRunSnapshot {
@@ -28,6 +43,7 @@ export interface StudioRunGateway {
     onEvent: (event: RunEvent) => void,
   ): Promise<{ id: string; done?: Promise<unknown> }>
   snapshot(id: string): Promise<StudioRunSnapshot>
+  cancel(id: string): Promise<void>
 }
 
 export interface StudioOptions {
@@ -232,6 +248,14 @@ export async function startStudio(
         if (!(await file.exists()))
           return new Response('Not found', { status: 404 })
         return new Response(file)
+      }
+      const cancelMatch = url.pathname.match(/^\/api\/runs\/([^/]+)\/cancel$/)
+      if (cancelMatch && request.method === 'POST') {
+        if (!options.gateway) {
+          return new Response('Test runs are unavailable', { status: 501 })
+        }
+        await options.gateway.cancel(decodeURIComponent(cancelMatch[1]!))
+        return new Response(null, { status: 204 })
       }
       const eventsMatch = url.pathname.match(/^\/api\/runs\/([^/]+)\/events$/)
       if (eventsMatch && request.method === 'GET') {

--- a/packages/studio/src/styles.css
+++ b/packages/studio/src/styles.css
@@ -1,0 +1,68 @@
+@import "tailwindcss";
+@import "tw-animate-css";
+
+@custom-variant dark (&:is(.dark *));
+
+@theme inline {
+  --font-sans: "IBM Plex Sans", ui-sans-serif, system-ui, sans-serif;
+  --font-mono: "IBM Plex Mono", ui-monospace, monospace;
+  --color-background: var(--background);
+  --color-foreground: var(--foreground);
+  --color-card: var(--card);
+  --color-card-foreground: var(--card-foreground);
+  --color-popover: var(--popover);
+  --color-popover-foreground: var(--popover-foreground);
+  --color-primary: var(--primary);
+  --color-primary-foreground: var(--primary-foreground);
+  --color-secondary: var(--secondary);
+  --color-secondary-foreground: var(--secondary-foreground);
+  --color-muted: var(--muted);
+  --color-muted-foreground: var(--muted-foreground);
+  --color-accent: var(--accent);
+  --color-accent-foreground: var(--accent-foreground);
+  --color-destructive: var(--destructive);
+  --color-destructive-foreground: var(--destructive-foreground);
+  --color-border: var(--border);
+  --color-input: var(--input);
+  --color-ring: var(--ring);
+  --color-adaptation: var(--adaptation);
+  --color-adaptation-foreground: var(--adaptation-foreground);
+  --radius-sm: calc(var(--radius) * 0.6);
+  --radius-md: calc(var(--radius) * 0.8);
+  --radius-lg: var(--radius);
+  --radius-xl: calc(var(--radius) * 1.4);
+}
+
+:root {
+  --radius: 0.5rem;
+  --background: oklch(0.965 0.008 240);
+  --foreground: oklch(0.23 0.03 250);
+  --card: oklch(0.99 0.004 240);
+  --card-foreground: oklch(0.23 0.03 250);
+  --popover: oklch(0.99 0.004 240);
+  --popover-foreground: oklch(0.23 0.03 250);
+  --primary: oklch(0.44 0.07 185);
+  --primary-foreground: oklch(0.98 0.01 185);
+  --secondary: oklch(0.93 0.01 240);
+  --secondary-foreground: oklch(0.28 0.03 250);
+  --muted: oklch(0.93 0.01 240);
+  --muted-foreground: oklch(0.5 0.02 250);
+  --accent: oklch(0.93 0.015 185);
+  --accent-foreground: oklch(0.28 0.04 185);
+  --destructive: oklch(0.55 0.14 40);
+  --destructive-foreground: oklch(0.98 0.01 40);
+  --border: oklch(0.88 0.01 240);
+  --input: oklch(0.88 0.01 240);
+  --ring: oklch(0.44 0.07 185);
+  --adaptation: oklch(0.72 0.1 85);
+  --adaptation-foreground: oklch(0.28 0.06 85);
+}
+
+@layer base {
+  * {
+    @apply border-border;
+  }
+  body {
+    @apply bg-background text-foreground font-sans antialiased;
+  }
+}

--- a/packages/studio/src/styles.css
+++ b/packages/studio/src/styles.css
@@ -4,8 +4,8 @@
 @custom-variant dark (&:is(.dark *));
 
 @theme inline {
-  --font-sans: "IBM Plex Sans", ui-sans-serif, system-ui, sans-serif;
-  --font-mono: "IBM Plex Mono", ui-monospace, monospace;
+  --font-sans: Inter, ui-sans-serif, system-ui, sans-serif;
+  --font-mono: "JetBrains Mono", ui-monospace, monospace;
   --color-background: var(--background);
   --color-foreground: var(--foreground);
   --color-card: var(--card);
@@ -27,6 +27,8 @@
   --color-ring: var(--ring);
   --color-adaptation: var(--adaptation);
   --color-adaptation-foreground: var(--adaptation-foreground);
+  --color-passed: var(--passed);
+  --color-passed-foreground: var(--passed-foreground);
   --radius-sm: calc(var(--radius) * 0.6);
   --radius-md: calc(var(--radius) * 0.8);
   --radius-lg: var(--radius);
@@ -34,35 +36,96 @@
 }
 
 :root {
+  color-scheme: dark;
   --radius: 0.5rem;
-  --background: oklch(0.965 0.008 240);
-  --foreground: oklch(0.23 0.03 250);
-  --card: oklch(0.99 0.004 240);
-  --card-foreground: oklch(0.23 0.03 250);
-  --popover: oklch(0.99 0.004 240);
-  --popover-foreground: oklch(0.23 0.03 250);
-  --primary: oklch(0.44 0.07 185);
-  --primary-foreground: oklch(0.98 0.01 185);
-  --secondary: oklch(0.93 0.01 240);
-  --secondary-foreground: oklch(0.28 0.03 250);
-  --muted: oklch(0.93 0.01 240);
-  --muted-foreground: oklch(0.5 0.02 250);
-  --accent: oklch(0.93 0.015 185);
-  --accent-foreground: oklch(0.28 0.04 185);
-  --destructive: oklch(0.55 0.14 40);
-  --destructive-foreground: oklch(0.98 0.01 40);
-  --border: oklch(0.88 0.01 240);
-  --input: oklch(0.88 0.01 240);
-  --ring: oklch(0.44 0.07 185);
-  --adaptation: oklch(0.72 0.1 85);
-  --adaptation-foreground: oklch(0.28 0.06 85);
+  --ease-out: cubic-bezier(0.23, 1, 0.32, 1);
+  --background: oklch(0.145 0.012 250);
+  --foreground: oklch(0.93 0.01 250);
+  --card: oklch(0.18 0.012 250);
+  --card-foreground: oklch(0.93 0.01 250);
+  --popover: oklch(0.18 0.012 250);
+  --popover-foreground: oklch(0.93 0.01 250);
+  --primary: oklch(0.93 0.01 250);
+  --primary-foreground: oklch(0.145 0.012 250);
+  --secondary: oklch(0.22 0.012 250);
+  --secondary-foreground: oklch(0.88 0.01 250);
+  --muted: oklch(0.22 0.01 250);
+  --muted-foreground: oklch(0.72 0.015 250);
+  --accent: oklch(0.24 0.025 185);
+  --accent-foreground: oklch(0.93 0.02 185);
+  --destructive: oklch(0.7 0.14 32);
+  --destructive-foreground: oklch(0.16 0.03 32);
+  --border: oklch(0.72 0.008 250 / 0.16);
+  --input: oklch(0.72 0.008 250 / 0.16);
+  --ring: oklch(0.72 0.008 250 / 0.28);
+  --adaptation: oklch(0.8 0.11 85);
+  --adaptation-foreground: oklch(0.22 0.05 85);
+  --passed: oklch(0.74 0.08 185);
+  --passed-foreground: oklch(0.16 0.03 185);
 }
 
 @layer base {
   * {
     @apply border-border;
+    scrollbar-color: oklch(0.72 0.008 250 / 0.22) transparent;
   }
   body {
     @apply bg-background text-foreground font-sans antialiased;
+  }
+  ::selection {
+    background: oklch(0.74 0.08 185 / 0.35);
+    color: oklch(0.93 0.01 250);
+  }
+  :focus-visible {
+    outline: 1px solid oklch(0.72 0.008 250 / 0.4);
+    outline-offset: 2px;
+  }
+}
+
+@keyframes pixel-on {
+  0%,
+  100% {
+    opacity: 0.15;
+  }
+  18%,
+  42% {
+    opacity: 1;
+  }
+  62% {
+    opacity: 0.15;
+  }
+}
+
+@keyframes shimmer-text {
+  0% {
+    background-position: 150% center;
+  }
+  100% {
+    background-position: -50% center;
+  }
+}
+
+.shimmer-label {
+  background-image: linear-gradient(
+    90deg,
+    var(--muted-foreground) 35%,
+    var(--foreground) 50%,
+    var(--muted-foreground) 65%
+  );
+  background-size: 200% 100%;
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
+  animation: shimmer-text 1.4s linear infinite;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  [data-slot="spinner"] > span {
+    animation: none;
+  }
+  .shimmer-label {
+    animation: none;
+    background-image: none;
+    color: var(--foreground);
   }
 }

--- a/packages/studio/tsconfig.json
+++ b/packages/studio/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "lib": ["ESNext", "DOM"],
+    "jsx": "react-jsx"
+  },
+  "include": ["src", "index.ts"]
+}

--- a/turbo.json
+++ b/turbo.json
@@ -8,6 +8,10 @@
     "run:example": {
       "cache": false,
       "persistent": false
+    },
+    "studio": {
+      "cache": false,
+      "persistent": false
     }
   }
 }


### PR DESCRIPTION
## Summary
- Adds `pickle studio`, a local loopback app that starts a web test run through the public runner and streams live events into a target matrix and step timeline.
- Surfaces failures and adaptations before passing results, with a running pixel-grid loading state and check/fail marks when a Scenario finishes.
- Uses shadcn Mira on Base UI with hairline borders, no button rings, and press/hover micro-interactions.

Closes #21

## Test plan
- [x] `pickle studio` starts a local application and opens the configured project
- [x] Studio can start a web test run through the public runner interface
- [x] Live run events update progress without polling completed result files
- [x] The run view presents failures and adaptations before passing results
- [ ] A target matrix keeps each Scenario and target-profile result distinct
- [ ] Step and resolved-action timelines connect intent, operations, errors, and test artifacts
- [ ] Running state shows the pixel-grid loading state; finished cells show a check or fail mark
- [ ] Buttons have no focus rings; selected cells use a stronger hairline
- [ ] The browser seam verifies the complete workflow against a temporary workspace


Made with [Cursor](https://cursor.com)