### PR TITLE
Manage Git, suites, and targets in Studio (#23)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,4 @@ report.[0-9]_.[0-9]_.[0-9]_.[0-9]_.json
 # Finder (MacOS) folder config
 .DS_Store
 .collaborator
+.impeccable/questions

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env bun
 
-import { basename, resolve } from 'node:path'
+import { resolve } from 'node:path'
 import {
   compareTestRuns,
   formatHtml,
@@ -11,17 +11,9 @@ import {
   openTestRunStore,
   writeRunArchive,
 } from '@pickle-spec/runner'
-import type {
-  SelectionOptions,
-  Specification,
-  SpecificationState,
-} from '@pickle-spec/spec'
-import type {
-  StudioAuthoringModel,
-  StudioRunRequest,
-  StudioSpecification,
-} from '@pickle-spec/studio'
-import { startStudio } from '@pickle-spec/studio'
+import type { SelectionOptions, SpecificationState } from '@pickle-spec/spec'
+import type { StudioAuthoringModel } from '@pickle-spec/studio'
+import { createCredentialStore, startStudio } from '@pickle-spec/studio'
 import {
   defaultModelName,
   screenshotModes,
@@ -35,6 +27,14 @@ import {
   startProjectRun,
 } from './execute-run'
 import { checkProject, initializeProject, migrateProject } from './project'
+import {
+  loadStudioProject,
+  patchStudioConfig,
+  resolveConfigSecrets,
+  saveStudioCredential,
+  studioRunReadiness,
+  studioRunSelection,
+} from './studio-project'
 
 interface RunArguments {
   pattern?: string
@@ -353,30 +353,6 @@ async function exportRun(argv: string[]): Promise<number> {
   return 0
 }
 
-function studioCatalog(
-  specifications: readonly Specification[],
-): StudioSpecification[] {
-  return specifications.map((specification) => ({
-    id: specification.id ?? specification.source.uri,
-    name: specification.name,
-    uri: specification.source.uri,
-    scenarios: specification.scenarios.map((scenario) => ({
-      id: scenario.id ?? scenario.name,
-      name: scenario.name,
-    })),
-  }))
-}
-
-function studioRunSelection(
-  request: StudioRunRequest | undefined,
-): SelectionOptions | undefined {
-  if (!request?.paths?.length && !request?.scenarioName) return undefined
-  return {
-    ...(request.paths?.length ? { paths: [...request.paths] } : {}),
-    ...(request.scenarioName ? { scenarioName: request.scenarioName } : {}),
-  }
-}
-
 function parseStudioArguments(argv: string[]): {
   configPath?: string
   extensionsPath?: string
@@ -416,27 +392,17 @@ function authoringModel(modelName: string | undefined): StudioAuthoringModel {
 async function studio(argv: string[]): Promise<number> {
   const args = parseStudioArguments(argv)
   const root = process.cwd()
-  const config = await loadConfig(args.configPath)
-  const profiles = config.executionTargetProfiles
-    ? Object.keys(config.executionTargetProfiles)
-    : [config.executionTargetProfile?.id ?? (config.web ? 'web' : 'custom')]
+  const credentials = createCredentialStore()
+  const context = {
+    root,
+    configPath: args.configPath,
+    credentials,
+  }
+  const config = await loadConfig(args.configPath, root)
   const specificationGlobs = config.specifications ?? defaultSpecificationGlob
   const model = authoringModel(config.web?.browser?.modelName)
   async function loadProject() {
-    return {
-      name: basename(root),
-      root,
-      profiles,
-      suites: Object.keys(config.suites ?? {}),
-      specifications: studioCatalog(
-        await loadProjectSpecifications(
-          specificationGlobs,
-          config.language,
-          root,
-        ),
-      ),
-      model,
-    }
+    return loadStudioProject(context)
   }
   const extensions = await loadExtensions(args.extensionsPath, root)
   const controller = new AbortController()
@@ -450,6 +416,19 @@ async function studio(argv: string[]): Promise<number> {
       model,
       propose: extensions.authorSpecification,
     },
+    management: {
+      saveConfig: (patch) => patchStudioConfig(context, patch),
+      saveCredential: (input) => saveStudioCredential(context, input),
+      async readiness(request) {
+        const current = await loadConfig(args.configPath, root)
+        const specifications = await loadProjectSpecifications(
+          current.specifications ?? defaultSpecificationGlob,
+          current.language,
+          root,
+        )
+        return studioRunReadiness(context, request, current, specifications)
+      },
+    },
     gateway: {
       async start(request, onEvent) {
         const runController = new AbortController()
@@ -457,9 +436,10 @@ async function studio(argv: string[]): Promise<number> {
         controller.signal.addEventListener('abort', onProcessAbort, {
           once: true,
         })
+        const current = await loadConfig(args.configPath, root)
         const started = await startProjectRun({
           root,
-          config,
+          config: await resolveConfigSecrets(current, credentials),
           options: {
             extensionsPath: args.extensionsPath,
             suite: request?.suite,

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -49,6 +49,10 @@ export interface ProjectArtifacts {
   capture?: ArtifactCapturePolicy
 }
 
+export interface ProjectSecretRef {
+  keychain: string
+}
+
 export interface PickleConfig {
   schemaVersion: 1
   language?: string
@@ -65,6 +69,8 @@ export interface PickleConfig {
   server?: ServerConfig
   retention?: ProjectRetention
   artifacts?: ProjectArtifacts
+  links?: Record<string, string>
+  secrets?: Record<string, ProjectSecretRef>
 }
 
 function toExecutionTargetProfile(
@@ -301,6 +307,28 @@ const pickleConfigSchema = strictObject('configuration', {
       })
       .optional(),
   }).optional(),
+  links: z
+    .record(
+      nonemptyKey('links'),
+      z
+        .string({ error: 'links templates must be a string' })
+        .refine((value) => value.includes('{id}'), {
+          error: 'links templates must include {id}',
+        }),
+    )
+    .optional(),
+  secrets: z
+    .record(
+      nonemptyKey('secrets'),
+      strictObject('secrets', {
+        keychain: z
+          .string({ error: 'secrets.keychain must not be empty' })
+          .refine((value) => value.trim().length > 0, {
+            error: 'secrets.keychain must not be empty',
+          }),
+      }),
+    )
+    .optional(),
 }).transform((config) => config as PickleConfig)
 
 function validateConfig(value: unknown): PickleConfig {
@@ -378,4 +406,20 @@ export async function loadConfig(
       `Invalid configuration ${selectedPath}: ${reason}. Correct the value and run pickle check again.`,
     )
   }
+}
+
+export async function saveConfig(
+  config: PickleConfig,
+  configPath = defaultConfigFile,
+  root = process.cwd(),
+): Promise<void> {
+  const selectedPath = configPath
+  if (!selectedPath.endsWith('.jsonc') && !selectedPath.endsWith('.json')) {
+    throw new Error('Configuration must use pickle.config.jsonc')
+  }
+  validateConfig(config)
+  await Bun.write(
+    resolve(root, selectedPath),
+    `${JSON.stringify(config, null, 2)}\n`,
+  )
 }

--- a/packages/cli/src/studio-project.ts
+++ b/packages/cli/src/studio-project.ts
@@ -1,0 +1,336 @@
+import { basename } from 'node:path'
+import type { ExecutionTargetAdapter } from '@pickle-spec/runner'
+import { validateTargetSelection } from '@pickle-spec/runner'
+import {
+  authorTags,
+  parseExternalLinks,
+  type SelectionOptions,
+  type Specification,
+  selectScenarios,
+} from '@pickle-spec/spec'
+import type {
+  CredentialStore,
+  StudioConfigPatch,
+  StudioCredential,
+  StudioProfile,
+  StudioProject,
+  StudioRunReadiness,
+  StudioRunRequest,
+  StudioSpecification,
+  StudioSuite,
+} from '@pickle-spec/studio'
+import {
+  defaultSpecificationGlob,
+  loadConfig,
+  type PickleConfig,
+  type ProjectExecutionTargetProfile,
+  runConfigurationFrom,
+  saveConfig,
+} from './config'
+import { loadProjectSpecifications } from './execute-run'
+
+export interface StudioProjectContext {
+  root: string
+  configPath?: string
+  credentials: CredentialStore
+}
+
+export function studioRunSelection(
+  request: StudioRunRequest | undefined,
+): SelectionOptions | undefined {
+  if (!request?.paths?.length && !request?.scenarioName) return undefined
+  return {
+    ...(request.paths?.length ? { paths: [...request.paths] } : {}),
+    ...(request.scenarioName ? { scenarioName: request.scenarioName } : {}),
+  }
+}
+
+async function studioCatalog(
+  context: StudioProjectContext,
+  config: PickleConfig,
+  specifications: readonly Specification[],
+  namespaces: readonly string[],
+): Promise<StudioSpecification[]> {
+  return Promise.all(
+    specifications.map(async (specification) => {
+      const specReady = await studioRunReadiness(
+        context,
+        { paths: [specification.source.uri] },
+        config,
+        specifications,
+      )
+      const scenarios = await Promise.all(
+        specification.scenarios.map(async (scenario) => {
+          const scenarioReady = await studioRunReadiness(
+            context,
+            {
+              paths: [specification.source.uri],
+              scenarioName: scenario.name,
+            },
+            config,
+            specifications,
+          )
+          return {
+            id: scenario.id ?? scenario.name,
+            name: scenario.name,
+            canRun: scenarioReady.ready,
+          }
+        }),
+      )
+      return {
+        id: specification.id ?? specification.source.uri,
+        name: specification.name,
+        uri: specification.source.uri,
+        ...(specification.state ? { state: specification.state } : {}),
+        tags: authorTags(specification.tags, namespaces),
+        links: parseExternalLinks(specification.tags, namespaces),
+        canRun: specReady.ready,
+        runReasons: specReady.reasons,
+        scenarios,
+      }
+    }),
+  )
+}
+
+function profileDetails(config: PickleConfig): StudioProfile[] {
+  if (config.executionTargetProfiles) {
+    return Object.entries(config.executionTargetProfiles).map(
+      ([id, profile]) => ({
+        id,
+        adapter: profile.adapter,
+        ...(profile.capabilities
+          ? { capabilities: [...profile.capabilities] }
+          : {}),
+      }),
+    )
+  }
+  const profile = config.executionTargetProfile
+  return [
+    {
+      id: profile?.id ?? (config.web ? 'web' : 'custom'),
+      adapter: profile?.adapter ?? (config.web ? 'web' : 'custom'),
+      ...(profile?.capabilities
+        ? { capabilities: [...profile.capabilities] }
+        : {}),
+    },
+  ]
+}
+
+function suiteDetails(config: PickleConfig): StudioSuite[] {
+  return Object.entries(config.suites ?? {}).map(([name, query]) => ({
+    name,
+    ...(query.paths ? { paths: query.paths } : {}),
+    ...(query.tagExpression ? { tagExpression: query.tagExpression } : {}),
+    ...(query.states ? { states: [...query.states] } : {}),
+    ...(query.scenarioName ? { scenarioName: query.scenarioName } : {}),
+  }))
+}
+
+function stubAdapter(capabilities?: readonly string[]): ExecutionTargetAdapter {
+  return {
+    ...(capabilities ? { capabilities: [...capabilities] } : {}),
+    async openSession() {
+      throw new Error('Studio run validation does not open sessions')
+    },
+  }
+}
+
+export async function studioRunReadiness(
+  context: StudioProjectContext,
+  request: StudioRunRequest | undefined,
+  config: PickleConfig,
+  specifications: readonly Specification[],
+): Promise<StudioRunReadiness> {
+  const reasons: string[] = []
+  try {
+    const suiteSelection = request?.suite
+      ? config.suites?.[request.suite]
+      : undefined
+    if (request?.suite && !suiteSelection) {
+      reasons.push(`Unknown test suite "${request.suite}"`)
+    }
+    const selection = {
+      ...suiteSelection,
+      ...studioRunSelection(request),
+    }
+    const selections = selectScenarios(specifications, selection)
+    if (selections.length === 0) {
+      reasons.push('No Scenarios match the current selection')
+    }
+    const runConfiguration = runConfigurationFrom(config, request?.profiles)
+    const profiles =
+      runConfiguration.executionTargetProfiles ??
+      (runConfiguration.executionTargetProfile
+        ? [runConfiguration.executionTargetProfile]
+        : [])
+    if (profiles.length === 0) {
+      reasons.push(
+        'A test run must select at least one execution target profile',
+      )
+    }
+    const targets = profiles.map((profile) => ({
+      executionTargetProfile: profile,
+      adapter: stubAdapter(profile.capabilities),
+    }))
+    validateTargetSelection(selections, targets)
+    const usesWeb = profileDetails(config).some(
+      (profile) => profile.adapter === 'web',
+    )
+    if (usesWeb) {
+      const secretNames = Object.keys(config.secrets ?? {})
+      let present = Boolean(
+        config.web?.browser?.modelApiKey ||
+          process.env.OPENAI_API_KEY ||
+          process.env.ANTHROPIC_API_KEY ||
+          process.env.GOOGLE_API_KEY ||
+          process.env.GEMINI_API_KEY ||
+          process.env.GOOGLE_GENERATIVE_AI_API_KEY,
+      )
+      if (!present) {
+        for (const [name, ref] of Object.entries(config.secrets ?? {})) {
+          if (
+            process.env[name] ||
+            (await context.credentials.has(ref.keychain))
+          ) {
+            present = true
+            break
+          }
+        }
+      }
+      if (!present && secretNames.length === 0) {
+        reasons.push(
+          'Store a model credential in the system keychain before a web test run',
+        )
+      } else if (!present) {
+        reasons.push('The referenced model credential is not available')
+      }
+    }
+  } catch (error) {
+    reasons.push(error instanceof Error ? error.message : String(error))
+  }
+  return { ready: reasons.length === 0, reasons }
+}
+
+export async function loadStudioProject(
+  context: StudioProjectContext,
+): Promise<StudioProject> {
+  const config = await loadConfig(context.configPath, context.root)
+  const namespaces = Object.keys(config.links ?? {})
+  const specifications = await loadProjectSpecifications(
+    config.specifications ?? defaultSpecificationGlob,
+    config.language,
+    context.root,
+  )
+  const profiles = profileDetails(config)
+  const secrets: StudioCredential[] = []
+  for (const [name, ref] of Object.entries(config.secrets ?? {})) {
+    secrets.push({
+      name,
+      present:
+        Boolean(process.env[name]) ||
+        (await context.credentials.has(ref.keychain)),
+    })
+  }
+  return {
+    name: basename(context.root),
+    root: context.root,
+    profiles: profiles.map((profile) => profile.id),
+    suites: suiteDetails(config).map((suite) => suite.name),
+    specifications: await studioCatalog(
+      context,
+      config,
+      specifications,
+      namespaces,
+    ),
+    links: config.links ?? {},
+    suiteDetails: suiteDetails(config),
+    profileDetails: profiles,
+    secrets,
+    readiness: await studioRunReadiness(
+      context,
+      undefined,
+      config,
+      specifications,
+    ),
+  }
+}
+
+export async function patchStudioConfig(
+  context: StudioProjectContext,
+  patch: StudioConfigPatch,
+): Promise<StudioProject> {
+  const config = await loadConfig(context.configPath, context.root)
+  const next: PickleConfig = { ...config }
+  if (patch.suites) next.suites = patch.suites
+  if (patch.links) next.links = patch.links
+  if (patch.secrets) next.secrets = patch.secrets
+  if (patch.executionTargetProfiles) {
+    const existing = config.executionTargetProfiles ?? {}
+    const profiles: Record<string, ProjectExecutionTargetProfile> = {}
+    for (const [id, profile] of Object.entries(patch.executionTargetProfiles)) {
+      profiles[id] = {
+        adapter: profile.adapter,
+        ...(profile.capabilities
+          ? { capabilities: [...profile.capabilities] }
+          : {}),
+        ...(existing[id]?.web ? { web: existing[id].web } : {}),
+      }
+    }
+    next.executionTargetProfiles = profiles
+    next.executionTargetProfile = undefined
+  }
+  await saveConfig(next, context.configPath, context.root)
+  return loadStudioProject(context)
+}
+
+export async function saveStudioCredential(
+  context: StudioProjectContext,
+  input: { name: string; secret: string },
+): Promise<StudioProject> {
+  const name = input.name.trim()
+  const secret = input.secret.trim()
+  if (!name) throw new Error('A credential name is required')
+  if (!secret) throw new Error('A credential secret is required')
+  await context.credentials.set(name, secret)
+  const config = await loadConfig(context.configPath, context.root)
+  await saveConfig(
+    {
+      ...config,
+      secrets: {
+        ...config.secrets,
+        [name]: { keychain: name },
+      },
+    },
+    context.configPath,
+    context.root,
+  )
+  return loadStudioProject(context)
+}
+
+export async function resolveConfigSecrets(
+  config: PickleConfig,
+  credentials: CredentialStore,
+): Promise<PickleConfig> {
+  if (!config.web) return config
+  if (config.web.browser?.modelApiKey) return config
+  let modelApiKey: string | undefined
+  for (const [name, ref] of Object.entries(config.secrets ?? {})) {
+    const value =
+      process.env[name]?.trim() || (await credentials.get(ref.keychain))
+    if (value) {
+      modelApiKey = value
+      break
+    }
+  }
+  if (!modelApiKey) return config
+  return {
+    ...config,
+    web: {
+      ...config.web,
+      browser: {
+        ...config.web.browser,
+        modelApiKey,
+      },
+    },
+  }
+}

--- a/packages/cli/src/studio.test.ts
+++ b/packages/cli/src/studio.test.ts
@@ -619,6 +619,7 @@ Feature: Disk edit
       await page
         .getByRole('region', { name: 'Specification metadata' })
         .waitFor()
+      await page.getByRole('button', { name: 'Edit metadata' }).click()
       await page.getByRole('button', { name: 'draft', exact: true }).click()
       await page.getByLabel('Specification tags').fill('@checkout @regression')
       await page.getByLabel('Link namespace').fill('jira')

--- a/packages/cli/src/studio.test.ts
+++ b/packages/cli/src/studio.test.ts
@@ -45,6 +45,9 @@ describe('Studio browser seam', () => {
       JSON.stringify({
         schemaVersion: 1,
         specifications: 'features/**/*.feature',
+        links: {
+          jira: 'https://example.test/browse/{id}',
+        },
         executionTargetProfiles: {
           chrome: { adapter: 'custom' },
           firefox: { adapter: 'custom' },
@@ -208,11 +211,12 @@ Feature: Search
       expect(
         await page.getByRole('link', { name: 'Plans', disabled: true }).count(),
       ).toBe(1)
+      expect(await page.getByRole('link', { name: 'Settings' }).count()).toBe(1)
       expect(
         await page
           .getByRole('link', { name: 'Settings', disabled: true })
           .count(),
-      ).toBe(1)
+      ).toBe(0)
       expect(
         await page.getByRole('status').filter({ hasText: 'Ready' }).count(),
       ).toBe(1)
@@ -599,6 +603,322 @@ Feature: Disk edit
       await outline.waitFor()
       expect(await outline.textContent()).toContain('Search')
       expect(await outline.textContent()).toContain('@pickle:state:draft')
+    } finally {
+      await page.close()
+      child.kill()
+      await child.exited
+    }
+  }, 60_000)
+
+  test('Studio edits Specification state, tags, and external links', async () => {
+    const project = await createStudioProject('manage-metadata')
+    const { child, url } = await startStudio(project)
+    const page = await browser.newPage()
+    try {
+      await page.goto(url)
+      await page
+        .getByRole('region', { name: 'Specification metadata' })
+        .waitFor()
+      await page.getByRole('button', { name: 'draft', exact: true }).click()
+      await page.getByLabel('Specification tags').fill('@checkout @regression')
+      await page.getByLabel('Link namespace').fill('jira')
+      await page.getByLabel('Link id').fill('PROJ-12')
+      await page.getByRole('button', { name: 'Add link' }).click()
+      await page.getByRole('button', { name: 'Save metadata' }).click()
+      const dialog = page.getByRole('dialog', {
+        name: 'Review Specification metadata',
+      })
+      await dialog.waitFor()
+      expect(
+        await page.getByRole('region', { name: 'Source diff' }).textContent(),
+      ).toContain('@pickle:state:draft')
+      await dialog.getByRole('button', { name: 'Save metadata' }).click()
+      const deadline = Date.now() + 10_000
+      let written = ''
+      while (Date.now() < deadline) {
+        written = await Bun.file(
+          join(project, 'features', 'checkout.feature'),
+        ).text()
+        if (written.includes('@pickle:state:draft')) break
+        await Bun.sleep(50)
+      }
+      expect(written).toContain('# keep this comment')
+      expect(written).toContain('@pickle:state:draft')
+      expect(written).not.toContain('@pickle:state:active')
+      expect(written).toContain('@checkout')
+      expect(written).toContain('@regression')
+      expect(written).toContain('@jira:PROJ-12')
+    } finally {
+      await page.close()
+      child.kill()
+      await child.exited
+    }
+  }, 60_000)
+
+  test('Studio creates named test suites and execution target profiles', async () => {
+    const project = await createStudioProject('manage-config')
+    const { child, url } = await startStudio(project)
+    const page = await browser.newPage()
+    try {
+      await page.goto(url)
+      await page.getByRole('link', { name: 'Settings' }).click()
+      await page.getByRole('heading', { name: 'Test suites' }).waitFor()
+      await page.getByLabel('Suite name').fill('smoke')
+      await page.getByLabel('Suite paths').fill('features/**/*.feature')
+      await page.getByLabel('Suite tag expression').fill('@smoke')
+      await page.getByLabel('Suite states').fill('active, draft')
+      await page.getByRole('button', { name: 'Save test suite' }).click()
+      await page.getByRole('button', { name: 'New test suite' }).click()
+      await page.getByLabel('Suite name').fill('checkout')
+      await page.getByLabel('Suite paths').fill('features/checkout.feature')
+      await page.getByRole('button', { name: 'Save test suite' }).click()
+      await page.getByLabel('Profile id').fill('safari')
+      await page.getByLabel('Profile adapter').fill('custom')
+      await page.getByLabel('Profile capabilities').fill('geolocation')
+      await page
+        .getByRole('button', { name: 'Save execution target profile' })
+        .click()
+      const deadline = Date.now() + 10_000
+      let config = ''
+      while (Date.now() < deadline) {
+        config = await Bun.file(join(project, 'pickle.config.jsonc')).text()
+        if (
+          config.includes('"smoke"') &&
+          config.includes('"checkout"') &&
+          config.includes('"safari"')
+        )
+          break
+        await Bun.sleep(50)
+      }
+      expect(config).toContain('"smoke"')
+      expect(config).toContain('"checkout"')
+      expect(config).toContain('"tagExpression": "@smoke"')
+      expect(config).toContain('"safari"')
+      expect(config).toContain('"geolocation"')
+    } finally {
+      await page.close()
+      child.kill()
+      await child.exited
+    }
+  }, 60_000)
+
+  test('Studio withholds the test-run action until the selection is valid', async () => {
+    const project = await createStudioProject('validate-run')
+    await Bun.write(
+      join(project, 'features', 'checkout.feature'),
+      `# keep this comment
+@pickle:id:speccheckaaaaaaaa @pickle:state:active
+Feature: Checkout
+  @pickle:id:scnpaybbbbbbbbbb @pickle:requires:geolocation
+  Scenario: Pay for the order
+    Then payment is captured
+`,
+    )
+    const { child, url } = await startStudio(project)
+    const page = await browser.newPage()
+    try {
+      await page.goto(url)
+      await page.getByRole('heading', { name: 'Checkout' }).waitFor()
+      expect(
+        await page.getByRole('button', { name: 'Run Specification' }).count(),
+      ).toBe(0)
+      expect(
+        await page
+          .getByRole('status')
+          .filter({ hasText: 'geolocation' })
+          .count(),
+      ).toBeGreaterThan(0)
+      await page.getByRole('link', { name: 'Settings' }).click()
+      await page.getByRole('button', { name: 'chrome' }).click()
+      await page.getByLabel('Profile capabilities').fill('geolocation')
+      await page
+        .getByRole('button', { name: 'Save execution target profile' })
+        .click()
+      await page.getByRole('button', { name: 'firefox' }).click()
+      await page.getByLabel('Profile capabilities').fill('geolocation')
+      await page
+        .getByRole('button', { name: 'Save execution target profile' })
+        .click()
+      await page.getByRole('link', { name: 'Specifications' }).click()
+      await page.getByRole('button', { name: 'Run Specification' }).waitFor({
+        timeout: 10_000,
+      })
+    } finally {
+      await page.close()
+      child.kill()
+      await child.exited
+    }
+  }, 60_000)
+
+  test('Studio stores credentials in a keychain store and keeps references in project configuration', async () => {
+    const project = await createStudioProject('manage-secrets')
+    const keychain = join(project, 'keychain')
+    const { child, url } = await startStudio(project, {
+      PICKLE_KEYCHAIN_DIR: keychain,
+    })
+    const page = await browser.newPage()
+    try {
+      await page.goto(url)
+      await page.getByRole('link', { name: 'Settings' }).click()
+      await page.getByLabel('Credential name').fill('ANTHROPIC_API_KEY')
+      await page.getByLabel('Credential secret').fill('sk-test-secret')
+      await page.getByRole('button', { name: 'Save credential' }).click()
+      await page.getByText('ANTHROPIC_API_KEY (present)').waitFor({
+        timeout: 10_000,
+      })
+      const config = await Bun.file(join(project, 'pickle.config.jsonc')).text()
+      expect(config).toContain('ANTHROPIC_API_KEY')
+      expect(config).toContain('keychain')
+      expect(config).not.toContain('sk-test-secret')
+      expect(await Bun.file(join(keychain, 'ANTHROPIC_API_KEY')).text()).toBe(
+        'sk-test-secret',
+      )
+    } finally {
+      await page.close()
+      child.kill()
+      await child.exited
+    }
+  }, 60_000)
+
+  test('Studio shows Git diffs, commits after confirmation, and never pushes', async () => {
+    const project = await createStudioProject('manage-git')
+    const remote = join(workspace, 'manage-git-remote.git')
+    await Bun.spawnSync({ cmd: ['git', 'init', '--bare', remote] })
+    await Bun.spawnSync({
+      cmd: ['git', 'init'],
+      cwd: project,
+    })
+    await Bun.spawnSync({
+      cmd: ['git', 'config', 'user.email', 'studio@example.test'],
+      cwd: project,
+    })
+    await Bun.spawnSync({
+      cmd: ['git', 'config', 'user.name', 'Studio Test'],
+      cwd: project,
+    })
+    await Bun.spawnSync({
+      cmd: ['git', 'add', 'features/checkout.feature', 'pickle.config.jsonc'],
+      cwd: project,
+    })
+    await Bun.spawnSync({
+      cmd: ['git', 'commit', '-m', 'initial'],
+      cwd: project,
+    })
+    await Bun.spawnSync({
+      cmd: ['git', 'remote', 'add', 'origin', remote],
+      cwd: project,
+    })
+    await Bun.spawnSync({
+      cmd: [
+        'git',
+        'remote',
+        'add',
+        'github',
+        'git@github.com:example/pickle-spec.git',
+      ],
+      cwd: project,
+    })
+    const branch =
+      Bun.spawnSync({
+        cmd: ['git', 'branch', '--show-current'],
+        cwd: project,
+      })
+        .stdout.toString()
+        .trim() || 'main'
+    await Bun.spawnSync({
+      cmd: ['git', 'update-ref', `refs/remotes/github/${branch}`, 'HEAD'],
+      cwd: project,
+    })
+    await Bun.spawnSync({
+      cmd: ['git', 'branch', `--set-upstream-to=github/${branch}`],
+      cwd: project,
+    })
+    await Bun.write(
+      join(project, 'features', 'checkout.feature'),
+      `# keep this comment
+@pickle:id:speccheckaaaaaaaa @pickle:state:active
+Feature: Basket
+  @pickle:id:scnpaybbbbbbbbbb
+  Scenario: Pay for the order
+    Then payment is captured
+`,
+    )
+    const ghLog = join(project, 'gh.log')
+    const gh = join(project, 'bin', 'gh')
+    await mkdir(join(project, 'bin'), { recursive: true })
+    await Bun.write(
+      gh,
+      `#!/bin/sh
+echo "$@" >> "$GH_LOG"
+if echo " $* " | grep -q " push "; then exit 1; fi
+if [ "$1" = "pr" ]; then
+  echo "https://github.com/example/pickle-spec/pull/1"
+  exit 0
+fi
+exit 0
+`,
+    )
+    await Bun.spawnSync({ cmd: ['chmod', '+x', gh] })
+    const { child, url } = await startStudio(project, {
+      PATH: `${join(project, 'bin')}:${Bun.env.PATH ?? ''}`,
+      GH_LOG: ghLog,
+    })
+    const page = await browser.newPage()
+    try {
+      await page.goto(url)
+      await page.getByRole('link', { name: 'Settings' }).click()
+      await page.getByRole('heading', { name: 'Repository' }).waitFor()
+      const changed = page
+        .getByRole('listitem')
+        .filter({ hasText: 'features/checkout.feature' })
+      await changed.waitFor()
+      await changed.getByRole('button', { name: 'Show diff' }).click()
+      expect(
+        await changed
+          .getByRole('region', { name: 'features/checkout.feature diff' })
+          .textContent(),
+      ).toContain('Basket')
+      await changed
+        .getByRole('checkbox', { name: 'features/checkout.feature' })
+        .click()
+      await page.getByRole('button', { name: 'Stage selected' }).click()
+      await changed.getByText('staged').waitFor()
+      await page.getByLabel('Commit message').fill('Update Checkout')
+      await page
+        .getByRole('button', { name: 'Commit selected changes' })
+        .click()
+      await page
+        .getByRole('dialog', { name: 'Commit selected changes?' })
+        .waitFor()
+      await page.getByRole('button', { name: 'Confirm commit' }).click()
+      const deadline = Date.now() + 10_000
+      let log = ''
+      while (Date.now() < deadline) {
+        const result = Bun.spawnSync({
+          cmd: ['git', 'log', '-1', '--pretty=%s'],
+          cwd: project,
+        })
+        log = result.stdout.toString().trim()
+        if (log === 'Update Checkout') break
+        await Bun.sleep(50)
+      }
+      expect(log).toBe('Update Checkout')
+      const remoteHeads = Bun.spawnSync({
+        cmd: ['git', 'ls-remote', remote, 'HEAD'],
+      })
+      expect(remoteHeads.stdout.toString().trim()).toBe('')
+      await page.getByRole('button', { name: 'Create pull request' }).click()
+      const ghDeadline = Date.now() + 10_000
+      let ghInvoked = ''
+      while (Date.now() < ghDeadline) {
+        if (await Bun.file(ghLog).exists()) {
+          ghInvoked = await Bun.file(ghLog).text()
+          if (ghInvoked.includes('pr create --web')) break
+        }
+        await Bun.sleep(50)
+      }
+      expect(ghInvoked).toContain('pr create --web')
+      expect(ghInvoked).not.toContain('push')
     } finally {
       await page.close()
       child.kill()

--- a/packages/spec/index.ts
+++ b/packages/spec/index.ts
@@ -1,5 +1,7 @@
 export type {
+  ExternalLink,
   SpecificationDocument,
+  SpecificationMetadata,
   StructuredBackground,
   StructuredChild,
   StructuredExamples,
@@ -9,9 +11,12 @@ export type {
   StructuredStep,
 } from './src/editor'
 export {
+  applySpecificationMetadata,
   applySpecificationSource,
   applyStructuredSpecification,
+  authorTags,
   ensureSpecificationState,
+  parseExternalLinks,
   readSpecificationDocument,
   specificationSourceDiff,
 } from './src/editor'

--- a/packages/spec/src/editor.test.ts
+++ b/packages/spec/src/editor.test.ts
@@ -1,8 +1,10 @@
 import { describe, expect, test } from 'bun:test'
 import {
+  applySpecificationMetadata,
   applySpecificationSource,
   applyStructuredSpecification,
   ensureSpecificationState,
+  parseExternalLinks,
   readSpecificationDocument,
   specificationSourceDiff,
 } from '../index'
@@ -276,5 +278,50 @@ Feature: Search
     expect(next).toContain('@pickle:state:draft')
     expect(next).not.toContain('@pickle:state:active')
     expect(next).toContain('Feature: Search')
+  })
+})
+
+describe('applySpecificationMetadata', () => {
+  test('updates Specification state, author tags, and namespaced external links', () => {
+    const source = `# keep this comment
+@pickle:id:specaaaaaaaaaaaa @pickle:state:active @smoke
+Feature: Checkout
+  Scenario: Pay
+    Then payment is captured
+`
+    const next = applySpecificationMetadata(source, {
+      state: 'draft',
+      tags: ['@checkout', '@regression'],
+      links: [{ namespace: 'jira', id: 'PROJ-12' }],
+    })
+    expect(next).toContain('# keep this comment')
+    expect(next).toContain('@pickle:id:specaaaaaaaaaaaa')
+    expect(next).toContain('@pickle:state:draft')
+    expect(next).not.toContain('@pickle:state:active')
+    expect(next).toContain('@checkout')
+    expect(next).toContain('@regression')
+    expect(next).not.toContain('@smoke')
+    expect(next).toContain('@jira:PROJ-12')
+    expect(next).toContain('Feature: Checkout')
+  })
+})
+
+describe('parseExternalLinks', () => {
+  test('maps namespaced tags onto external links using configured namespaces', () => {
+    expect(
+      parseExternalLinks(
+        [
+          '@pickle:id:specaaaaaaaaaaaa',
+          '@pickle:state:active',
+          '@smoke',
+          '@jira:PROJ-12',
+          '@gh:23',
+        ],
+        ['jira', 'gh'],
+      ),
+    ).toEqual([
+      { namespace: 'jira', id: 'PROJ-12' },
+      { namespace: 'gh', id: '23' },
+    ])
   })
 })

--- a/packages/spec/src/editor.ts
+++ b/packages/spec/src/editor.ts
@@ -143,6 +143,17 @@ function mapChild(
   }
 }
 
+export interface ExternalLink {
+  namespace: string
+  id: string
+}
+
+export interface SpecificationMetadata {
+  state?: SpecificationState
+  tags?: readonly string[]
+  links?: readonly ExternalLink[]
+}
+
 export interface ApplyStructuredSpecificationInput {
   uri: string
   source: string
@@ -592,6 +603,98 @@ function longestCommonSubsequence(
 }
 
 const stateTagPrefix = '@pickle:state:'
+const idTagPrefix = '@pickle:id:'
+const requiresTagPrefix = '@pickle:requires:'
+
+function normalizedTag(tag: string): string {
+  const value = tag.trim()
+  return value.startsWith('@') ? value : `@${value}`
+}
+
+function linkTagPrefix(namespace: string): string {
+  return `@${namespace}:`
+}
+
+function isLinkTag(tag: string, namespaces: readonly string[]): boolean {
+  return namespaces.some(
+    (namespace) =>
+      namespace.length > 0 && tag.startsWith(linkTagPrefix(namespace)),
+  )
+}
+
+export function parseExternalLinks(
+  tags: readonly string[],
+  namespaces: readonly string[],
+): ExternalLink[] {
+  const links: ExternalLink[] = []
+  for (const tag of tags) {
+    for (const namespace of namespaces) {
+      const prefix = linkTagPrefix(namespace)
+      if (!tag.startsWith(prefix)) continue
+      const id = tag.slice(prefix.length)
+      if (id) links.push({ namespace, id })
+    }
+  }
+  return links
+}
+
+export function authorTags(
+  tags: readonly string[],
+  namespaces: readonly string[] = [],
+): string[] {
+  return tags.filter(
+    (tag) => !tag.startsWith('@pickle:') && !isLinkTag(tag, namespaces),
+  )
+}
+
+function nextFeatureTags(
+  current: readonly string[],
+  metadata: SpecificationMetadata,
+): string[] {
+  const linkNamespaces = [
+    ...new Set((metadata.links ?? []).map((link) => link.namespace)),
+  ]
+  const identity = current.filter((tag) => tag.startsWith(idTagPrefix))
+  const requires = current.filter((tag) => tag.startsWith(requiresTagPrefix))
+  const state = metadata.state
+    ? [`${stateTagPrefix}${metadata.state}`]
+    : current.filter((tag) => tag.startsWith(stateTagPrefix))
+  const links = metadata.links
+    ? metadata.links
+        .filter((link) => link.namespace.trim() && link.id.trim())
+        .map(
+          (link) => `${linkTagPrefix(link.namespace.trim())}${link.id.trim()}`,
+        )
+    : parseExternalLinks(current, linkNamespaces).map(
+        (link) => `${linkTagPrefix(link.namespace)}${link.id}`,
+      )
+  const authors = metadata.tags
+    ? authorTags(
+        metadata.tags.map(normalizedTag).filter((tag) => tag.length > 1),
+        linkNamespaces,
+      )
+    : authorTags(current, linkNamespaces)
+  return [...identity, ...state, ...authors, ...links, ...requires]
+}
+
+export function applySpecificationMetadata(
+  source: string,
+  metadata: SpecificationMetadata,
+  language = 'en',
+): string {
+  const document = parseDocument(source, language)
+  const feature = document.feature
+  if (!feature) {
+    throw new Error('Specification does not contain a Feature')
+  }
+  const replacement = tagReplacement(
+    source,
+    feature.tags,
+    nextFeatureTags(tagNames(feature.tags), metadata),
+    feature.location,
+  )
+  return replacement ? applyReplacements(source, [replacement]) : source
+}
 
 export function ensureSpecificationState(
   source: string,

--- a/packages/studio/index.ts
+++ b/packages/studio/index.ts
@@ -1,13 +1,32 @@
+export type { CredentialStore } from './src/credentials'
+export {
+  createCredentialStore,
+  createDirectoryCredentialStore,
+} from './src/credentials'
+export type {
+  GitWorkspace,
+  StudioGitFile,
+  StudioGitStatus,
+  StudioPullRequestResult,
+} from './src/git'
+export { createGitWorkspace } from './src/git'
 export type {
   StudioAuthoringGateway,
   StudioAuthoringModel,
+  StudioConfigPatch,
+  StudioCredential,
+  StudioExternalLink,
+  StudioManagementGateway,
   StudioOptions,
+  StudioProfile,
   StudioProject,
   StudioRunGateway,
+  StudioRunReadiness,
   StudioRunRequest,
   StudioRunSnapshot,
   StudioScenario,
   StudioServer,
   StudioSpecification,
+  StudioSuite,
 } from './src/server'
 export { startStudio } from './src/server'

--- a/packages/studio/src/components/ui/checkbox.tsx
+++ b/packages/studio/src/components/ui/checkbox.tsx
@@ -1,0 +1,31 @@
+import { Checkbox as CheckboxPrimitive } from '@base-ui/react/checkbox'
+import { Tick02Icon } from '@hugeicons/core-free-icons'
+import { HugeiconsIcon } from '@hugeicons/react'
+import { cn } from '../../lib/utils'
+
+function Checkbox({ className, ...props }: CheckboxPrimitive.Root.Props) {
+  return (
+    <CheckboxPrimitive.Root
+      data-slot="checkbox"
+      className={cn(
+        'peer relative flex size-4 shrink-0 items-center justify-center rounded-[4px] border border-input bg-input/20 transition-colors outline-none focus-visible:border-foreground/30 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive data-checked:border-foreground/40 data-checked:bg-primary data-checked:text-primary-foreground motion-reduce:transition-none',
+        className,
+      )}
+      {...props}
+    >
+      <CheckboxPrimitive.Indicator
+        data-slot="checkbox-indicator"
+        className="grid place-content-center text-current"
+      >
+        <HugeiconsIcon
+          icon={Tick02Icon}
+          strokeWidth={2}
+          aria-hidden
+          className="size-3.5"
+        />
+      </CheckboxPrimitive.Indicator>
+    </CheckboxPrimitive.Root>
+  )
+}
+
+export { Checkbox }

--- a/packages/studio/src/components/ui/collapsible.tsx
+++ b/packages/studio/src/components/ui/collapsible.tsx
@@ -1,0 +1,19 @@
+import { Collapsible as CollapsiblePrimitive } from '@base-ui/react/collapsible'
+
+function Collapsible({ ...props }: CollapsiblePrimitive.Root.Props) {
+  return <CollapsiblePrimitive.Root data-slot="collapsible" {...props} />
+}
+
+function CollapsibleTrigger({ ...props }: CollapsiblePrimitive.Trigger.Props) {
+  return (
+    <CollapsiblePrimitive.Trigger data-slot="collapsible-trigger" {...props} />
+  )
+}
+
+function CollapsibleContent({ ...props }: CollapsiblePrimitive.Panel.Props) {
+  return (
+    <CollapsiblePrimitive.Panel data-slot="collapsible-content" {...props} />
+  )
+}
+
+export { Collapsible, CollapsibleContent, CollapsibleTrigger }

--- a/packages/studio/src/credentials.ts
+++ b/packages/studio/src/credentials.ts
@@ -1,0 +1,94 @@
+import { mkdir } from 'node:fs/promises'
+import { homedir } from 'node:os'
+import { join } from 'node:path'
+
+const service = 'pickle-spec'
+
+export interface CredentialStore {
+  get(account: string): Promise<string | undefined>
+  set(account: string, secret: string): Promise<void>
+  has(account: string): Promise<boolean>
+}
+
+export function createDirectoryCredentialStore(
+  directory: string,
+): CredentialStore {
+  function fileFor(account: string) {
+    return Bun.file(join(directory, encodeURIComponent(account)))
+  }
+
+  async function get(account: string) {
+    const file = fileFor(account)
+    if (!(await file.exists())) return
+    const value = (await file.text()).trim()
+    return value || undefined
+  }
+
+  return {
+    get,
+    async set(account, secret) {
+      await mkdir(directory, { recursive: true })
+      await Bun.write(fileFor(account), secret)
+    },
+    async has(account) {
+      return (await get(account)) !== undefined
+    },
+  }
+}
+
+function keychainStore(): CredentialStore {
+  return {
+    async get(account) {
+      const result = Bun.spawnSync({
+        cmd: [
+          'security',
+          'find-generic-password',
+          '-s',
+          service,
+          '-a',
+          account,
+          '-w',
+        ],
+        stdout: 'pipe',
+        stderr: 'pipe',
+      })
+      if (result.exitCode !== 0) return
+      const value = result.stdout.toString().trim()
+      return value || undefined
+    },
+    async set(account, secret) {
+      const result = Bun.spawnSync({
+        cmd: [
+          'security',
+          'add-generic-password',
+          '-s',
+          service,
+          '-a',
+          account,
+          '-w',
+          secret,
+          '-U',
+        ],
+        stdout: 'pipe',
+        stderr: 'pipe',
+      })
+      if (result.exitCode !== 0) {
+        throw new Error(
+          result.stderr.toString().trim() || 'Unable to store credential',
+        )
+      }
+    },
+    async has(account) {
+      return (await this.get(account)) !== undefined
+    },
+  }
+}
+
+export function createCredentialStore(): CredentialStore {
+  const directory = process.env.PICKLE_KEYCHAIN_DIR
+  if (directory) return createDirectoryCredentialStore(directory)
+  if (process.platform === 'darwin') return keychainStore()
+  return createDirectoryCredentialStore(
+    join(homedir(), '.pickle', 'credentials'),
+  )
+}

--- a/packages/studio/src/documents.ts
+++ b/packages/studio/src/documents.ts
@@ -1,10 +1,12 @@
 import { watch } from 'node:fs'
 import { relative, resolve, sep } from 'node:path'
 import {
+  applySpecificationMetadata,
   applySpecificationSource,
   applyStructuredSpecification,
   ensureSpecificationState,
   readSpecificationDocument,
+  type SpecificationMetadata,
   type StructuredSpecification,
   specificationSourceDiff,
 } from '@pickle-spec/spec'
@@ -65,6 +67,7 @@ export interface SpecificationWorkspace {
     uri: string
     source: string
     specification?: StructuredSpecification
+    metadata?: SpecificationMetadata
     diffAgainst?: string
   }): SpecificationPreview
   write(input: {
@@ -144,18 +147,20 @@ export function createSpecificationWorkspace(
     },
 
     preview(input) {
-      const next = input.specification
-        ? applyStructuredSpecification({
-            uri: input.uri,
-            source: input.source,
-            language,
-            specification: input.specification,
-          })
-        : applySpecificationSource({
-            uri: input.uri,
-            source: input.source,
-            language,
-          })
+      const next = input.metadata
+        ? applySpecificationMetadata(input.source, input.metadata, language)
+        : input.specification
+          ? applyStructuredSpecification({
+              uri: input.uri,
+              source: input.source,
+              language,
+              specification: input.specification,
+            })
+          : applySpecificationSource({
+              uri: input.uri,
+              source: input.source,
+              language,
+            })
       return {
         ...buffer(input.uri, next),
         diff: specificationSourceDiff(input.diffAgainst ?? input.source, next),

--- a/packages/studio/src/frontend.tsx
+++ b/packages/studio/src/frontend.tsx
@@ -18,18 +18,25 @@ import {
   statusLabel,
   type TestResultState,
 } from './run-view'
+import { SettingsPanel } from './settings'
 import { SpecificationEditor } from './specification-editor'
 import './styles.css'
 
 type StudioScenario = {
   id: string
   name: string
+  canRun?: boolean
 }
 
 type StudioSpecification = {
   id: string
   name: string
   uri: string
+  state?: string
+  tags?: string[]
+  links?: Array<{ namespace: string; id: string }>
+  canRun?: boolean
+  runReasons?: string[]
   scenarios: StudioScenario[]
 }
 
@@ -43,6 +50,21 @@ type StudioProject = {
     provider: string
     name: string
   }
+  links?: Record<string, string>
+  suiteDetails?: Array<{
+    name: string
+    paths?: string | string[]
+    tagExpression?: string
+    states?: string[]
+    scenarioName?: string
+  }>
+  profileDetails?: Array<{
+    id: string
+    adapter: string
+    capabilities?: string[]
+  }>
+  secrets?: Array<{ name: string; present: boolean }>
+  readiness?: { ready: boolean; reasons: string[] }
 }
 
 type StudioRunRequest = {
@@ -55,7 +77,7 @@ const areas = [
   { name: 'Specifications', available: true },
   { name: 'Runs', available: false },
   { name: 'Plans', available: false },
-  { name: 'Settings', available: false },
+  { name: 'Settings', available: true },
 ] as const
 
 async function api<T>(path: string, init?: RequestInit): Promise<T> {
@@ -118,6 +140,8 @@ function StudioApp() {
   const [error, setError] = useState<string>()
   const [runId, setRunId] = useState<string>()
   const [selectedId, setSelectedId] = useState<string>()
+  const [currentArea, setCurrentArea] =
+    useState<(typeof areas)[number]['name']>('Specifications')
   const [view, setView] = useState<RunView>(emptyRunView)
   const running = view.phase === 'running'
 
@@ -154,6 +178,9 @@ function StudioApp() {
   const selected =
     project?.specifications.find((item) => item.id === selectedId) ??
     project?.specifications[0]
+  const canRunAll = Boolean(project?.readiness?.ready ?? true)
+  const specCanRun = selected?.canRun ?? canRunAll
+  const runReasons = selected?.runReasons ?? project?.readiness?.reasons
 
   async function reloadProject() {
     const value = await api<StudioProject>('/api/project')
@@ -236,148 +263,181 @@ function StudioApp() {
         aria-label="Studio"
         className="flex gap-px border-b border-border px-2 py-1"
       >
-        {areas.map((area) => (
-          <a
-            key={area.name}
-            href={`#${area.name.toLowerCase()}`}
-            aria-current={area.available ? 'page' : undefined}
-            aria-disabled={area.available ? undefined : true}
-            tabIndex={area.available ? undefined : -1}
-            className={cn(
-              'inline-flex h-7 items-center rounded-md px-2 text-xs/relaxed transition-colors duration-150 ease-[cubic-bezier(0.23,1,0.32,1)] motion-reduce:transition-none',
-              area.available
-                ? 'bg-accent text-accent-foreground'
-                : 'cursor-not-allowed text-muted-foreground opacity-60',
-            )}
+        {areas.map((item) => (
+          <Button
+            key={item.name}
+            variant={
+              item.available && item.name === currentArea
+                ? 'secondary'
+                : 'ghost'
+            }
+            render={
+              <a
+                href={`#${item.name.toLowerCase()}`}
+                aria-current={
+                  item.available && item.name === currentArea
+                    ? 'page'
+                    : undefined
+                }
+                aria-disabled={item.available ? undefined : true}
+                tabIndex={item.available ? undefined : -1}
+              />
+            }
+            className={
+              item.available
+                ? undefined
+                : 'pointer-events-none text-muted-foreground opacity-60'
+            }
             onClick={(event) => {
-              if (!area.available) event.preventDefault()
+              if (!item.available) {
+                event.preventDefault()
+                return
+              }
+              setCurrentArea(item.name)
             }}
           >
-            {area.name}
-          </a>
+            {item.name}
+          </Button>
         ))}
       </nav>
-      <div className="grid min-h-0 flex-1 lg:grid-cols-[16rem_1fr]">
-        <SpecificationList
-          specifications={project.specifications}
-          selectedId={selected?.id}
-          running={running}
-          onSelect={setSelectedId}
-          onRunAll={() => void startRun({})}
+      {currentArea === 'Settings' ? (
+        <SettingsPanel
+          project={project}
+          api={api}
+          onProject={setProject}
+          onError={setError}
         />
-        <main className="min-w-0 space-y-6 p-6" aria-busy={running}>
-          {error ? (
-            <p role="alert" className="text-sm text-destructive">
-              {error}
-            </p>
-          ) : null}
-          {selected ? (
-            <>
-              <div className="flex flex-wrap items-start justify-between gap-3">
-                <div className="min-w-0 space-y-1">
-                  <h2 className="text-lg font-medium">{selected.name}</h2>
-                  <p className="truncate font-mono text-xs text-muted-foreground">
-                    {selected.uri}
-                  </p>
-                </div>
-                {running && runId ? (
-                  <Button
-                    type="button"
-                    variant="destructive"
-                    onClick={() => void cancelRun()}
-                  >
-                    Cancel test run
-                  </Button>
-                ) : (
-                  <Button
-                    type="button"
-                    disabled={running}
-                    onClick={() => void startRun({ paths: [selected.uri] })}
-                  >
-                    Run Specification
-                  </Button>
-                )}
-              </div>
-              <SpecificationEditor
-                uri={selected.uri}
-                model={project.model}
-                api={api}
-                onCatalogChange={async () => {
-                  await reloadProject()
-                }}
-                onCreated={(uri) => {
-                  void reloadProject().then((value) => {
-                    const created = value.specifications.find(
-                      (item) => item.uri === uri,
-                    )
-                    if (created) setSelectedId(created.id)
-                  })
-                }}
-                onError={(message) => setError(message)}
-              />
-              <ScenarioTable
-                profiles={project.profiles}
-                scenarios={selected.scenarios}
-                cells={view.cells}
-                selected={view.selected}
-                running={running}
-                onSelect={(cell) =>
-                  setView((current) => pinCell(current, cell))
-                }
-                onRun={(scenarioName) =>
-                  void startRun({ paths: [selected.uri], scenarioName })
-                }
-              />
-            </>
-          ) : (
-            <p className="text-sm text-muted-foreground">
-              No Specifications found. Add a feature file matching the project
-              configuration.
-            </p>
-          )}
-          {attention.length > 0 ? (
-            <div>
-              <h3 className="mb-2 text-sm font-medium">Needs attention</h3>
-              <ul
-                aria-label="Needs attention"
-                aria-live="polite"
-                className="space-y-2"
-              >
-                {attention.map((cell) => (
-                  <li key={cellKey(cell.scenarioId, cell.profileId)}>
-                    <button
+      ) : (
+        <div className="grid min-h-0 flex-1 lg:grid-cols-[16rem_1fr]">
+          <SpecificationList
+            specifications={project.specifications}
+            selectedId={selected?.id}
+            running={running}
+            canRun={canRunAll}
+            onSelect={setSelectedId}
+            onRunAll={() => void startRun({})}
+          />
+          <main className="min-w-0 space-y-6 p-6" aria-busy={running}>
+            {error ? (
+              <p role="alert" className="text-sm text-destructive">
+                {error}
+              </p>
+            ) : null}
+            {!specCanRun && runReasons?.length ? (
+              <p role="status" className="text-sm text-muted-foreground">
+                {runReasons.join(' ')}
+              </p>
+            ) : null}
+            {selected ? (
+              <>
+                <div className="flex flex-wrap items-start justify-between gap-3">
+                  <div className="min-w-0 space-y-1">
+                    <h2 className="text-lg font-medium">{selected.name}</h2>
+                    <p className="truncate font-mono text-xs text-muted-foreground">
+                      {selected.uri}
+                    </p>
+                  </div>
+                  {running && runId ? (
+                    <Button
                       type="button"
-                      className={cn(
-                        'flex w-full min-w-0 flex-col gap-1 rounded-md border bg-card px-3 py-2 text-left text-sm outline-none transition-[transform,background-color,border-color] duration-150 ease-[cubic-bezier(0.23,1,0.32,1)] hover:bg-muted/30 active:scale-[0.99] focus-visible:border-foreground/30 motion-reduce:transition-none motion-reduce:active:scale-100',
-                        isSelectedCell(view.selected, cell)
-                          ? 'border-foreground/25'
-                          : 'border-border',
-                      )}
-                      onClick={() =>
-                        setView((current) => pinCell(current, cell))
-                      }
+                      variant="destructive"
+                      onClick={() => void cancelRun()}
                     >
-                      <span className="flex min-w-0 items-center gap-2">
-                        <span className="min-w-0 flex-1 truncate">
-                          {cell.scenarioName}
+                      Cancel test run
+                    </Button>
+                  ) : specCanRun ? (
+                    <Button
+                      type="button"
+                      disabled={running}
+                      onClick={() => void startRun({ paths: [selected.uri] })}
+                    >
+                      Run Specification
+                    </Button>
+                  ) : null}
+                </div>
+                <SpecificationEditor
+                  uri={selected.uri}
+                  model={project.model}
+                  namespaces={Object.keys(project.links ?? {})}
+                  linkTemplates={project.links}
+                  api={api}
+                  onCatalogChange={async () => {
+                    await reloadProject()
+                  }}
+                  onCreated={(uri) => {
+                    void reloadProject().then((value) => {
+                      const created = value.specifications.find(
+                        (item) => item.uri === uri,
+                      )
+                      if (created) setSelectedId(created.id)
+                    })
+                  }}
+                  onError={(message) => setError(message)}
+                />
+                <ScenarioTable
+                  profiles={project.profiles}
+                  scenarios={selected.scenarios}
+                  cells={view.cells}
+                  selected={view.selected}
+                  running={running}
+                  onSelect={(cell) =>
+                    setView((current) => pinCell(current, cell))
+                  }
+                  onRun={(scenarioName) =>
+                    void startRun({ paths: [selected.uri], scenarioName })
+                  }
+                />
+              </>
+            ) : (
+              <p className="text-sm text-muted-foreground">
+                No Specifications found. Add a feature file matching the project
+                configuration.
+              </p>
+            )}
+            {attention.length > 0 ? (
+              <div>
+                <h3 className="mb-2 text-sm font-medium">Needs attention</h3>
+                <ul
+                  aria-label="Needs attention"
+                  aria-live="polite"
+                  className="space-y-2"
+                >
+                  {attention.map((cell) => (
+                    <li key={cellKey(cell.scenarioId, cell.profileId)}>
+                      <button
+                        type="button"
+                        className={cn(
+                          'flex w-full min-w-0 flex-col gap-1 rounded-md border bg-card px-3 py-2 text-left text-sm outline-none transition-[transform,background-color,border-color] duration-150 ease-[cubic-bezier(0.23,1,0.32,1)] hover:bg-muted/30 active:scale-[0.99] focus-visible:border-foreground/30 motion-reduce:transition-none motion-reduce:active:scale-100',
+                          isSelectedCell(view.selected, cell)
+                            ? 'border-foreground/25'
+                            : 'border-border',
+                        )}
+                        onClick={() =>
+                          setView((current) => pinCell(current, cell))
+                        }
+                      >
+                        <span className="flex min-w-0 items-center gap-2">
+                          <span className="min-w-0 flex-1 truncate">
+                            {cell.scenarioName}
+                          </span>
+                          <Badge variant={badgeVariant(cell.state)}>
+                            <ResultMark key={cell.state} state={cell.state} />
+                            {cell.state}
+                          </Badge>
                         </span>
-                        <Badge variant={badgeVariant(cell.state)}>
-                          <ResultMark key={cell.state} state={cell.state} />
-                          {cell.state}
-                        </Badge>
-                      </span>
-                      <span className="text-xs text-muted-foreground">
-                        {cell.profileId} · Open step timeline
-                      </span>
-                    </button>
-                  </li>
-                ))}
-              </ul>
-            </div>
-          ) : null}
-          <Timeline cell={view.selected} />
-        </main>
-      </div>
+                        <span className="text-xs text-muted-foreground">
+                          {cell.profileId} · Open step timeline
+                        </span>
+                      </button>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            ) : null}
+            <Timeline cell={view.selected} />
+          </main>
+        </div>
+      )}
     </div>
   )
 }
@@ -386,6 +446,7 @@ function SpecificationList(props: {
   specifications: StudioSpecification[]
   selectedId?: string
   running: boolean
+  canRun: boolean
   onSelect: (id: string) => void
   onRunAll: () => void
 }) {
@@ -430,15 +491,17 @@ function SpecificationList(props: {
         </ul>
       )}
       <div className="border-t border-border p-2">
-        <Button
-          type="button"
-          variant="outline"
-          className="w-full"
-          disabled={props.running || props.specifications.length === 0}
-          onClick={props.onRunAll}
-        >
-          Run all Specifications
-        </Button>
+        {props.canRun ? (
+          <Button
+            type="button"
+            variant="outline"
+            className="w-full"
+            disabled={props.running || props.specifications.length === 0}
+            onClick={props.onRunAll}
+          >
+            Run all Specifications
+          </Button>
+        ) : null}
       </div>
     </nav>
   )
@@ -531,16 +594,18 @@ function ScenarioTable(props: {
                   )
                 })}
                 <td className="px-3 py-2 text-right">
-                  <Button
-                    type="button"
-                    size="sm"
-                    variant="outline"
-                    disabled={props.running}
-                    aria-label={`Run Scenario ${scenario.name}`}
-                    onClick={() => props.onRun(scenario.name)}
-                  >
-                    Run
-                  </Button>
+                  {scenario.canRun !== false ? (
+                    <Button
+                      type="button"
+                      size="sm"
+                      variant="outline"
+                      disabled={props.running}
+                      aria-label={`Run Scenario ${scenario.name}`}
+                      onClick={() => props.onRun(scenario.name)}
+                    >
+                      Run
+                    </Button>
+                  ) : null}
                 </td>
               </tr>
             ))

--- a/packages/studio/src/frontend.tsx
+++ b/packages/studio/src/frontend.tsx
@@ -143,6 +143,7 @@ function StudioApp() {
   const [currentArea, setCurrentArea] =
     useState<(typeof areas)[number]['name']>('Specifications')
   const [view, setView] = useState<RunView>(emptyRunView)
+  const [authoring, setAuthoring] = useState(false)
   const running = view.phase === 'running'
 
   useEffect(() => {
@@ -254,7 +255,7 @@ function StudioApp() {
   }
 
   return (
-    <div className="flex min-h-screen flex-col">
+    <div className="flex h-screen flex-col overflow-hidden">
       <header className="flex items-center justify-between border-b border-border bg-card px-6 py-3">
         <h1 className="text-xl font-semibold tracking-tight">{project.name}</h1>
         <StatusBadge state={aggregate} />
@@ -301,12 +302,14 @@ function StudioApp() {
         ))}
       </nav>
       {currentArea === 'Settings' ? (
-        <SettingsPanel
-          project={project}
-          api={api}
-          onProject={setProject}
-          onError={setError}
-        />
+        <div className="min-h-0 flex-1 overflow-auto">
+          <SettingsPanel
+            project={project}
+            api={api}
+            onProject={setProject}
+            onError={setError}
+          />
+        </div>
       ) : (
         <div className="grid min-h-0 flex-1 lg:grid-cols-[16rem_1fr]">
           <SpecificationList
@@ -317,124 +320,154 @@ function StudioApp() {
             onSelect={setSelectedId}
             onRunAll={() => void startRun({})}
           />
-          <main className="min-w-0 space-y-6 p-6" aria-busy={running}>
+          <main
+            className="flex min-h-0 min-w-0 flex-1 flex-col"
+            aria-busy={running}
+          >
             {error ? (
-              <p role="alert" className="text-sm text-destructive">
+              <p role="alert" className="px-6 pt-6 text-sm text-destructive">
                 {error}
-              </p>
-            ) : null}
-            {!specCanRun && runReasons?.length ? (
-              <p role="status" className="text-sm text-muted-foreground">
-                {runReasons.join(' ')}
               </p>
             ) : null}
             {selected ? (
               <>
-                <div className="flex flex-wrap items-start justify-between gap-3">
-                  <div className="min-w-0 space-y-1">
-                    <h2 className="text-lg font-medium">{selected.name}</h2>
-                    <p className="truncate font-mono text-xs text-muted-foreground">
-                      {selected.uri}
-                    </p>
+                <header
+                  className={
+                    authoring
+                      ? 'flex min-h-0 flex-1 flex-col space-y-3 border-b border-border px-6 py-4'
+                      : 'shrink-0 space-y-3 border-b border-border px-6 py-4'
+                  }
+                >
+                  <div className="flex shrink-0 flex-wrap items-start justify-between gap-3">
+                    <div className="min-w-0 space-y-1">
+                      <h2 className="text-lg font-medium">{selected.name}</h2>
+                      <p className="truncate font-mono text-xs text-muted-foreground">
+                        {selected.uri}
+                      </p>
+                    </div>
+                    {running && runId ? (
+                      <Button
+                        type="button"
+                        variant="destructive"
+                        onClick={() => void cancelRun()}
+                      >
+                        Cancel test run
+                      </Button>
+                    ) : specCanRun ? (
+                      <Button
+                        type="button"
+                        disabled={running}
+                        onClick={() => void startRun({ paths: [selected.uri] })}
+                      >
+                        Run Specification
+                      </Button>
+                    ) : null}
                   </div>
-                  {running && runId ? (
-                    <Button
-                      type="button"
-                      variant="destructive"
-                      onClick={() => void cancelRun()}
-                    >
-                      Cancel test run
-                    </Button>
-                  ) : specCanRun ? (
-                    <Button
-                      type="button"
-                      disabled={running}
-                      onClick={() => void startRun({ paths: [selected.uri] })}
-                    >
-                      Run Specification
-                    </Button>
+                  {!specCanRun && runReasons?.length ? (
+                    <p role="status" className="text-sm text-muted-foreground">
+                      {runReasons.join(' ')}
+                    </p>
                   ) : null}
-                </div>
-                <SpecificationEditor
-                  uri={selected.uri}
-                  model={project.model}
-                  namespaces={Object.keys(project.links ?? {})}
-                  linkTemplates={project.links}
-                  api={api}
-                  onCatalogChange={async () => {
-                    await reloadProject()
-                  }}
-                  onCreated={(uri) => {
-                    void reloadProject().then((value) => {
-                      const created = value.specifications.find(
-                        (item) => item.uri === uri,
-                      )
-                      if (created) setSelectedId(created.id)
-                    })
-                  }}
-                  onError={(message) => setError(message)}
-                />
-                <ScenarioTable
-                  profiles={project.profiles}
-                  scenarios={selected.scenarios}
-                  cells={view.cells}
-                  selected={view.selected}
-                  running={running}
-                  onSelect={(cell) =>
-                    setView((current) => pinCell(current, cell))
-                  }
-                  onRun={(scenarioName) =>
-                    void startRun({ paths: [selected.uri], scenarioName })
-                  }
-                />
+                  <div
+                    className={
+                      authoring ? 'flex min-h-0 flex-1 flex-col' : undefined
+                    }
+                  >
+                    <SpecificationEditor
+                      uri={selected.uri}
+                      model={project.model}
+                      namespaces={Object.keys(project.links ?? {})}
+                      linkTemplates={project.links}
+                      api={api}
+                      onModeChange={(mode) => setAuthoring(mode === 'edit')}
+                      onCatalogChange={async () => {
+                        await reloadProject()
+                      }}
+                      onCreated={(uri) => {
+                        void reloadProject().then((value) => {
+                          const created = value.specifications.find(
+                            (item) => item.uri === uri,
+                          )
+                          if (created) setSelectedId(created.id)
+                        })
+                      }}
+                      onError={(message) => setError(message)}
+                    />
+                  </div>
+                </header>
+                {authoring ? null : (
+                  <div className="min-h-0 flex-1 space-y-6 overflow-auto px-6 py-4">
+                    <ScenarioTable
+                      profiles={project.profiles}
+                      scenarios={selected.scenarios}
+                      cells={view.cells}
+                      selected={view.selected}
+                      running={running}
+                      onSelect={(cell) =>
+                        setView((current) => pinCell(current, cell))
+                      }
+                      onRun={(scenarioName) =>
+                        void startRun({
+                          paths: [selected.uri],
+                          scenarioName,
+                        })
+                      }
+                    />
+                    {attention.length > 0 ? (
+                      <div>
+                        <h3 className="mb-2 text-sm font-medium">
+                          Needs attention
+                        </h3>
+                        <ul
+                          aria-label="Needs attention"
+                          aria-live="polite"
+                          className="space-y-2"
+                        >
+                          {attention.map((cell) => (
+                            <li key={cellKey(cell.scenarioId, cell.profileId)}>
+                              <button
+                                type="button"
+                                className={cn(
+                                  'flex w-full min-w-0 flex-col gap-1 rounded-md border bg-card px-3 py-2 text-left text-sm outline-none transition-[transform,background-color,border-color] duration-150 ease-[cubic-bezier(0.23,1,0.32,1)] hover:bg-muted/30 active:scale-[0.99] focus-visible:border-foreground/30 motion-reduce:transition-none motion-reduce:active:scale-100',
+                                  isSelectedCell(view.selected, cell)
+                                    ? 'border-foreground/25'
+                                    : 'border-border',
+                                )}
+                                onClick={() =>
+                                  setView((current) => pinCell(current, cell))
+                                }
+                              >
+                                <span className="flex min-w-0 items-center gap-2">
+                                  <span className="min-w-0 flex-1 truncate">
+                                    {cell.scenarioName}
+                                  </span>
+                                  <Badge variant={badgeVariant(cell.state)}>
+                                    <ResultMark
+                                      key={cell.state}
+                                      state={cell.state}
+                                    />
+                                    {cell.state}
+                                  </Badge>
+                                </span>
+                                <span className="text-xs text-muted-foreground">
+                                  {cell.profileId} · Open step timeline
+                                </span>
+                              </button>
+                            </li>
+                          ))}
+                        </ul>
+                      </div>
+                    ) : null}
+                    <Timeline cell={view.selected} />
+                  </div>
+                )}
               </>
             ) : (
-              <p className="text-sm text-muted-foreground">
+              <p className="p-6 text-sm text-muted-foreground">
                 No Specifications found. Add a feature file matching the project
                 configuration.
               </p>
             )}
-            {attention.length > 0 ? (
-              <div>
-                <h3 className="mb-2 text-sm font-medium">Needs attention</h3>
-                <ul
-                  aria-label="Needs attention"
-                  aria-live="polite"
-                  className="space-y-2"
-                >
-                  {attention.map((cell) => (
-                    <li key={cellKey(cell.scenarioId, cell.profileId)}>
-                      <button
-                        type="button"
-                        className={cn(
-                          'flex w-full min-w-0 flex-col gap-1 rounded-md border bg-card px-3 py-2 text-left text-sm outline-none transition-[transform,background-color,border-color] duration-150 ease-[cubic-bezier(0.23,1,0.32,1)] hover:bg-muted/30 active:scale-[0.99] focus-visible:border-foreground/30 motion-reduce:transition-none motion-reduce:active:scale-100',
-                          isSelectedCell(view.selected, cell)
-                            ? 'border-foreground/25'
-                            : 'border-border',
-                        )}
-                        onClick={() =>
-                          setView((current) => pinCell(current, cell))
-                        }
-                      >
-                        <span className="flex min-w-0 items-center gap-2">
-                          <span className="min-w-0 flex-1 truncate">
-                            {cell.scenarioName}
-                          </span>
-                          <Badge variant={badgeVariant(cell.state)}>
-                            <ResultMark key={cell.state} state={cell.state} />
-                            {cell.state}
-                          </Badge>
-                        </span>
-                        <span className="text-xs text-muted-foreground">
-                          {cell.profileId} · Open step timeline
-                        </span>
-                      </button>
-                    </li>
-                  ))}
-                </ul>
-              </div>
-            ) : null}
-            <Timeline cell={view.selected} />
           </main>
         </div>
       )}

--- a/packages/studio/src/git.ts
+++ b/packages/studio/src/git.ts
@@ -1,0 +1,220 @@
+import { join } from 'node:path'
+
+export interface StudioGitFile {
+  path: string
+  status: string
+  staged: boolean
+  diff: string
+}
+
+export interface StudioGitStatus {
+  branch?: string
+  files: StudioGitFile[]
+  pullRequestAvailable: boolean
+  pullRequestReason?: string
+}
+
+export interface StudioPullRequestResult {
+  url?: string
+  message: string
+}
+
+export interface GitWorkspace {
+  status(): Promise<StudioGitStatus>
+  stage(paths: readonly string[]): Promise<StudioGitStatus>
+  commit(input: {
+    message: string
+    confirmed: boolean
+    paths?: readonly string[]
+  }): Promise<StudioGitStatus>
+  pullRequest(): Promise<StudioPullRequestResult>
+}
+
+function run(
+  cwd: string,
+  cmd: string[],
+): { stdout: string; stderr: string; exitCode: number } {
+  const result = Bun.spawnSync({
+    cmd,
+    cwd,
+    stdout: 'pipe',
+    stderr: 'pipe',
+  })
+  return {
+    stdout: result.stdout.toString(),
+    stderr: result.stderr.toString(),
+    exitCode: result.exitCode ?? 1,
+  }
+}
+
+function git(cwd: string, args: string[]) {
+  return run(cwd, ['git', ...args])
+}
+
+function assertGitSuccess(
+  result: { stderr: string; exitCode: number },
+  action: string,
+) {
+  if (result.exitCode === 0) return
+  throw new Error(result.stderr.trim() || `Unable to ${action}`)
+}
+
+function fileStaged(line: string): boolean {
+  const indexStatus = line[0]
+  return Boolean(indexStatus && indexStatus !== ' ' && indexStatus !== '?')
+}
+
+function fileUnstaged(line: string): boolean {
+  const worktreeStatus = line[1]
+  return Boolean(worktreeStatus && worktreeStatus !== ' ')
+}
+
+async function diffFor(
+  root: string,
+  path: string,
+  staged: boolean,
+  untracked: boolean,
+) {
+  if (untracked) {
+    const file = Bun.file(join(root, path))
+    if (!(await file.exists())) return ''
+    return `${(await file.text())
+      .split('\n')
+      .map((line) => `+${line}`)
+      .join('\n')}\n`
+  }
+  const result = git(root, [
+    'diff',
+    '--no-color',
+    ...(staged ? ['--cached'] : []),
+    '--',
+    path,
+  ])
+  return result.stdout
+}
+
+async function pullRequestAvailability(root: string): Promise<{
+  available: boolean
+  reason?: string
+}> {
+  if (!Bun.which('gh')) {
+    return { available: false, reason: 'GitHub CLI is not available' }
+  }
+  const remotes = git(root, ['remote', '-v'])
+  if (!/github\.com[:/]/i.test(remotes.stdout)) {
+    return { available: false, reason: 'No GitHub remote is configured' }
+  }
+  const upstream = git(root, ['rev-parse', '--abbrev-ref', '@{upstream}'])
+  if (upstream.exitCode !== 0) {
+    return {
+      available: false,
+      reason: 'Publish the branch before creating a pull request',
+    }
+  }
+  return { available: true }
+}
+
+export function createGitWorkspace(root: string): GitWorkspace {
+  async function status(): Promise<StudioGitStatus> {
+    const repo = git(root, ['rev-parse', '--is-inside-work-tree'])
+    if (repo.exitCode !== 0) {
+      return {
+        files: [],
+        pullRequestAvailable: false,
+        pullRequestReason: 'This project is not a Git repository',
+      }
+    }
+    const branch = git(root, ['branch', '--show-current']).stdout.trim()
+    const porcelain = git(root, ['status', '--porcelain', '-uall'])
+    assertGitSuccess(porcelain, 'read repository status')
+    const files: StudioGitFile[] = []
+    for (const line of porcelain.stdout.split('\n').filter(Boolean)) {
+      const path = line
+        .slice(3)
+        .replace(/^"(.*)"$/, '$1')
+        .split(' -> ')
+        .at(-1)
+      if (!path) continue
+      const untracked = line.startsWith('??')
+      const staged = fileStaged(line)
+      const unstaged = fileUnstaged(line)
+      const statusLabel = untracked
+        ? 'untracked'
+        : line.includes('D')
+          ? 'deleted'
+          : staged && !unstaged && line[0] === 'A'
+            ? 'added'
+            : 'modified'
+      const diff = unstaged
+        ? await diffFor(root, path, false, untracked)
+        : await diffFor(root, path, staged, untracked)
+      files.push({
+        path,
+        status: statusLabel,
+        staged: staged && !unstaged,
+        diff,
+      })
+    }
+    const pullRequest = await pullRequestAvailability(root)
+    return {
+      ...(branch ? { branch } : {}),
+      files,
+      pullRequestAvailable: pullRequest.available,
+      ...(pullRequest.reason ? { pullRequestReason: pullRequest.reason } : {}),
+    }
+  }
+
+  return {
+    status,
+    async stage(paths) {
+      if (paths.length === 0)
+        throw new Error('Select at least one path to stage')
+      assertGitSuccess(
+        git(root, ['add', '--', ...paths]),
+        'stage selected changes',
+      )
+      return status()
+    },
+    async commit(input) {
+      if (!input.confirmed) {
+        throw new Error(
+          'Confirm the commit before Studio writes to the repository',
+        )
+      }
+      const message = input.message.trim()
+      if (!message) throw new Error('A commit message is required')
+      const paths = [...(input.paths ?? [])].filter((path) => path.length > 0)
+      if (paths.length === 0) {
+        throw new Error('Select at least one path to commit')
+      }
+      assertGitSuccess(
+        git(root, ['add', '--', ...paths]),
+        'stage selected changes',
+      )
+      assertGitSuccess(
+        git(root, ['commit', '-m', message, '--', ...paths]),
+        'create the commit',
+      )
+      return status()
+    },
+    async pullRequest() {
+      const availability = await pullRequestAvailability(root)
+      if (!availability.available) {
+        throw new Error(
+          availability.reason ?? 'Pull request actions are unavailable',
+        )
+      }
+      const result = run(root, ['gh', 'pr', 'create', '--web'])
+      if (result.exitCode !== 0) {
+        throw new Error(
+          result.stderr.trim() || 'GitHub CLI could not open a pull request',
+        )
+      }
+      const url = result.stdout.match(/https?:\/\/\S+/)?.[0]
+      return {
+        ...(url ? { url } : {}),
+        message: 'Opened the GitHub pull request workflow',
+      }
+    },
+  }
+}

--- a/packages/studio/src/server.ts
+++ b/packages/studio/src/server.ts
@@ -2,10 +2,11 @@ import { mkdtemp, rm } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { basename, join, resolve } from 'node:path'
 import type { RunEvent, TestRunManifest } from '@pickle-spec/runner'
-import {
-  type StructuredSpecification,
-  specificationSourceDiff,
+import type {
+  SpecificationMetadata,
+  StructuredSpecification,
 } from '@pickle-spec/spec'
+import { specificationSourceDiff } from '@pickle-spec/spec'
 import tailwind from 'bun-plugin-tailwind'
 import {
   createSpecificationWorkspace,
@@ -13,17 +14,71 @@ import {
   DocumentConflictError,
   type SpecificationWorkspace,
 } from './documents'
+import { createGitWorkspace, type GitWorkspace } from './git'
 
 export interface StudioScenario {
   id: string
   name: string
+  canRun?: boolean
+}
+
+export interface StudioExternalLink {
+  namespace: string
+  id: string
 }
 
 export interface StudioSpecification {
   id: string
   name: string
   uri: string
+  state?: 'draft' | 'active' | 'deprecated'
+  tags?: readonly string[]
+  links?: readonly StudioExternalLink[]
+  canRun?: boolean
+  runReasons?: readonly string[]
   scenarios: readonly StudioScenario[]
+}
+
+export interface StudioSuite {
+  name: string
+  paths?: string | readonly string[]
+  tagExpression?: string
+  states?: readonly ('draft' | 'active' | 'deprecated')[]
+  scenarioName?: string
+}
+
+export interface StudioProfile {
+  id: string
+  adapter: string
+  capabilities?: readonly string[]
+}
+
+export interface StudioCredential {
+  name: string
+  present: boolean
+}
+
+export interface StudioRunReadiness {
+  ready: boolean
+  reasons: readonly string[]
+}
+
+export interface StudioConfigPatch {
+  suites?: Record<
+    string,
+    {
+      paths?: string | readonly string[]
+      tagExpression?: string
+      states?: readonly ('draft' | 'active' | 'deprecated')[]
+      scenarioName?: string
+    }
+  >
+  executionTargetProfiles?: Record<
+    string,
+    { adapter: string; capabilities?: readonly string[] }
+  >
+  links?: Record<string, string>
+  secrets?: Record<string, { keychain: string }>
 }
 
 export interface StudioAuthoringModel {
@@ -38,6 +93,11 @@ export interface StudioProject {
   suites: readonly string[]
   specifications: readonly StudioSpecification[]
   model?: StudioAuthoringModel
+  links?: Readonly<Record<string, string>>
+  suiteDetails?: readonly StudioSuite[]
+  profileDetails?: readonly StudioProfile[]
+  secrets?: readonly StudioCredential[]
+  readiness?: StudioRunReadiness
 }
 
 export interface StudioRunRequest {
@@ -70,12 +130,23 @@ export interface StudioAuthoringGateway {
   }) => Promise<{ source: string }>
 }
 
+export interface StudioManagementGateway {
+  saveConfig(patch: StudioConfigPatch): Promise<StudioProject>
+  saveCredential(input: {
+    name: string
+    secret: string
+  }): Promise<StudioProject>
+  readiness(request?: StudioRunRequest): Promise<StudioRunReadiness>
+}
+
 export interface StudioOptions {
   project: StudioProject
   loadProject?: () => Promise<StudioProject> | StudioProject
   gateway?: StudioRunGateway
   documents?: SpecificationWorkspace
   authoring?: StudioAuthoringGateway
+  management?: StudioManagementGateway
+  git?: GitWorkspace
   specificationGlobs?: string | readonly string[]
   language?: string
   hostname?: string
@@ -113,10 +184,26 @@ type StudioSocketData =
       listener?: (event: WorkspaceStreamEvent) => void
     }
 
+type CredentialWriteRequest = {
+  name?: string
+  secret?: string
+}
+
+type GitPathsRequest = {
+  paths?: string[]
+}
+
+type GitCommitRequest = {
+  message?: string
+  confirmed?: boolean
+  paths?: string[]
+}
+
 type DocumentPreviewRequest = {
   uri: string
   source: string
   specification?: StructuredSpecification
+  metadata?: SpecificationMetadata
   diffAgainst?: string
 }
 
@@ -210,6 +297,7 @@ export async function startStudio(
       globs: options.specificationGlobs ?? 'features/**/*.feature',
       language: options.language,
     })
+  const git = options.git ?? createGitWorkspace(options.project.root)
   const listeners = new Map<string, Set<(event: StudioStreamEvent) => void>>()
   const buffers = new Map<string, StudioStreamEvent[]>()
   const workspaceListeners = new Set<(event: WorkspaceStreamEvent) => void>()
@@ -319,6 +407,86 @@ export async function startStudio(
       if (url.pathname === '/api/project' && request.method === 'GET') {
         return Response.json(await currentProject())
       }
+      if (url.pathname === '/api/config' && request.method === 'PUT') {
+        if (!options.management) {
+          return new Response('Project configuration is unavailable', {
+            status: 501,
+          })
+        }
+        try {
+          const patch = (await request.json()) as StudioConfigPatch
+          return Response.json(await options.management.saveConfig(patch))
+        } catch (error) {
+          const message = error instanceof Error ? error.message : String(error)
+          return new Response(message, { status: 400 })
+        }
+      }
+      if (url.pathname === '/api/credentials' && request.method === 'PUT') {
+        if (!options.management) {
+          return new Response('Credentials are unavailable', { status: 501 })
+        }
+        try {
+          const body = (await request.json()) as CredentialWriteRequest
+          return Response.json(
+            await options.management.saveCredential({
+              name: body.name ?? '',
+              secret: body.secret ?? '',
+            }),
+          )
+        } catch (error) {
+          const message = error instanceof Error ? error.message : String(error)
+          return new Response(message, { status: 400 })
+        }
+      }
+      if (url.pathname === '/api/run-readiness' && request.method === 'POST') {
+        if (!options.management) {
+          return Response.json(
+            (await currentProject()).readiness ?? { ready: true, reasons: [] },
+          )
+        }
+        const body = (await request
+          .json()
+          .catch(() => ({}))) as StudioRunRequest
+        return Response.json(await options.management.readiness(body))
+      }
+      if (url.pathname === '/api/git' && request.method === 'GET') {
+        return Response.json(await git.status())
+      }
+      if (url.pathname === '/api/git/stage' && request.method === 'POST') {
+        const body = (await request.json()) as GitPathsRequest
+        try {
+          return Response.json(await git.stage(body.paths ?? []))
+        } catch (error) {
+          const message = error instanceof Error ? error.message : String(error)
+          return new Response(message, { status: 400 })
+        }
+      }
+      if (url.pathname === '/api/git/commit' && request.method === 'POST') {
+        const body = (await request.json()) as GitCommitRequest
+        try {
+          return Response.json(
+            await git.commit({
+              message: body.message ?? '',
+              confirmed: Boolean(body.confirmed),
+              paths: body.paths ?? [],
+            }),
+          )
+        } catch (error) {
+          const message = error instanceof Error ? error.message : String(error)
+          return new Response(message, { status: 400 })
+        }
+      }
+      if (
+        url.pathname === '/api/git/pull-request' &&
+        request.method === 'POST'
+      ) {
+        try {
+          return Response.json(await git.pullRequest())
+        } catch (error) {
+          const message = error instanceof Error ? error.message : String(error)
+          return new Response(message, { status: 400 })
+        }
+      }
       if (url.pathname === '/api/documents' && request.method === 'GET') {
         const uri = url.searchParams.get('uri')
         if (!uri) return new Response('Missing uri', { status: 400 })
@@ -346,6 +514,7 @@ export async function startStudio(
               uri: body.uri,
               source: body.source,
               specification: body.specification,
+              metadata: body.metadata,
               diffAgainst: body.diffAgainst,
             }),
           )

--- a/packages/studio/src/settings.tsx
+++ b/packages/studio/src/settings.tsx
@@ -1,0 +1,630 @@
+import { useEffect, useState } from 'react'
+import { Badge } from './components/ui/badge'
+import { Button } from './components/ui/button'
+import { Checkbox } from './components/ui/checkbox'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from './components/ui/dialog'
+import { Input } from './components/ui/input'
+import { Label } from './components/ui/label'
+
+type StudioSuite = {
+  name: string
+  paths?: string | readonly string[]
+  tagExpression?: string
+  states?: readonly string[]
+  scenarioName?: string
+}
+
+type StudioProfile = {
+  id: string
+  adapter: string
+  capabilities?: readonly string[]
+}
+
+type StudioCredential = {
+  name: string
+  present: boolean
+}
+
+type GitFile = {
+  path: string
+  status: string
+  staged: boolean
+  diff: string
+}
+
+type GitStatus = {
+  branch?: string
+  files: GitFile[]
+  pullRequestAvailable: boolean
+  pullRequestReason?: string
+}
+
+const specificationStates = ['draft', 'active', 'deprecated'] as const
+
+function reasonMessage(reason: unknown) {
+  return reason instanceof Error ? reason.message : String(reason)
+}
+
+function pathsText(paths: StudioSuite['paths']): string {
+  if (!paths) return ''
+  if (typeof paths === 'string') return paths
+  return paths.join(', ')
+}
+
+export function SettingsPanel<
+  T extends {
+    suiteDetails?: readonly StudioSuite[]
+    profileDetails?: readonly StudioProfile[]
+    secrets?: readonly StudioCredential[]
+  },
+>(props: {
+  project: T
+  api: <R>(path: string, init?: RequestInit) => Promise<R>
+  onProject: (project: T) => void
+  onError: (message: string | undefined) => void
+}) {
+  const [suiteName, setSuiteName] = useState(
+    props.project.suiteDetails?.[0]?.name ?? '',
+  )
+  const [originalSuiteName, setOriginalSuiteName] = useState(suiteName)
+  const selectedSuite = props.project.suiteDetails?.find(
+    (suite) => suite.name === originalSuiteName,
+  )
+  const [suitePaths, setSuitePaths] = useState(pathsText(selectedSuite?.paths))
+  const [suiteTags, setSuiteTags] = useState(selectedSuite?.tagExpression ?? '')
+  const [suiteStates, setSuiteStates] = useState(
+    (selectedSuite?.states ?? ['active']).join(', '),
+  )
+  const [suiteScenario, setSuiteScenario] = useState(
+    selectedSuite?.scenarioName ?? '',
+  )
+  const [profileId, setProfileId] = useState(
+    props.project.profileDetails?.[0]?.id ?? '',
+  )
+  const selectedProfile =
+    props.project.profileDetails?.find((profile) => profile.id === profileId) ??
+    props.project.profileDetails?.[0]
+  const [adapter, setAdapter] = useState(selectedProfile?.adapter ?? 'custom')
+  const [capabilities, setCapabilities] = useState(
+    (selectedProfile?.capabilities ?? []).join(', '),
+  )
+  const [secretName, setSecretName] = useState('')
+  const [secretValue, setSecretValue] = useState('')
+  const [git, setGit] = useState<GitStatus>()
+  const [selectedPaths, setSelectedPaths] = useState<string[]>([])
+  const [commitMessage, setCommitMessage] = useState('')
+  const [confirmOpen, setConfirmOpen] = useState(false)
+  const [expandedDiff, setExpandedDiff] = useState<string>()
+
+  useEffect(() => {
+    if (!originalSuiteName) {
+      setSuitePaths('')
+      setSuiteTags('')
+      setSuiteStates('active')
+      setSuiteScenario('')
+      return
+    }
+    const suite = props.project.suiteDetails?.find(
+      (item) => item.name === originalSuiteName,
+    )
+    if (!suite) return
+    setSuitePaths(pathsText(suite.paths))
+    setSuiteTags(suite.tagExpression ?? '')
+    setSuiteStates((suite.states ?? ['active']).join(', '))
+    setSuiteScenario(suite.scenarioName ?? '')
+  }, [props.project.suiteDetails, originalSuiteName])
+
+  useEffect(() => {
+    const profile =
+      props.project.profileDetails?.find((item) => item.id === profileId) ??
+      props.project.profileDetails?.[0]
+    setAdapter(profile?.adapter ?? 'custom')
+    setCapabilities((profile?.capabilities ?? []).join(', '))
+  }, [props.project.profileDetails, profileId])
+
+  useEffect(() => {
+    let cancelled = false
+    props
+      .api<GitStatus>('/api/git')
+      .then((value) => {
+        if (!cancelled) setGit(value)
+      })
+      .catch((reason: unknown) => {
+        if (!cancelled) props.onError(reasonMessage(reason))
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [props.api, props.onError])
+
+  async function saveSuites() {
+    const name = suiteName.trim()
+    if (!name) {
+      props.onError('A test suite name is required')
+      return
+    }
+    const suites = Object.fromEntries(
+      (props.project.suiteDetails ?? []).map((suite) => [
+        suite.name,
+        {
+          ...(suite.paths ? { paths: suite.paths } : {}),
+          ...(suite.tagExpression
+            ? { tagExpression: suite.tagExpression }
+            : {}),
+          ...(suite.states ? { states: suite.states } : {}),
+          ...(suite.scenarioName ? { scenarioName: suite.scenarioName } : {}),
+        },
+      ]),
+    )
+    const paths = suitePaths
+      .split(',')
+      .map((path) => path.trim())
+      .filter(Boolean)
+    const states = suiteStates
+      .split(',')
+      .map((state) => state.trim())
+      .filter((state): state is (typeof specificationStates)[number] =>
+        specificationStates.includes(
+          state as (typeof specificationStates)[number],
+        ),
+      )
+    suites[name] = {
+      ...(paths.length ? { paths } : {}),
+      ...(suiteTags.trim() ? { tagExpression: suiteTags.trim() } : {}),
+      ...(states.length ? { states } : {}),
+      ...(suiteScenario.trim() ? { scenarioName: suiteScenario.trim() } : {}),
+    }
+    if (originalSuiteName && originalSuiteName !== name) {
+      delete suites[originalSuiteName]
+    }
+    props.onError(undefined)
+    try {
+      props.onProject(
+        await props.api<T>('/api/config', {
+          method: 'PUT',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify({ suites }),
+        }),
+      )
+      setOriginalSuiteName(name)
+    } catch (reason) {
+      props.onError(reasonMessage(reason))
+    }
+  }
+
+  async function saveProfiles() {
+    const id = profileId.trim()
+    if (!id) {
+      props.onError('An execution target profile id is required')
+      return
+    }
+    const profiles = Object.fromEntries(
+      (props.project.profileDetails ?? []).map((profile) => [
+        profile.id,
+        {
+          adapter: profile.adapter,
+          ...(profile.capabilities
+            ? { capabilities: profile.capabilities }
+            : {}),
+        },
+      ]),
+    )
+    const nextCapabilities = capabilities
+      .split(',')
+      .map((value) => value.trim())
+      .filter(Boolean)
+    profiles[id] = {
+      adapter: adapter.trim() || 'custom',
+      ...(nextCapabilities.length ? { capabilities: nextCapabilities } : {}),
+    }
+    props.onError(undefined)
+    try {
+      props.onProject(
+        await props.api<T>('/api/config', {
+          method: 'PUT',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify({ executionTargetProfiles: profiles }),
+        }),
+      )
+    } catch (reason) {
+      props.onError(reasonMessage(reason))
+    }
+  }
+
+  async function saveCredential() {
+    props.onError(undefined)
+    try {
+      props.onProject(
+        await props.api<T>('/api/credentials', {
+          method: 'PUT',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify({ name: secretName, secret: secretValue }),
+        }),
+      )
+      setSecretValue('')
+    } catch (reason) {
+      props.onError(reasonMessage(reason))
+    }
+  }
+
+  async function refreshGit() {
+    setGit(await props.api<GitStatus>('/api/git'))
+  }
+
+  async function stageSelected() {
+    props.onError(undefined)
+    try {
+      setGit(
+        await props.api<GitStatus>('/api/git/stage', {
+          method: 'POST',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify({ paths: selectedPaths }),
+        }),
+      )
+    } catch (reason) {
+      props.onError(reasonMessage(reason))
+    }
+  }
+
+  async function commitSelected() {
+    props.onError(undefined)
+    try {
+      setGit(
+        await props.api<GitStatus>('/api/git/commit', {
+          method: 'POST',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify({
+            message: commitMessage,
+            confirmed: true,
+            paths: selectedPaths,
+          }),
+        }),
+      )
+      setConfirmOpen(false)
+      setCommitMessage('')
+      setSelectedPaths([])
+    } catch (reason) {
+      props.onError(reasonMessage(reason))
+    }
+  }
+
+  async function openPullRequest() {
+    props.onError(undefined)
+    try {
+      await props.api('/api/git/pull-request', { method: 'POST' })
+      await refreshGit()
+    } catch (reason) {
+      props.onError(reasonMessage(reason))
+    }
+  }
+
+  const secrets: readonly StudioCredential[] = props.project.secrets ?? []
+  const profiles: readonly StudioProfile[] = props.project.profileDetails ?? []
+  const suites: readonly StudioSuite[] = props.project.suiteDetails ?? []
+
+  return (
+    <main className="min-w-0 space-y-8 p-6">
+      <section className="space-y-3" aria-labelledby="suites-heading">
+        <h2 id="suites-heading" className="text-lg font-medium">
+          Test suites
+        </h2>
+        <div className="flex flex-wrap gap-1">
+          {suites.map((suite) => (
+            <Button
+              key={suite.name}
+              type="button"
+              size="sm"
+              variant={suite.name === originalSuiteName ? 'default' : 'outline'}
+              aria-pressed={suite.name === originalSuiteName}
+              onClick={() => {
+                setSuiteName(suite.name)
+                setOriginalSuiteName(suite.name)
+              }}
+            >
+              {suite.name}
+            </Button>
+          ))}
+          <Button
+            type="button"
+            size="sm"
+            variant="outline"
+            onClick={() => {
+              setSuiteName('')
+              setOriginalSuiteName('')
+              setSuitePaths('')
+              setSuiteTags('')
+              setSuiteStates('active')
+              setSuiteScenario('')
+            }}
+          >
+            New test suite
+          </Button>
+        </div>
+        <div className="grid gap-3 sm:grid-cols-2">
+          <div className="space-y-1">
+            <Label htmlFor="suite-name">Suite name</Label>
+            <Input
+              id="suite-name"
+              aria-label="Suite name"
+              value={suiteName}
+              onChange={(event) => setSuiteName(event.target.value)}
+            />
+          </div>
+          <div className="space-y-1">
+            <Label htmlFor="suite-paths">Paths</Label>
+            <Input
+              id="suite-paths"
+              aria-label="Suite paths"
+              value={suitePaths}
+              onChange={(event) => setSuitePaths(event.target.value)}
+            />
+          </div>
+          <div className="space-y-1">
+            <Label htmlFor="suite-tags">Tag expression</Label>
+            <Input
+              id="suite-tags"
+              aria-label="Suite tag expression"
+              value={suiteTags}
+              onChange={(event) => setSuiteTags(event.target.value)}
+            />
+          </div>
+          <div className="space-y-1">
+            <Label htmlFor="suite-states">States</Label>
+            <Input
+              id="suite-states"
+              aria-label="Suite states"
+              value={suiteStates}
+              onChange={(event) => setSuiteStates(event.target.value)}
+            />
+          </div>
+          <div className="space-y-1 sm:col-span-2">
+            <Label htmlFor="suite-scenario">Scenario name</Label>
+            <Input
+              id="suite-scenario"
+              aria-label="Suite scenario name"
+              value={suiteScenario}
+              onChange={(event) => setSuiteScenario(event.target.value)}
+            />
+          </div>
+        </div>
+        <Button type="button" onClick={() => void saveSuites()}>
+          Save test suite
+        </Button>
+      </section>
+
+      <section className="space-y-3" aria-labelledby="profiles-heading">
+        <h2 id="profiles-heading" className="text-lg font-medium">
+          Execution target profiles
+        </h2>
+        <div className="flex flex-wrap gap-1">
+          {profiles.map((profile) => (
+            <Button
+              key={profile.id}
+              type="button"
+              size="sm"
+              variant={profile.id === profileId ? 'default' : 'outline'}
+              aria-pressed={profile.id === profileId}
+              onClick={() => setProfileId(profile.id)}
+            >
+              {profile.id}
+            </Button>
+          ))}
+        </div>
+        <div className="grid gap-3 sm:grid-cols-3">
+          <div className="space-y-1">
+            <Label htmlFor="profile-id">Profile id</Label>
+            <Input
+              id="profile-id"
+              aria-label="Profile id"
+              value={profileId}
+              onChange={(event) => setProfileId(event.target.value)}
+            />
+          </div>
+          <div className="space-y-1">
+            <Label htmlFor="profile-adapter">Adapter</Label>
+            <Input
+              id="profile-adapter"
+              aria-label="Profile adapter"
+              value={adapter}
+              onChange={(event) => setAdapter(event.target.value)}
+            />
+          </div>
+          <div className="space-y-1">
+            <Label htmlFor="profile-capabilities">Capabilities</Label>
+            <Input
+              id="profile-capabilities"
+              aria-label="Profile capabilities"
+              value={capabilities}
+              onChange={(event) => setCapabilities(event.target.value)}
+            />
+          </div>
+        </div>
+        <Button type="button" onClick={() => void saveProfiles()}>
+          Save execution target profile
+        </Button>
+      </section>
+
+      <section className="space-y-3" aria-labelledby="credentials-heading">
+        <h2 id="credentials-heading" className="text-lg font-medium">
+          Credentials
+        </h2>
+        {secrets.length === 0 ? (
+          <p className="text-sm text-muted-foreground">
+            Project configuration stores keychain references only.
+          </p>
+        ) : (
+          <ul aria-label="Credential references" className="space-y-1 text-sm">
+            {secrets.map((secret) => (
+              <li key={secret.name}>
+                {secret.name}
+                {secret.present ? ' (present)' : ' (missing)'}
+              </li>
+            ))}
+          </ul>
+        )}
+        <div className="grid gap-3 sm:grid-cols-2">
+          <div className="space-y-1">
+            <Label htmlFor="credential-name">Credential name</Label>
+            <Input
+              id="credential-name"
+              aria-label="Credential name"
+              value={secretName}
+              onChange={(event) => setSecretName(event.target.value)}
+            />
+          </div>
+          <div className="space-y-1">
+            <Label htmlFor="credential-secret">Secret</Label>
+            <Input
+              id="credential-secret"
+              aria-label="Credential secret"
+              type="password"
+              value={secretValue}
+              onChange={(event) => setSecretValue(event.target.value)}
+            />
+          </div>
+        </div>
+        <Button type="button" onClick={() => void saveCredential()}>
+          Save credential
+        </Button>
+      </section>
+
+      <section className="space-y-3" aria-labelledby="git-heading">
+        <h2 id="git-heading" className="text-lg font-medium">
+          Repository
+        </h2>
+        <p className="font-mono text-xs text-muted-foreground" role="status">
+          {git?.branch ? `Branch ${git.branch}` : 'No Git repository'}
+        </p>
+        {git?.files.length ? (
+          <ul aria-label="Repository changes" className="space-y-2">
+            {git.files.map((file) => (
+              <li
+                key={file.path}
+                className="space-y-1 rounded-md border border-border bg-card p-3"
+              >
+                <div className="flex items-center gap-2">
+                  <Checkbox
+                    id={`git-${file.path}`}
+                    checked={selectedPaths.includes(file.path)}
+                    onCheckedChange={(checked) => {
+                      setSelectedPaths((current) =>
+                        checked
+                          ? [...current, file.path]
+                          : current.filter((path) => path !== file.path),
+                      )
+                    }}
+                  />
+                  <Label htmlFor={`git-${file.path}`} className="font-mono">
+                    {file.path}
+                  </Label>
+                  <Badge>
+                    {file.status}
+                    {file.staged ? ' staged' : ''}
+                  </Badge>
+                </div>
+                <Button
+                  type="button"
+                  size="sm"
+                  variant="outline"
+                  onClick={() =>
+                    setExpandedDiff((current) =>
+                      current === file.path ? undefined : file.path,
+                    )
+                  }
+                >
+                  {expandedDiff === file.path ? 'Hide diff' : 'Show diff'}
+                </Button>
+                {expandedDiff === file.path ? (
+                  <section
+                    aria-label={`${file.path} diff`}
+                    className="max-h-64 overflow-auto"
+                  >
+                    <pre className="font-mono text-xs">
+                      {file.diff || 'No textual diff'}
+                    </pre>
+                  </section>
+                ) : null}
+              </li>
+            ))}
+          </ul>
+        ) : (
+          <p className="text-sm text-muted-foreground">
+            No repository changes.
+          </p>
+        )}
+        <div className="flex flex-wrap gap-2">
+          <Button
+            type="button"
+            variant="outline"
+            disabled={selectedPaths.length === 0}
+            onClick={() => void stageSelected()}
+          >
+            Stage selected
+          </Button>
+          <Button
+            type="button"
+            disabled={!commitMessage.trim() || selectedPaths.length === 0}
+            onClick={() => setConfirmOpen(true)}
+          >
+            Commit selected changes
+          </Button>
+          {git?.pullRequestAvailable ? (
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => void openPullRequest()}
+            >
+              Create pull request
+            </Button>
+          ) : (
+            <p className="text-xs text-muted-foreground">
+              {git?.pullRequestReason ??
+                'Pull request actions use the GitHub CLI when available.'}
+            </p>
+          )}
+        </div>
+        <div className="space-y-1">
+          <Label htmlFor="commit-message">Commit message</Label>
+          <Input
+            id="commit-message"
+            aria-label="Commit message"
+            value={commitMessage}
+            onChange={(event) => setCommitMessage(event.target.value)}
+          />
+        </div>
+      </section>
+
+      <Dialog open={confirmOpen} onOpenChange={setConfirmOpen}>
+        <DialogContent showCloseButton={false}>
+          <DialogHeader>
+            <DialogTitle>Commit selected changes?</DialogTitle>
+            <DialogDescription>
+              Studio will create a local commit. It will not push repository
+              changes.
+            </DialogDescription>
+          </DialogHeader>
+          <p className="font-mono text-xs">{commitMessage}</p>
+          <DialogFooter>
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => setConfirmOpen(false)}
+            >
+              Cancel
+            </Button>
+            <Button type="button" onClick={() => void commitSelected()}>
+              Confirm commit
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </main>
+  )
+}

--- a/packages/studio/src/specification-editor.tsx
+++ b/packages/studio/src/specification-editor.tsx
@@ -13,6 +13,7 @@ import { Label } from './components/ui/label'
 import { Textarea } from './components/ui/textarea'
 import { GherkinEditor } from './gherkin-editor'
 import type { GherkinCatalog } from './gherkin-language'
+import { SpecificationMetadataForm } from './specification-metadata'
 import { SpecificationOutline } from './specification-outline'
 
 export type StructuredStep = {
@@ -126,6 +127,8 @@ function conflictFromReason(reason: unknown): ConflictState | undefined {
 export function SpecificationEditor(props: {
   uri: string
   model?: StudioAuthoringModel
+  namespaces?: readonly string[]
+  linkTemplates?: Readonly<Record<string, string>>
   api: <T>(path: string, init?: RequestInit) => Promise<T>
   onCatalogChange: () => Promise<void>
   onCreated?: (uri: string) => void
@@ -354,7 +357,18 @@ export function SpecificationEditor(props: {
         )}
       </div>
       {mode === 'view' ? (
-        <SpecificationOutline specification={buffer.specification} />
+        <>
+          <SpecificationMetadataForm
+            buffer={buffer}
+            namespaces={props.namespaces ?? []}
+            templates={props.linkTemplates}
+            api={props.api}
+            onReview={setReview}
+            onWrite={write}
+            onError={props.onError}
+          />
+          <SpecificationOutline specification={buffer.specification} />
+        </>
       ) : (
         <div className="space-y-3">
           <GherkinEditor

--- a/packages/studio/src/specification-editor.tsx
+++ b/packages/studio/src/specification-editor.tsx
@@ -133,6 +133,7 @@ export function SpecificationEditor(props: {
   onCatalogChange: () => Promise<void>
   onCreated?: (uri: string) => void
   onError: (message: string | undefined) => void
+  onModeChange?: (mode: 'view' | 'edit') => void
 }) {
   const [mode, setMode] = useState<'view' | 'edit'>('view')
   const [buffer, setBuffer] = useState<SpecificationBuffer>()
@@ -165,12 +166,20 @@ export function SpecificationEditor(props: {
   const loadRef = useRef(load)
   const catalogRef = useRef(props.onCatalogChange)
   const errorRef = useRef(props.onError)
+  const modeChangeRef = useRef(props.onModeChange)
   loadRef.current = load
   catalogRef.current = props.onCatalogChange
   errorRef.current = props.onError
+  modeChangeRef.current = props.onModeChange
+
+  function setEditorMode(next: 'view' | 'edit') {
+    setMode(next)
+    modeChangeRef.current?.(next)
+  }
 
   useEffect(() => {
     setMode('view')
+    modeChangeRef.current?.('view')
     let cancelled = false
     void loadRef.current(props.uri).catch((reason: unknown) => {
       if (!cancelled) errorRef.current(reasonMessage(reason))
@@ -298,7 +307,7 @@ export function SpecificationEditor(props: {
       setDiscardOpen(true)
       return
     }
-    setMode('view')
+    setEditorMode('view')
   }
 
   function discardEdits() {
@@ -306,7 +315,7 @@ export function SpecificationEditor(props: {
     setSource(buffer.source)
     setSavedSource(buffer.source)
     setDiscardOpen(false)
-    setMode('view')
+    setEditorMode('view')
   }
 
   if (!buffer) {
@@ -316,7 +325,11 @@ export function SpecificationEditor(props: {
   }
 
   return (
-    <div className="space-y-3">
+    <div
+      className={
+        mode === 'edit' ? 'flex min-h-0 flex-1 flex-col gap-3' : 'space-y-3'
+      }
+    >
       <div className="flex flex-wrap items-center justify-between gap-2">
         <div className="flex flex-wrap items-center gap-x-3 gap-y-1">
           <p
@@ -341,7 +354,7 @@ export function SpecificationEditor(props: {
           <Button
             type="button"
             variant="outline"
-            onClick={() => setMode('edit')}
+            onClick={() => setEditorMode('edit')}
           >
             Edit Specification
           </Button>
@@ -359,6 +372,7 @@ export function SpecificationEditor(props: {
       {mode === 'view' ? (
         <>
           <SpecificationMetadataForm
+            key={buffer.uri}
             buffer={buffer}
             namespaces={props.namespaces ?? []}
             templates={props.linkTemplates}
@@ -370,7 +384,7 @@ export function SpecificationEditor(props: {
           <SpecificationOutline specification={buffer.specification} />
         </>
       ) : (
-        <div className="space-y-3">
+        <div className="flex min-h-0 flex-1 flex-col gap-3">
           <GherkinEditor
             source={source}
             catalog={catalog}

--- a/packages/studio/src/specification-metadata.tsx
+++ b/packages/studio/src/specification-metadata.tsx
@@ -1,0 +1,234 @@
+import { useEffect, useState } from 'react'
+import { Button } from './components/ui/button'
+import { Input } from './components/ui/input'
+import { Label } from './components/ui/label'
+import type {
+  SpecificationBuffer,
+  SpecificationPreview,
+} from './specification-editor'
+
+const specificationStates = ['draft', 'active', 'deprecated'] as const
+type SpecificationState = (typeof specificationStates)[number]
+
+type ExternalLink = { namespace: string; id: string }
+
+function parseState(tags: readonly string[]): SpecificationState {
+  const tag = tags.find((value) => value.startsWith('@pickle:state:'))
+  const state = tag?.slice('@pickle:state:'.length)
+  return specificationStates.find((value) => value === state) ?? 'active'
+}
+
+function parseAuthorTags(
+  tags: readonly string[],
+  namespaces: readonly string[],
+) {
+  return tags.filter((tag) => {
+    if (tag.startsWith('@pickle:')) return false
+    return !namespaces.some(
+      (namespace) => namespace && tag.startsWith(`@${namespace}:`),
+    )
+  })
+}
+
+function parseLinks(
+  tags: readonly string[],
+  namespaces: readonly string[],
+): ExternalLink[] {
+  const links: ExternalLink[] = []
+  for (const tag of tags) {
+    for (const namespace of namespaces) {
+      const prefix = `@${namespace}:`
+      if (tag.startsWith(prefix) && tag.length > prefix.length) {
+        links.push({ namespace, id: tag.slice(prefix.length) })
+      }
+    }
+  }
+  return links
+}
+
+function reasonMessage(reason: unknown) {
+  return reason instanceof Error ? reason.message : String(reason)
+}
+
+export function SpecificationMetadataForm(props: {
+  buffer: SpecificationBuffer
+  namespaces: readonly string[]
+  templates?: Readonly<Record<string, string>>
+  api: <T>(path: string, init?: RequestInit) => Promise<T>
+  onReview: (input: {
+    title: string
+    description: string
+    diff: string
+    confirmLabel: string
+    onConfirm: () => Promise<void>
+  }) => void
+  onWrite: (source: string) => Promise<void>
+  onError: (message: string | undefined) => void
+}) {
+  const tags = props.buffer.specification.tags
+  const [state, setState] = useState<SpecificationState>(() => parseState(tags))
+  const [tagText, setTagText] = useState(() =>
+    parseAuthorTags(tags, props.namespaces).join(' '),
+  )
+  const [links, setLinks] = useState<ExternalLink[]>(() =>
+    parseLinks(tags, props.namespaces),
+  )
+  const [namespace, setNamespace] = useState(props.namespaces[0] ?? '')
+  const [linkId, setLinkId] = useState('')
+
+  useEffect(() => {
+    const nextTags = props.buffer.specification.tags
+    setState(parseState(nextTags))
+    setTagText(parseAuthorTags(nextTags, props.namespaces).join(' '))
+    setLinks(parseLinks(nextTags, props.namespaces))
+  }, [props.buffer, props.namespaces])
+
+  async function save() {
+    props.onError(undefined)
+    try {
+      const preview = await props.api<SpecificationPreview>(
+        '/api/documents/preview',
+        {
+          method: 'POST',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify({
+            uri: props.buffer.uri,
+            source: props.buffer.source,
+            metadata: {
+              state,
+              tags: tagText
+                .split(/\s+/)
+                .map((tag) => tag.trim())
+                .filter(Boolean),
+              links,
+            },
+          }),
+        },
+      )
+      if (!preview.diff) return
+      props.onReview({
+        title: 'Review Specification metadata',
+        description:
+          'State, tags, and external links update Gherkin tags. Confirm to write the Specification.',
+        diff: preview.diff,
+        confirmLabel: 'Save metadata',
+        onConfirm: () => props.onWrite(preview.source),
+      })
+    } catch (reason) {
+      props.onError(reasonMessage(reason))
+    }
+  }
+
+  return (
+    <section
+      aria-label="Specification metadata"
+      className="space-y-3 rounded-lg border border-border bg-card px-4 py-3"
+    >
+      <div className="space-y-1">
+        <p className="text-xs text-muted-foreground">Specification state</p>
+        <div className="flex flex-wrap gap-1">
+          {specificationStates.map((value) => (
+            <Button
+              key={value}
+              type="button"
+              size="sm"
+              variant={state === value ? 'default' : 'outline'}
+              aria-pressed={state === value}
+              onClick={() => setState(value)}
+            >
+              {value}
+            </Button>
+          ))}
+        </div>
+      </div>
+      <div className="space-y-1">
+        <Label htmlFor="specification-tags">Tags</Label>
+        <Input
+          id="specification-tags"
+          aria-label="Specification tags"
+          value={tagText}
+          onChange={(event) => setTagText(event.target.value)}
+        />
+      </div>
+      <div className="space-y-2">
+        <p className="text-xs text-muted-foreground">External links</p>
+        {links.length === 0 ? (
+          <p className="text-xs text-muted-foreground">None yet.</p>
+        ) : (
+          <ul aria-label="External links" className="space-y-1">
+            {links.map((link) => {
+              const template = props.templates?.[link.namespace]
+              const href = template
+                ? template.replaceAll('{id}', link.id)
+                : undefined
+              return (
+                <li
+                  key={`${link.namespace}:${link.id}`}
+                  className="flex items-center justify-between gap-2 font-mono text-xs"
+                >
+                  {href ? (
+                    <Button variant="link" render={<a href={href} />}>
+                      {link.namespace}:{link.id}
+                    </Button>
+                  ) : (
+                    <span>
+                      {link.namespace}:{link.id}
+                    </span>
+                  )}
+                  <Button
+                    type="button"
+                    size="sm"
+                    variant="outline"
+                    aria-label={`Remove ${link.namespace}:${link.id}`}
+                    onClick={() =>
+                      setLinks((current) =>
+                        current.filter(
+                          (item) =>
+                            item.namespace !== link.namespace ||
+                            item.id !== link.id,
+                        ),
+                      )
+                    }
+                  >
+                    Remove
+                  </Button>
+                </li>
+              )
+            })}
+          </ul>
+        )}
+        <div className="grid gap-2 sm:grid-cols-[1fr_1fr_auto]">
+          <Input
+            aria-label="Link namespace"
+            placeholder="jira"
+            value={namespace}
+            onChange={(event) => setNamespace(event.target.value)}
+          />
+          <Input
+            aria-label="Link id"
+            placeholder="PROJ-12"
+            value={linkId}
+            onChange={(event) => setLinkId(event.target.value)}
+          />
+          <Button
+            type="button"
+            variant="outline"
+            disabled={!namespace.trim() || !linkId.trim()}
+            onClick={() => {
+              setLinks((current) => [
+                ...current,
+                { namespace: namespace.trim(), id: linkId.trim() },
+              ])
+              setLinkId('')
+            }}
+          >
+            Add link
+          </Button>
+        </div>
+      </div>
+      <Button type="button" onClick={() => void save()}>
+        Save metadata
+      </Button>
+    </section>
+  )
+}

--- a/packages/studio/src/specification-metadata.tsx
+++ b/packages/studio/src/specification-metadata.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react'
+import { Badge } from './components/ui/badge'
 import { Button } from './components/ui/button'
 import { Input } from './components/ui/input'
 import { Label } from './components/ui/label'
@@ -50,6 +51,20 @@ function reasonMessage(reason: unknown) {
   return reason instanceof Error ? reason.message : String(reason)
 }
 
+function LinkLabel(props: { link: ExternalLink; href?: string }) {
+  const label = `${props.link.namespace}:${props.link.id}`
+  if (!props.href) return <span className="font-mono text-xs">{label}</span>
+  return (
+    <Button
+      variant="link"
+      className="h-auto px-0"
+      render={<a href={props.href} />}
+    >
+      {label}
+    </Button>
+  )
+}
+
 export function SpecificationMetadataForm(props: {
   buffer: SpecificationBuffer
   namespaces: readonly string[]
@@ -66,6 +81,7 @@ export function SpecificationMetadataForm(props: {
   onError: (message: string | undefined) => void
 }) {
   const tags = props.buffer.specification.tags
+  const [editing, setEditing] = useState(false)
   const [state, setState] = useState<SpecificationState>(() => parseState(tags))
   const [tagText, setTagText] = useState(() =>
     parseAuthorTags(tags, props.namespaces).join(' '),
@@ -105,41 +121,91 @@ export function SpecificationMetadataForm(props: {
           }),
         },
       )
-      if (!preview.diff) return
+      if (!preview.diff) {
+        setEditing(false)
+        return
+      }
       props.onReview({
         title: 'Review Specification metadata',
         description:
           'State, tags, and external links update Gherkin tags. Confirm to write the Specification.',
         diff: preview.diff,
         confirmLabel: 'Save metadata',
-        onConfirm: () => props.onWrite(preview.source),
+        onConfirm: async () => {
+          await props.onWrite(preview.source)
+          setEditing(false)
+        },
       })
     } catch (reason) {
       props.onError(reasonMessage(reason))
     }
   }
 
+  const authorTags = tagText
+    .split(/\s+/)
+    .map((tag) => tag.trim())
+    .filter(Boolean)
+
+  if (!editing) {
+    return (
+      <section
+        aria-label="Specification metadata"
+        className="flex min-w-0 flex-wrap items-center gap-x-3 gap-y-1"
+      >
+        <Badge>{state}</Badge>
+        {authorTags.length > 0 ? (
+          <p className="min-w-0 truncate font-mono text-[0.625rem] leading-4 text-muted-foreground">
+            {authorTags.join(' ')}
+          </p>
+        ) : null}
+        {links.length > 0 ? (
+          <ul
+            aria-label="External links"
+            className="flex flex-wrap items-center gap-x-2"
+          >
+            {links.map((link) => {
+              const template = props.templates?.[link.namespace]
+              const href = template
+                ? template.replaceAll('{id}', link.id)
+                : undefined
+              return (
+                <li key={`${link.namespace}:${link.id}`}>
+                  <LinkLabel link={link} href={href} />
+                </li>
+              )
+            })}
+          </ul>
+        ) : null}
+        <Button
+          type="button"
+          size="sm"
+          variant="outline"
+          onClick={() => setEditing(true)}
+        >
+          Edit metadata
+        </Button>
+      </section>
+    )
+  }
+
   return (
     <section
       aria-label="Specification metadata"
-      className="space-y-3 rounded-lg border border-border bg-card px-4 py-3"
+      className="space-y-3 rounded-lg border border-border bg-card px-3 py-2"
     >
-      <div className="space-y-1">
-        <p className="text-xs text-muted-foreground">Specification state</p>
-        <div className="flex flex-wrap gap-1">
-          {specificationStates.map((value) => (
-            <Button
-              key={value}
-              type="button"
-              size="sm"
-              variant={state === value ? 'default' : 'outline'}
-              aria-pressed={state === value}
-              onClick={() => setState(value)}
-            >
-              {value}
-            </Button>
-          ))}
-        </div>
+      <div className="flex flex-wrap gap-1">
+        {specificationStates.map((value) => (
+          <Button
+            key={value}
+            type="button"
+            size="sm"
+            variant={state === value ? 'default' : 'outline'}
+            aria-pressed={state === value}
+            onClick={() => setState(value)}
+          >
+            {value}
+          </Button>
+        ))}
       </div>
       <div className="space-y-1">
         <Label htmlFor="specification-tags">Tags</Label>
@@ -151,10 +217,7 @@ export function SpecificationMetadataForm(props: {
         />
       </div>
       <div className="space-y-2">
-        <p className="text-xs text-muted-foreground">External links</p>
-        {links.length === 0 ? (
-          <p className="text-xs text-muted-foreground">None yet.</p>
-        ) : (
+        {links.length === 0 ? null : (
           <ul aria-label="External links" className="space-y-1">
             {links.map((link) => {
               const template = props.templates?.[link.namespace]
@@ -166,15 +229,7 @@ export function SpecificationMetadataForm(props: {
                   key={`${link.namespace}:${link.id}`}
                   className="flex items-center justify-between gap-2 font-mono text-xs"
                 >
-                  {href ? (
-                    <Button variant="link" render={<a href={href} />}>
-                      {link.namespace}:{link.id}
-                    </Button>
-                  ) : (
-                    <span>
-                      {link.namespace}:{link.id}
-                    </span>
-                  )}
+                  <LinkLabel link={link} href={href} />
                   <Button
                     type="button"
                     size="sm"
@@ -226,9 +281,18 @@ export function SpecificationMetadataForm(props: {
           </Button>
         </div>
       </div>
-      <Button type="button" onClick={() => void save()}>
-        Save metadata
-      </Button>
+      <div className="flex flex-wrap gap-2">
+        <Button
+          type="button"
+          variant="outline"
+          onClick={() => setEditing(false)}
+        >
+          Cancel
+        </Button>
+        <Button type="button" onClick={() => void save()}>
+          Save metadata
+        </Button>
+      </div>
     </section>
   )
 }

--- a/packages/studio/src/specification-outline.tsx
+++ b/packages/studio/src/specification-outline.tsx
@@ -1,4 +1,10 @@
 // biome-ignore-all lint/suspicious/noArrayIndexKey: Gherkin children are ordered and may share names
+import { Button } from './components/ui/button'
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from './components/ui/collapsible'
 import type {
   StructuredChild,
   StructuredSpecification,
@@ -23,12 +29,21 @@ function OutlineName(props: { name: string }) {
   return <span className="text-sm">{props.name}</span>
 }
 
+function scenarioNames(items: readonly StructuredChild[]): string[] {
+  const names: string[] = []
+  for (const child of items) {
+    if (child.kind === 'rule') names.push(...scenarioNames(child.children))
+    if (child.kind === 'scenario' && child.name) names.push(child.name)
+  }
+  return names
+}
+
 function OutlineRows(props: {
   items: readonly StructuredChild[]
   depth: number
 }) {
   return (
-    <ol className={props.depth > 0 ? 'space-y-2 pl-4' : 'space-y-2'}>
+    <ol className={props.depth > 0 ? 'space-y-1 pl-4' : 'space-y-1'}>
       {props.items.map((child, index) => (
         <li key={`${child.kind}-${child.name}-${index}`} className="space-y-1">
           {child.kind === 'rule' ? (
@@ -79,21 +94,27 @@ function OutlineRows(props: {
 export function SpecificationOutline(props: {
   specification: StructuredSpecification
 }) {
+  const names = scenarioNames(props.specification.children)
   return (
-    <section
-      aria-label="Specification outline"
-      className="space-y-3 rounded-lg border border-border bg-card px-4 py-3"
-    >
-      <div className="space-y-1">
-        <div className="flex flex-wrap items-baseline gap-x-2 gap-y-0.5">
-          <span className="text-xs text-muted-foreground">Feature</span>
-          <span className="text-sm font-medium">
-            {props.specification.name}
-          </span>
-        </div>
-        <TagList tags={props.specification.tags} />
+    <section aria-label="Specification outline" className="space-y-1">
+      <div className="flex flex-wrap items-baseline gap-x-2 gap-y-0.5">
+        <span className="text-xs text-muted-foreground">Feature</span>
+        <span className="text-sm font-medium">{props.specification.name}</span>
       </div>
-      <OutlineRows items={props.specification.children} depth={0} />
+      <TagList tags={props.specification.tags} />
+      {names.length > 0 ? (
+        <p className="text-sm text-muted-foreground">{names.join(' · ')}</p>
+      ) : null}
+      <Collapsible>
+        <CollapsibleTrigger
+          render={<Button type="button" size="sm" variant="outline" />}
+        >
+          Show structure
+        </CollapsibleTrigger>
+        <CollapsibleContent className="pt-2">
+          <OutlineRows items={props.specification.children} depth={0} />
+        </CollapsibleContent>
+      </Collapsible>
     </section>
   )
 }


### PR DESCRIPTION
## Summary
- Studio Settings can create and edit named suite queries, execution target profiles, and capabilities, store credentials in the keychain as config references, and stage or commit selected Git changes locally without pushing.
- Operators can edit Specification state, tags, and external links; Studio withholds Run until the current selection is valid, and pull-request actions use `gh pr create --web` when a GitHub remote and upstream already exist.
- The Specification screen is diagnosis-first: a compact header for identity, metadata, and outline, with the Scenario table as the main pane.

## Test plan
- [ ] Open Studio and edit Specification state, tags, and an external link; confirm the source-diff dialog before write
- [ ] In Settings, create two named suites and an execution target profile with capabilities
- [ ] Confirm Run is hidden until required capabilities (and credentials, if web) are present
- [ ] Store a credential and confirm `pickle.config.jsonc` has only a `{ keychain }` reference
- [ ] Stage and commit a selected file after confirmation; confirm nothing is pushed
- [ ] On the Specification screen, confirm the Scenario table leads and Edit Specification still opens Gherkin


Made with [Cursor](https://cursor.com)