### PR TITLE
Add iOS mobile adapter and simulator execution support

### DIFF
--- a/packages/mobile/README.md
+++ b/packages/mobile/README.md
@@ -1,8 +1,8 @@
 # `@pickle-spec/mobile`
 
-The mobile adapter runs Android Emulator scenarios through a versioned Node
-worker. The Bun runner remains runtime-independent, and `agent-device` types
-stay inside the worker.
+The mobile adapter runs Android Emulator and iOS Simulator scenarios through a
+versioned Node worker. The Bun runner remains runtime-independent, and
+`agent-device` types stay inside the worker.
 
 ## Real-emulator smoke test
 
@@ -28,3 +28,59 @@ Set `PICKLE_ANDROID_TARGET_ID=emulator-5554` when more than one emulator is
 booted. The adapter uses `agent-device reinstall` semantics before every
 logical session, so the selected application's existing emulator data is
 deleted and the configured binary is installed fresh.
+
+## Real iOS Simulator smoke test
+
+The iOS smoke test is also optional and skipped by default. It requires:
+
+- macOS with Xcode and Xcode Command Line Tools installed;
+- Node 22.12 or newer on `PATH`, or an absolute `PICKLE_NODE_PATH`;
+- a booted iOS Simulator visible to `agent-device doctor`;
+- an installable `.app` or `.ipa` and its bundle identifier;
+- visible text that the installed application should show after launch.
+
+Run it from the repository root:
+
+```sh
+PICKLE_IOS_SMOKE=1 \
+PICKLE_IOS_APP_ID=com.example.checkout \
+PICKLE_IOS_APP_PATH=/absolute/path/to/Checkout.app \
+PICKLE_IOS_SMOKE_STEP='Checkout' \
+bun test packages/mobile/src/ios-simulator.smoke.test.ts
+```
+
+Set `PICKLE_IOS_TARGET_ID` to a Simulator UDID when more than one compatible
+Simulator is booted. The adapter reinstalls and verifies the configured bundle
+for every logical session. Physical-device provisioning remains outside this
+release.
+
+## Test evidence and redaction
+
+Set `artifactDirectory` and choose the evidence kinds to capture with
+`artifacts`: `screenshot`, `device-log`, `recording`, or `trace`. The adapter
+checks the selected Simulator or Emulator capabilities before installation and
+rejects unsupported evidence or Scenario capability requirements.
+
+Text logs can be redacted before Pickle Spec persists them:
+
+```ts
+createMobileAdapter({
+  executionTarget: 'ios-simulator',
+  application: {
+    id: 'com.example.checkout',
+    binaryPath: '/absolute/path/to/Checkout.app',
+  },
+  artifactDirectory: '/absolute/path/to/test-artifacts',
+  artifacts: ['device-log'],
+  redactions: [
+    { match: 'secret-value' },
+    { match: 'customer@example.com', replacement: '[EMAIL]' },
+  ],
+})
+```
+
+Redaction matches literal text and defaults the replacement to `[REDACTED]`.
+Screenshots, recordings, and traces are binary and cannot use text redaction;
+the adapter rejects a session that combines those evidence kinds with text
+redaction rules. Binary evidence stays local in the explicitly configured
+artifact directory.

--- a/packages/mobile/index.ts
+++ b/packages/mobile/index.ts
@@ -1,10 +1,17 @@
 export type {
   AndroidApplication,
+  AndroidMobileAdapterOptions,
   AndroidTarget,
+  IosApplication,
+  IosMobileAdapterOptions,
+  IosTarget,
   MobileAdapterOptions,
+  MobileArtifactKind,
   MobileExecutionTargetAdapter,
+  MobileTextRedaction,
 } from './src/mobile-adapter'
 export {
   androidCapabilities,
   createMobileAdapter,
+  iosCapabilities,
 } from './src/mobile-adapter'

--- a/packages/mobile/src/agent-device-client.ts
+++ b/packages/mobile/src/agent-device-client.ts
@@ -1,10 +1,11 @@
 import { createAgentDeviceClient, isAgentDeviceError } from 'agent-device'
 import { z } from 'zod'
+import type { MobilePlatform } from './worker-protocol'
 
 export interface AgentDeviceClientConfig {
   session: string
   lockPolicy: 'reject'
-  lockPlatform: 'android'
+  lockPlatform: MobilePlatform
 }
 
 export interface AndroidSelection {
@@ -12,35 +13,51 @@ export interface AndroidSelection {
   serial: string
 }
 
-interface AppDeployOptions extends AndroidSelection {
+export interface IosSelection {
+  platform: 'ios'
+  udid: string
+}
+
+export type MobileSelection = AndroidSelection | IosSelection
+
+type AppDeployOptions = MobileSelection & {
   app: string
   appPath: string
 }
 
-interface AppOpenOptions extends AndroidSelection {
+type AppOpenOptions = MobileSelection & {
   app: string
 }
 
-interface WaitOptions extends AndroidSelection {
+type WaitOptions = MobileSelection & {
   text: string
 }
 
-interface FindOptions extends AndroidSelection {
+type FindOptions = MobileSelection & {
   query: string
   action: 'click'
 }
 
+interface LogsOptions {
+  action: 'start' | 'stop' | 'path'
+}
+
+interface RecordingOptions {
+  action: 'start' | 'stop'
+  path?: string
+}
+
 export interface AgentDeviceClientPort {
   devices: {
-    list(options: { platform: 'android' }): Promise<unknown>
-    capabilities(options: AndroidSelection): Promise<unknown>
+    list(options: { platform: MobilePlatform }): Promise<unknown>
+    capabilities(options: MobileSelection): Promise<unknown>
   }
   apps: {
     reinstall(options: AppDeployOptions): Promise<unknown>
     open(options: AppOpenOptions): Promise<unknown>
   }
   command: {
-    appState(options: AndroidSelection): Promise<unknown>
+    appState(options: MobileSelection): Promise<unknown>
     wait(options: WaitOptions): Promise<unknown>
   }
   interactions: {
@@ -48,6 +65,13 @@ export interface AgentDeviceClientPort {
   }
   capture: {
     screenshot(options: { path?: string }): Promise<unknown>
+  }
+  observability: {
+    logs(options: LogsOptions): Promise<unknown>
+  }
+  recording: {
+    record(options: RecordingOptions): Promise<unknown>
+    trace(options: RecordingOptions): Promise<unknown>
   }
   sessions: {
     close(): Promise<unknown>
@@ -69,22 +93,57 @@ const androidDeviceSchema = z.strictObject({
   android: z.strictObject({ serial: z.string().min(1) }),
 })
 
-export const androidDevicesSchema = z.array(androidDeviceSchema)
+const iosDeviceSchema = z.strictObject({
+  platform: z.literal('ios'),
+  target: z.literal('mobile'),
+  kind: z.enum(['simulator', 'device']),
+  id: z.string().min(1),
+  name: z.string().min(1),
+  booted: z.boolean().optional(),
+  appleOs: z.enum(['ios', 'ipados']).optional(),
+  identifiers: z.record(z.string(), z.unknown()),
+  ios: z.strictObject({ udid: z.string().min(1) }),
+})
+
+const mobileDeviceSchema = z.discriminatedUnion('platform', [
+  androidDeviceSchema,
+  iosDeviceSchema,
+])
+
+export const mobileDevicesSchema = z.array(mobileDeviceSchema)
+
+export type AgentDeviceDevice = z.infer<typeof mobileDeviceSchema>
 
 export const agentDeviceCapabilitiesSchema = z.strictObject({
-  device: androidDeviceSchema,
+  device: mobileDeviceSchema,
   availableCommands: z.array(z.string()),
 })
 
-export const androidAppStateSchema = z.strictObject({
+const androidAppStateSchema = z.strictObject({
   platform: z.literal('android'),
   package: z.string(),
   activity: z.string(),
 })
 
+export const mobileAppStateSchema = z.discriminatedUnion('platform', [
+  androidAppStateSchema,
+  z.object({
+    platform: z.literal('ios'),
+    appName: z.string(),
+    appBundleId: z.string().optional(),
+    source: z.literal('session'),
+    surface: z.string(),
+  }),
+])
+
+export const agentDeviceLogPathSchema = z.object({
+  path: z.string().min(1),
+})
+
 const functionalFailureCodes = new Set([
   'AMBIGUOUS_MATCH',
-  'COMMAND_FAILED',
+  'ELEMENT_NOT_FOUND',
+  'ELEMENT_OFFSCREEN',
   'REPLAY_DIVERGENCE',
 ])
 

--- a/packages/mobile/src/agent-device-gateway.test.ts
+++ b/packages/mobile/src/agent-device-gateway.test.ts
@@ -1,4 +1,9 @@
 import { expect, mock, test } from 'bun:test'
+import { mkdtemp, readFile, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { AppError } from 'agent-device'
+import { isFunctionalAgentDeviceFailure } from './agent-device-client'
 import {
   type AgentDeviceClientPort,
   AgentDeviceGateway,
@@ -15,6 +20,18 @@ const androidEmulator = {
   android: { serial: 'emulator-5554' },
 }
 
+const iosSimulator = {
+  platform: 'ios',
+  target: 'mobile',
+  kind: 'simulator',
+  id: 'F2D95476-0A9E-4A8C-9F48-8C77B2F5B8D0',
+  name: 'iPhone 16 Pro',
+  booted: true,
+  appleOs: 'ios',
+  identifiers: {},
+  ios: { udid: 'F2D95476-0A9E-4A8C-9F48-8C77B2F5B8D0' },
+}
+
 const application = {
   id: 'com.example.checkout',
   binaryPath: '/tmp/checkout.apk',
@@ -24,6 +41,14 @@ const runningAppState = {
   platform: 'android',
   package: application.id,
   activity: '.MainActivity',
+}
+
+const runningIosAppState = {
+  platform: 'ios',
+  appName: 'Checkout',
+  appBundleId: application.id,
+  source: 'session',
+  surface: 'app',
 }
 
 interface OpenTestSessionOptions {
@@ -61,6 +86,19 @@ function fakeClient(
         return { path: options.path ?? '' }
       },
     },
+    observability: {
+      async logs() {
+        throw new Error('Unexpected logs request')
+      },
+    },
+    recording: {
+      async record() {
+        throw new Error('Unexpected recording request')
+      },
+      async trace() {
+        throw new Error('Unexpected trace request')
+      },
+    },
     sessions: {
       async close() {},
     },
@@ -77,7 +115,10 @@ function emulatorClient(
         return [androidEmulator]
       },
       async capabilities() {
-        throw new Error('Unexpected capabilities request')
+        return {
+          device: androidEmulator,
+          availableCommands: ['screenshot'],
+        }
       },
     },
     command: {
@@ -145,6 +186,53 @@ test('discovers compatible Android Emulator targets and normalizes capabilities'
   expect(close).toHaveBeenCalledTimes(1)
 })
 
+test('discovers compatible iOS Simulator targets and normalizes supported evidence', async () => {
+  const close = mock(async () => {})
+  const capabilities = mock(async () => ({
+    device: iosSimulator,
+    availableCommands: ['snapshot', 'screenshot', 'logs', 'record', 'find'],
+  }))
+  const client = fakeClient({
+    devices: {
+      async list() {
+        return [
+          iosSimulator,
+          {
+            ...iosSimulator,
+            kind: 'device',
+            id: 'physical-ios-1',
+            name: 'Physical iPhone',
+            ios: { udid: 'physical-ios-1' },
+          },
+        ]
+      },
+      capabilities,
+    },
+    sessions: { close },
+  })
+  const gateway = new AgentDeviceGateway(() => client)
+
+  expect(await gateway.discoverTargets('ios')).toEqual([
+    {
+      id: iosSimulator.id,
+      name: iosSimulator.name,
+      state: 'booted',
+      capabilities: [
+        'ios',
+        'ios-simulator',
+        'screenshots',
+        'device-logs',
+        'recordings',
+      ],
+    },
+  ])
+  expect(capabilities).toHaveBeenCalledWith({
+    platform: 'ios',
+    udid: iosSimulator.ios.udid,
+  })
+  expect(close).toHaveBeenCalledTimes(1)
+})
+
 test('reinstalls, opens, and verifies the configured application for a logical session', async () => {
   const reinstall = mock(async () => {})
   const open = mock(async () => {})
@@ -176,6 +264,49 @@ test('reinstalls, opens, and verifies the configured application for a logical s
   expect(appState).toHaveBeenCalledWith({
     platform: 'android',
     serial: androidEmulator.android.serial,
+  })
+})
+
+test('reinstalls, opens, and verifies an iOS application for a logical session', async () => {
+  const reinstall = mock(async () => {})
+  const open = mock(async () => {})
+  const appState = mock(async () => runningIosAppState)
+  const client = fakeClient({
+    devices: {
+      async list() {
+        return [iosSimulator]
+      },
+      async capabilities() {
+        throw new Error('Unexpected capabilities request')
+      },
+    },
+    apps: { reinstall, open },
+    command: { appState, async wait() {} },
+  })
+  const gateway = new AgentDeviceGateway(() => client)
+
+  await expect(
+    gateway.openSession({
+      sessionId: 'session-1',
+      platform: 'ios',
+      targetId: iosSimulator.id,
+      application,
+    }),
+  ).resolves.toEqual({ targetId: iosSimulator.id })
+  expect(reinstall).toHaveBeenCalledWith({
+    app: application.id,
+    appPath: application.binaryPath,
+    platform: 'ios',
+    udid: iosSimulator.ios.udid,
+  })
+  expect(open).toHaveBeenCalledWith({
+    app: application.id,
+    platform: 'ios',
+    udid: iosSimulator.ios.udid,
+  })
+  expect(appState).toHaveBeenCalledWith({
+    platform: 'ios',
+    udid: iosSimulator.ios.udid,
   })
 })
 
@@ -337,6 +468,124 @@ test('classifies unexpected worker and device errors as infrastructure errors', 
   })
 })
 
+test('normalizes iOS device errors into the common infrastructure-error model', async () => {
+  const gateway = new AgentDeviceGateway(() =>
+    fakeClient({
+      devices: {
+        async list() {
+          return [iosSimulator]
+        },
+        async capabilities() {
+          throw new Error('Unexpected capabilities request')
+        },
+      },
+      command: {
+        async appState() {
+          return runningIosAppState
+        },
+        async wait() {},
+      },
+      interactions: {
+        async find() {
+          throw new AppError('COMMAND_FAILED', 'XCTest runner disconnected', {
+            reason: 'IOS_RUNNER_CONNECT_TIMEOUT',
+            retriable: true,
+          })
+        },
+      },
+    }),
+  )
+  await gateway.openSession({
+    sessionId: 'session-1',
+    platform: 'ios',
+    application,
+  })
+
+  await expect(
+    gateway.executeStep({
+      sessionId: 'session-1',
+      stepIndex: 0,
+      step: { type: 'action', text: 'Pay now' },
+    }),
+  ).resolves.toEqual({
+    state: 'infrastructure-error',
+    resolvedActions: [],
+    message: 'XCTest runner disconnected',
+  })
+})
+
+test('classifies unannotated daemon and iOS runner command failures as infrastructure', () => {
+  for (const message of [
+    'Daemon request timed out',
+    'Failed to communicate with daemon',
+    'Remote daemon is unavailable',
+    'Runner did not accept connection',
+    'Invalid runner response',
+  ]) {
+    expect(
+      isFunctionalAgentDeviceFailure(new AppError('COMMAND_FAILED', message)),
+    ).toBe(false)
+  }
+})
+
+test('normalizes iOS interaction errors into the common failure model', async () => {
+  const find = mock(async () => {
+    throw new AppError('AMBIGUOUS_MATCH', 'Multiple buttons matched')
+  })
+  const gateway = new AgentDeviceGateway(() =>
+    fakeClient({
+      devices: {
+        async list() {
+          return [iosSimulator]
+        },
+        async capabilities() {
+          throw new Error('Unexpected capabilities request')
+        },
+      },
+      command: {
+        async appState() {
+          return runningIosAppState
+        },
+        async wait() {},
+      },
+      interactions: { find },
+    }),
+  )
+  await gateway.openSession({
+    sessionId: 'session-1',
+    platform: 'ios',
+    application,
+  })
+
+  await expect(
+    gateway.executeStep({
+      sessionId: 'session-1',
+      stepIndex: 0,
+      step: { type: 'action', text: 'Pay now' },
+    }),
+  ).resolves.toEqual({
+    state: 'failed',
+    resolvedActions: [],
+    message: 'Multiple buttons matched',
+  })
+  expect(find).toHaveBeenCalledWith({
+    platform: 'ios',
+    udid: iosSimulator.ios.udid,
+    query: 'Pay now',
+    action: 'click',
+  })
+})
+
+test('classifies iOS selector misses and offscreen elements as functional', () => {
+  for (const code of ['ELEMENT_NOT_FOUND', 'ELEMENT_OFFSCREEN']) {
+    expect(
+      isFunctionalAgentDeviceFailure(
+        new AppError(code, `iOS interaction failed: ${code}`),
+      ),
+    ).toBe(true)
+  }
+})
+
 test('reports requested screenshot capture failures as infrastructure errors', async () => {
   const gateway = new AgentDeviceGateway(() =>
     emulatorClient({
@@ -361,6 +610,218 @@ test('reports requested screenshot capture failures as infrastructure errors', a
     state: 'infrastructure-error',
     message: 'Screenshot capture failed: Screenshot helper is unavailable',
   })
+})
+
+test('captures requested iOS logs, recordings, and traces as common test artifacts', async () => {
+  const root = await mkdtemp(join(tmpdir(), 'pickle-ios-evidence-'))
+  const sourceLogPath = join(root, 'app.log')
+  await Bun.write(sourceLogPath, 'Checkout started\n')
+  const logs = mock(async (options: { action: string }) =>
+    options.action === 'path' ? { path: sourceLogPath } : {},
+  )
+  const record = mock(async (options: { action: string; path?: string }) => ({
+    recording: options.action === 'start' ? 'started' : 'stopped',
+    outPath: options.path ?? '',
+  }))
+  const trace = mock(async (options: { action: string; path?: string }) => ({
+    trace: options.action === 'start' ? 'started' : 'stopped',
+    outPath: options.path ?? '',
+  }))
+  const gateway = new AgentDeviceGateway(() =>
+    fakeClient({
+      devices: {
+        async list() {
+          return [iosSimulator]
+        },
+        async capabilities() {
+          return {
+            device: iosSimulator,
+            availableCommands: ['logs', 'record', 'trace'],
+          }
+        },
+      },
+      command: {
+        async appState() {
+          return runningIosAppState
+        },
+        async wait() {},
+      },
+      observability: { logs },
+      recording: { record, trace },
+    }),
+  )
+
+  try {
+    await gateway.openSession({
+      sessionId: 'session-1',
+      platform: 'ios',
+      application,
+      artifactDirectory: root,
+      artifacts: ['device-log', 'recording', 'trace'],
+    })
+
+    await expect(
+      gateway.executeStep({
+        sessionId: 'session-1',
+        stepIndex: 0,
+        step: { type: 'action', text: 'Pay now' },
+      }),
+    ).resolves.toMatchObject({
+      state: 'passed',
+      artifacts: [
+        {
+          kind: 'device-log',
+          path: join(root, 'session-1', 'step-01.log'),
+          mediaType: 'text/plain',
+        },
+        {
+          kind: 'recording',
+          path: join(root, 'session-1', 'step-01.mp4'),
+          mediaType: 'video/mp4',
+        },
+        {
+          kind: 'trace',
+          path: join(root, 'session-1', 'step-01.trace'),
+        },
+      ],
+    })
+    expect(record.mock.calls.map((call) => call[0].action)).toEqual([
+      'start',
+      'stop',
+    ])
+    expect(trace.mock.calls.map((call) => call[0].action)).toEqual([
+      'start',
+      'stop',
+    ])
+    await gateway.closeSession('session-1')
+    expect(logs.mock.calls.map((call) => call[0].action)).toEqual([
+      'start',
+      'path',
+      'stop',
+    ])
+  } finally {
+    await rm(root, { recursive: true, force: true })
+  }
+})
+
+test('redacts configured text before persisting device logs', async () => {
+  const root = await mkdtemp(join(tmpdir(), 'pickle-ios-redaction-'))
+  const sourceLogPath = join(root, 'app.log')
+  await Bun.write(sourceLogPath, 'token=secret-value\n')
+  const gateway = new AgentDeviceGateway(() =>
+    fakeClient({
+      devices: {
+        async list() {
+          return [iosSimulator]
+        },
+        async capabilities() {
+          return { device: iosSimulator, availableCommands: ['logs'] }
+        },
+      },
+      command: {
+        async appState() {
+          return runningIosAppState
+        },
+        async wait() {},
+      },
+      observability: {
+        async logs(options) {
+          return options.action === 'path' ? { path: sourceLogPath } : {}
+        },
+      },
+    }),
+  )
+
+  try {
+    await gateway.openSession({
+      sessionId: 'session-1',
+      platform: 'ios',
+      application,
+      artifactDirectory: root,
+      artifacts: ['device-log'],
+      redactions: [{ match: 'secret-value', replacement: '[REDACTED]' }],
+    })
+    await gateway.executeStep({
+      sessionId: 'session-1',
+      stepIndex: 0,
+      step: { type: 'action', text: 'Pay now' },
+    })
+
+    expect(await readFile(join(root, 'session-1', 'step-01.log'), 'utf8')).toBe(
+      'token=[REDACTED]\n',
+    )
+  } finally {
+    await gateway.dispose().catch(() => {})
+    await rm(root, { recursive: true, force: true })
+  }
+})
+
+test('rejects requested evidence that the selected target does not support', async () => {
+  const reinstall = mock(async () => {})
+  const gateway = new AgentDeviceGateway(() =>
+    fakeClient({
+      devices: {
+        async list() {
+          return [iosSimulator]
+        },
+        async capabilities() {
+          return { device: iosSimulator, availableCommands: ['screenshot'] }
+        },
+      },
+      apps: { reinstall, async open() {} },
+    }),
+  )
+
+  await expect(
+    gateway.openSession({
+      sessionId: 'session-1',
+      platform: 'ios',
+      application,
+      artifacts: ['recording'],
+    }),
+  ).rejects.toThrow('does not support requested evidence: recording')
+  expect(reinstall).not.toHaveBeenCalled()
+})
+
+test('rejects Scenario requirements unsupported by the selected target', async () => {
+  const reinstall = mock(async () => {})
+  const gateway = new AgentDeviceGateway(() =>
+    fakeClient({
+      devices: {
+        async list() {
+          return [iosSimulator]
+        },
+        async capabilities() {
+          return { device: iosSimulator, availableCommands: ['screenshot'] }
+        },
+      },
+      apps: { reinstall, async open() {} },
+    }),
+  )
+
+  await expect(
+    gateway.openSession({
+      sessionId: 'session-1',
+      platform: 'ios',
+      application,
+      requiredCapabilities: ['traces'],
+    }),
+  ).rejects.toThrow('does not satisfy required capabilities: traces')
+  expect(reinstall).not.toHaveBeenCalled()
+})
+
+test('rejects text redaction policies for binary evidence', async () => {
+  const gateway = new AgentDeviceGateway(() => fakeClient())
+
+  await expect(
+    gateway.openSession({
+      sessionId: 'session-1',
+      platform: 'ios',
+      application,
+      artifacts: ['recording'],
+      redactions: [{ match: 'secret' }],
+    }),
+  ).rejects.toThrow('Binary mobile evidence cannot apply text redactions')
 })
 
 test('retains session ownership when close fails so disposal can retry', async () => {

--- a/packages/mobile/src/agent-device-gateway.ts
+++ b/packages/mobile/src/agent-device-gateway.ts
@@ -1,9 +1,12 @@
 import {
   type AgentDeviceClientFactory,
+  type AgentDeviceDevice,
   agentDeviceCapabilitiesSchema,
-  androidAppStateSchema,
-  androidDevicesSchema,
+  agentDeviceLogPathSchema,
   defaultAgentDeviceClientFactory,
+  type MobileSelection,
+  mobileAppStateSchema,
+  mobileDevicesSchema,
 } from './agent-device-client'
 import {
   type AgentDeviceStepSession,
@@ -11,8 +14,11 @@ import {
   executeAgentDeviceStep,
 } from './agent-device-step'
 import type {
-  AndroidApplication,
-  AndroidTarget,
+  MobileApplication,
+  MobileArtifactKind,
+  MobilePlatform,
+  MobileTarget,
+  MobileTextRedaction,
   WorkerStepExecution,
 } from './worker-protocol'
 
@@ -23,21 +29,96 @@ export type {
 
 export interface OpenGatewaySessionInput {
   sessionId: string
+  platform?: MobilePlatform
   targetId?: string
-  application: AndroidApplication
+  application: MobileApplication
   artifactDirectory?: string
+  artifacts?: readonly MobileArtifactKind[]
+  redactions?: readonly MobileTextRedaction[]
+  requiredCapabilities?: readonly string[]
 }
 
-function normalizedCapabilities(commands: readonly string[]): string[] {
-  const capabilities = ['android', 'android-emulator']
+interface GatewaySession {
+  artifactDirectory?: string
+  artifacts: ReadonlySet<MobileArtifactKind>
+  client: AgentDeviceStepSession['client']
+  deviceLogPath?: string
+  logsStarted: boolean
+  redactions: readonly MobileTextRedaction[]
+  selection?: MobileSelection
+}
+
+interface MobilePlatformPolicy {
+  applicationName: string
+  targetCapability: string
+  targetKind: AgentDeviceDevice['kind']
+  targetName: string
+}
+
+const mobilePlatformPolicies: Record<MobilePlatform, MobilePlatformPolicy> = {
+  android: {
+    applicationName: 'Android application',
+    targetCapability: 'android-emulator',
+    targetKind: 'emulator',
+    targetName: 'Android Emulator',
+  },
+  ios: {
+    applicationName: 'iOS application',
+    targetCapability: 'ios-simulator',
+    targetKind: 'simulator',
+    targetName: 'iOS Simulator',
+  },
+}
+
+const artifactCommands: Record<MobileArtifactKind, string> = {
+  screenshot: 'screenshot',
+  'device-log': 'logs',
+  recording: 'record',
+  trace: 'trace',
+}
+
+const binaryArtifacts = new Set<MobileArtifactKind>([
+  'screenshot',
+  'recording',
+  'trace',
+])
+
+function validateArtifactRedactions(input: OpenGatewaySessionInput): void {
+  if (!input.redactions?.length) return
+  const unsupported = (input.artifacts ?? ['screenshot']).filter((artifact) =>
+    binaryArtifacts.has(artifact),
+  )
+  if (unsupported.length > 0) {
+    throw new Error(
+      `Binary mobile evidence cannot apply text redactions: ${unsupported.join(', ')}`,
+    )
+  }
+}
+
+function normalizedCapabilities(
+  platform: MobilePlatform,
+  commands: readonly string[],
+): string[] {
+  const capabilities = [
+    platform,
+    mobilePlatformPolicies[platform].targetCapability,
+  ]
   if (commands.includes('screenshot')) capabilities.push('screenshots')
   if (commands.includes('logs')) capabilities.push('device-logs')
+  if (commands.includes('record')) capabilities.push('recordings')
+  if (commands.includes('trace')) capabilities.push('traces')
   return capabilities
+}
+
+function deviceSelection(device: AgentDeviceDevice): MobileSelection {
+  return device.platform === 'ios'
+    ? { platform: 'ios', udid: device.ios.udid }
+    : { platform: 'android', serial: device.android.serial }
 }
 
 export class AgentDeviceGateway {
   private readonly createClient: AgentDeviceClientFactory
-  private readonly sessions = new Map<string, AgentDeviceStepSession>()
+  private readonly sessions = new Map<string, GatewaySession>()
 
   constructor(
     createClient: AgentDeviceClientFactory = defaultAgentDeviceClientFactory,
@@ -45,30 +126,36 @@ export class AgentDeviceGateway {
     this.createClient = createClient
   }
 
-  async discoverTargets(): Promise<AndroidTarget[]> {
+  async discoverTargets(
+    platform: MobilePlatform = 'android',
+  ): Promise<MobileTarget[]> {
+    const policy = mobilePlatformPolicies[platform]
     const client = this.createClient({
       session: 'pickle-mobile-discovery',
       lockPolicy: 'reject',
-      lockPlatform: 'android',
+      lockPlatform: platform,
     })
     try {
-      const devices = androidDevicesSchema.parse(
-        await client.devices.list({ platform: 'android' }),
+      const devices = mobileDevicesSchema.parse(
+        await client.devices.list({ platform }),
       )
-      const emulators = devices.filter((device) => device.kind === 'emulator')
+      const compatibleTargets = devices.filter(
+        (device) =>
+          device.platform === platform && device.kind === policy.targetKind,
+      )
       return await Promise.all(
-        emulators.map(async (device) => {
+        compatibleTargets.map(async (device) => {
           const result = agentDeviceCapabilitiesSchema.parse(
-            await client.devices.capabilities({
-              platform: 'android',
-              serial: device.android.serial,
-            }),
+            await client.devices.capabilities(deviceSelection(device)),
           )
           return {
             id: device.id,
             name: device.name,
             state: device.booted ? ('booted' as const) : ('offline' as const),
-            capabilities: normalizedCapabilities(result.availableCommands),
+            capabilities: normalizedCapabilities(
+              platform,
+              result.availableCommands,
+            ),
           }
         }),
       )
@@ -80,18 +167,25 @@ export class AgentDeviceGateway {
   async openSession(
     input: OpenGatewaySessionInput,
   ): Promise<{ targetId: string }> {
+    validateArtifactRedactions(input)
     if (this.sessions.has(input.sessionId)) {
       throw new Error(`Mobile logical session "${input.sessionId}" is open`)
     }
+    const platform = input.platform ?? 'android'
+    const policy = mobilePlatformPolicies[platform]
     const client = this.createClient({
       session: input.sessionId,
       lockPolicy: 'reject',
-      lockPlatform: 'android',
+      lockPlatform: platform,
     })
-    const session: AgentDeviceStepSession = {
+    const requestedArtifacts =
+      input.artifacts ?? (input.artifactDirectory ? ['screenshot'] : [])
+    const session: GatewaySession = {
       artifactDirectory: input.artifactDirectory,
+      artifacts: new Set(requestedArtifacts),
       client,
-      serial: '',
+      logsStarted: false,
+      redactions: input.redactions ?? [],
     }
     this.sessions.set(input.sessionId, session)
     const ensureSessionOwned = () => {
@@ -101,28 +195,55 @@ export class AgentDeviceGateway {
     }
 
     try {
-      const devices = androidDevicesSchema.parse(
-        await client.devices.list({ platform: 'android' }),
+      const devices = mobileDevicesSchema.parse(
+        await client.devices.list({ platform }),
       )
       ensureSessionOwned()
       const target = devices.find(
         (device) =>
-          device.kind === 'emulator' &&
+          device.platform === platform &&
+          device.kind === policy.targetKind &&
           device.booted === true &&
           (input.targetId === undefined || device.id === input.targetId),
       )
       if (!target) {
         throw new Error(
           input.targetId
-            ? `Booted Android Emulator target "${input.targetId}" was not found`
-            : 'No booted Android Emulator target was found',
+            ? `Booted ${policy.targetName} target "${input.targetId}" was not found`
+            : `No booted ${policy.targetName} target was found`,
         )
       }
 
-      session.serial = target.android.serial
-      const selection = {
-        platform: 'android' as const,
-        serial: session.serial,
+      const selection = deviceSelection(target)
+      session.selection = selection
+      if (requestedArtifacts.length > 0 || input.requiredCapabilities?.length) {
+        const capabilityResult = agentDeviceCapabilitiesSchema.parse(
+          await client.devices.capabilities(selection),
+        )
+        ensureSessionOwned()
+        const unsupportedArtifacts = requestedArtifacts.filter(
+          (artifact) =>
+            !capabilityResult.availableCommands.includes(
+              artifactCommands[artifact],
+            ),
+        )
+        if (unsupportedArtifacts.length > 0) {
+          throw new Error(
+            `${policy.targetName} does not support requested evidence: ${unsupportedArtifacts.join(', ')}`,
+          )
+        }
+        const targetCapabilities = normalizedCapabilities(
+          platform,
+          capabilityResult.availableCommands,
+        )
+        const unsupportedRequirements = (
+          input.requiredCapabilities ?? []
+        ).filter((capability) => !targetCapabilities.includes(capability))
+        if (unsupportedRequirements.length > 0) {
+          throw new Error(
+            `${policy.targetName} does not satisfy required capabilities: ${unsupportedRequirements.join(', ')}`,
+          )
+        }
       }
       await client.apps.reinstall({
         ...selection,
@@ -135,14 +256,29 @@ export class AgentDeviceGateway {
         app: input.application.id,
       })
       ensureSessionOwned()
-      const state = androidAppStateSchema.parse(
+      const state = mobileAppStateSchema.parse(
         await client.command.appState(selection),
       )
       ensureSessionOwned()
-      if (state.package !== input.application.id) {
+      const runningApplicationId =
+        state.platform === 'ios' ? state.appBundleId : state.package
+      if (
+        state.platform !== platform ||
+        runningApplicationId !== input.application.id
+      ) {
         throw new Error(
-          `Android application reset verification failed: expected ${input.application.id}, found ${state.package}`,
+          `${policy.applicationName} reset verification failed: expected ${input.application.id}, found ${runningApplicationId ?? 'unknown'}`,
         )
+      }
+      if (session.artifactDirectory && session.artifacts.has('device-log')) {
+        await client.observability.logs({ action: 'start' })
+        session.logsStarted = true
+        ensureSessionOwned()
+        const log = agentDeviceLogPathSchema.parse(
+          await client.observability.logs({ action: 'path' }),
+        )
+        session.deviceLogPath = log.path
+        ensureSessionOwned()
       }
       return { targetId: target.id }
     } catch (error) {
@@ -158,16 +294,48 @@ export class AgentDeviceGateway {
     if (!session) {
       throw new Error(`Mobile logical session "${input.sessionId}" is not open`)
     }
-    return executeAgentDeviceStep(input, session)
+    if (!session.selection) {
+      throw new Error(
+        `Mobile logical session "${input.sessionId}" has no execution target`,
+      )
+    }
+    return executeAgentDeviceStep(input, {
+      artifactDirectory: session.artifactDirectory,
+      artifacts: session.artifacts,
+      client: session.client,
+      deviceLogPath: session.deviceLogPath,
+      redactions: session.redactions,
+      selection: session.selection,
+    })
   }
 
   async closeSession(sessionId: string): Promise<void> {
     const session = this.sessions.get(sessionId)
     if (!session) return
-    await session.client.sessions.close()
+    let logError: unknown
+    if (session.logsStarted) {
+      try {
+        await session.client.observability.logs({ action: 'stop' })
+        session.logsStarted = false
+      } catch (error) {
+        logError = error
+      }
+    }
+    try {
+      await session.client.sessions.close()
+    } catch (error) {
+      if (logError) {
+        throw new AggregateError(
+          [logError, error],
+          'Failed to close mobile evidence and session',
+        )
+      }
+      throw error
+    }
     if (this.sessions.get(sessionId) === session) {
       this.sessions.delete(sessionId)
     }
+    if (logError) throw logError
   }
 
   cancelSession(sessionId: string): Promise<void> {

--- a/packages/mobile/src/agent-device-step.ts
+++ b/packages/mobile/src/agent-device-step.ts
@@ -1,10 +1,15 @@
-import { mkdir } from 'node:fs/promises'
+import { mkdir, readFile, writeFile } from 'node:fs/promises'
 import { join } from 'node:path'
 import { z } from 'zod'
-import type { AgentDeviceClientPort } from './agent-device-client'
+import type {
+  AgentDeviceClientPort,
+  MobileSelection,
+} from './agent-device-client'
 import { isFunctionalAgentDeviceFailure } from './agent-device-client'
 import type {
+  MobileArtifactKind,
   MobileStep,
+  MobileTextRedaction,
   WorkerResolvedAction,
   WorkerStepExecution,
 } from './worker-protocol'
@@ -18,8 +23,11 @@ export interface ExecuteAgentDeviceStepInput {
 
 export interface AgentDeviceStepSession {
   artifactDirectory?: string
+  artifacts: ReadonlySet<MobileArtifactKind>
   client: AgentDeviceClientPort
-  serial: string
+  deviceLogPath?: string
+  redactions: readonly MobileTextRedaction[]
+  selection: MobileSelection
 }
 
 const replayActionSchema = z.strictObject({
@@ -33,8 +41,29 @@ const screenshotResultSchema = z.object({ path: z.string().min(1) })
 type ReplayAction = z.infer<typeof replayActionSchema>
 type ScreenshotArtifact = NonNullable<WorkerStepExecution['artifacts']>[number]
 
+interface TimedEvidence {
+  recordingPath?: string
+  tracePath?: string
+}
+
+interface CapturedEvidence {
+  artifacts: ScreenshotArtifact[]
+  errors: string[]
+}
+
 function errorMessage(error: unknown): string {
   return error instanceof Error ? error.message : String(error)
+}
+
+function redactText(
+  value: string,
+  redactions: readonly MobileTextRedaction[],
+): string {
+  return redactions.reduce(
+    (redacted, rule) =>
+      redacted.split(rule.match).join(rule.replacement ?? '[REDACTED]'),
+    value,
+  )
 }
 
 function adaptiveAction(step: MobileStep): ReplayAction {
@@ -53,19 +82,15 @@ async function executeAction(
   session: AgentDeviceStepSession,
   action: ReplayAction,
 ): Promise<void> {
-  const selection = {
-    platform: 'android' as const,
-    serial: session.serial,
-  }
   if (action.action === 'wait') {
     await session.client.command.wait({
-      ...selection,
+      ...session.selection,
       text: action.query,
     })
     return
   }
   await session.client.interactions.find({
-    ...selection,
+    ...session.selection,
     query: action.query,
     action: 'click',
   })
@@ -123,7 +148,9 @@ async function captureScreenshot(
   input: ExecuteAgentDeviceStepInput,
   session: AgentDeviceStepSession,
 ): Promise<ScreenshotArtifact | undefined> {
-  if (!session.artifactDirectory) return
+  if (!session.artifactDirectory || !session.artifacts.has('screenshot')) {
+    return
+  }
   const directory = join(session.artifactDirectory, input.sessionId)
   await mkdir(directory, { recursive: true })
   const path = join(
@@ -140,10 +167,142 @@ async function captureScreenshot(
   }
 }
 
+function stepArtifactPath(
+  input: ExecuteAgentDeviceStepInput,
+  session: AgentDeviceStepSession,
+  extension: string,
+): string | undefined {
+  if (!session.artifactDirectory) return
+  return join(
+    session.artifactDirectory,
+    input.sessionId,
+    `step-${String(input.stepIndex + 1).padStart(2, '0')}.${extension}`,
+  )
+}
+
+async function startTimedEvidence(
+  input: ExecuteAgentDeviceStepInput,
+  session: AgentDeviceStepSession,
+): Promise<TimedEvidence> {
+  if (!session.artifactDirectory) return {}
+  await mkdir(join(session.artifactDirectory, input.sessionId), {
+    recursive: true,
+  })
+  const evidence: TimedEvidence = {}
+  try {
+    if (session.artifacts.has('recording')) {
+      evidence.recordingPath = stepArtifactPath(input, session, 'mp4')
+      await session.client.recording.record({
+        action: 'start',
+        path: evidence.recordingPath,
+      })
+    }
+    if (session.artifacts.has('trace')) {
+      evidence.tracePath = stepArtifactPath(input, session, 'trace')
+      await session.client.recording.trace({
+        action: 'start',
+        path: evidence.tracePath,
+      })
+    }
+    return evidence
+  } catch (error) {
+    await Promise.allSettled([
+      ...(evidence.recordingPath
+        ? [
+            session.client.recording.record({
+              action: 'stop',
+              path: evidence.recordingPath,
+            }),
+          ]
+        : []),
+      ...(evidence.tracePath
+        ? [
+            session.client.recording.trace({
+              action: 'stop',
+              path: evidence.tracePath,
+            }),
+          ]
+        : []),
+    ])
+    throw error
+  }
+}
+
+async function captureRequestedEvidence(
+  input: ExecuteAgentDeviceStepInput,
+  session: AgentDeviceStepSession,
+  timedEvidence: TimedEvidence,
+): Promise<CapturedEvidence> {
+  const artifacts: ScreenshotArtifact[] = []
+  const errors: string[] = []
+
+  if (session.artifacts.has('device-log') && session.artifactDirectory) {
+    const path = stepArtifactPath(input, session, 'log')
+    try {
+      if (!path || !session.deviceLogPath) {
+        throw new Error('Agent Device did not provide an app log path')
+      }
+      const log = await readFile(session.deviceLogPath, 'utf8')
+      await writeFile(path, redactText(log, session.redactions), 'utf8')
+      artifacts.push({ kind: 'device-log', path, mediaType: 'text/plain' })
+    } catch (error) {
+      errors.push(`Device log capture failed: ${errorMessage(error)}`)
+    }
+  }
+
+  if (timedEvidence.recordingPath) {
+    try {
+      await session.client.recording.record({
+        action: 'stop',
+        path: timedEvidence.recordingPath,
+      })
+      artifacts.push({
+        kind: 'recording',
+        path: timedEvidence.recordingPath,
+        mediaType: 'video/mp4',
+      })
+    } catch (error) {
+      errors.push(`Recording capture failed: ${errorMessage(error)}`)
+    }
+  }
+
+  if (timedEvidence.tracePath) {
+    try {
+      await session.client.recording.trace({
+        action: 'stop',
+        path: timedEvidence.tracePath,
+      })
+      artifacts.push({ kind: 'trace', path: timedEvidence.tracePath })
+    } catch (error) {
+      errors.push(`Trace capture failed: ${errorMessage(error)}`)
+    }
+  }
+
+  try {
+    const screenshot = await captureScreenshot(input, session)
+    if (screenshot) artifacts.push(screenshot)
+  } catch (error) {
+    errors.push(`Screenshot capture failed: ${errorMessage(error)}`)
+  }
+
+  return { artifacts, errors }
+}
+
 export async function executeAgentDeviceStep(
   input: ExecuteAgentDeviceStepInput,
   session: AgentDeviceStepSession,
 ): Promise<WorkerStepExecution> {
+  let timedEvidence: TimedEvidence
+  try {
+    timedEvidence = await startTimedEvidence(input, session)
+  } catch (error) {
+    return {
+      state: 'infrastructure-error',
+      resolvedActions: [],
+      message: `Test artifact capture failed: ${errorMessage(error)}`,
+    }
+  }
+
   let execution: WorkerStepExecution
   try {
     execution = await executeStepActions(input, session)
@@ -157,14 +316,16 @@ export async function executeAgentDeviceStep(
     }
   }
 
-  try {
-    const artifact = await captureScreenshot(input, session)
-    return artifact ? { ...execution, artifacts: [artifact] } : execution
-  } catch (error) {
+  const evidence = await captureRequestedEvidence(input, session, timedEvidence)
+  if (evidence.errors.length > 0) {
     return {
       ...execution,
       state: 'infrastructure-error',
-      message: `Screenshot capture failed: ${errorMessage(error)}`,
+      message: evidence.errors.join('; '),
+      artifacts: evidence.artifacts.length > 0 ? evidence.artifacts : undefined,
     }
   }
+  return evidence.artifacts.length > 0
+    ? { ...execution, artifacts: evidence.artifacts }
+    : execution
 }

--- a/packages/mobile/src/ios-simulator.smoke.test.ts
+++ b/packages/mobile/src/ios-simulator.smoke.test.ts
@@ -1,0 +1,49 @@
+import { expect, test } from 'bun:test'
+import { runScenario } from '@pickle-spec/runner'
+import { createMobileAdapter } from '../index'
+
+const smokeEnabled = process.env.PICKLE_IOS_SMOKE === '1'
+const smokeTest = smokeEnabled ? test : test.skip
+
+smokeTest('runs one Scenario through a real iOS Simulator', async () => {
+  const applicationId = process.env.PICKLE_IOS_APP_ID
+  const binaryPath = process.env.PICKLE_IOS_APP_PATH
+  const stepText = process.env.PICKLE_IOS_SMOKE_STEP
+  if (!applicationId || !binaryPath || !stepText) {
+    throw new Error(
+      'Set PICKLE_IOS_APP_ID, PICKLE_IOS_APP_PATH, and PICKLE_IOS_SMOKE_STEP',
+    )
+  }
+
+  const scenario = {
+    name: 'iOS Simulator smoke',
+    tags: [],
+    steps: [{ keyword: 'Then', text: stepText, type: 'outcome' as const }],
+  }
+  const specification = {
+    name: 'Mobile smoke',
+    source: { uri: 'smoke/ios.feature', language: 'en' },
+    tags: [],
+    scenarios: [scenario],
+  }
+  const adapter = createMobileAdapter({
+    executionTarget: 'ios-simulator',
+    application: { id: applicationId, binaryPath },
+    targetId: process.env.PICKLE_IOS_TARGET_ID,
+    nodePath: process.env.PICKLE_NODE_PATH,
+  })
+
+  try {
+    const targets = await adapter.discoverTargets()
+    expect(targets.some((target) => target.state === 'booted')).toBe(true)
+    const run = await runScenario({
+      specification,
+      scenario,
+      executionTargetProfile: { id: 'ios-smoke' },
+      adapter,
+    })
+    expect(run.result.state).toBe('passed')
+  } finally {
+    await adapter.dispose?.()
+  }
+})

--- a/packages/mobile/src/mobile-adapter.conformance.test.ts
+++ b/packages/mobile/src/mobile-adapter.conformance.test.ts
@@ -24,6 +24,11 @@ const application = {
   binaryPath: '/tmp/checkout.apk',
 }
 
+const iosApplication = {
+  id: 'com.example.checkout',
+  binaryPath: '/tmp/Checkout.app',
+}
+
 function conformanceWorker(): MobileWorkerClient {
   const sessions = new Map<
     string,
@@ -33,14 +38,15 @@ function conformanceWorker(): MobileWorkerClient {
     async request(request) {
       switch (request.type) {
         case 'discover-targets':
-          return { version: 1, type: 'targets-discovered', targets: [] }
+          return { version: 2, type: 'targets-discovered', targets: [] }
         case 'open-session':
           sessions.set(request.sessionId, request)
           return {
-            version: 1,
+            version: 2,
             type: 'session-opened',
             sessionId: request.sessionId,
-            targetId: 'emulator-5554',
+            targetId:
+              request.platform === 'ios' ? 'ios-simulator-1' : 'emulator-5554',
           }
         case 'execute-step': {
           const session = sessions.get(request.sessionId)
@@ -48,7 +54,7 @@ function conformanceWorker(): MobileWorkerClient {
           const planned =
             session.plan?.steps[request.stepIndex]?.resolvedActions
           return {
-            version: 1,
+            version: 2,
             type: 'step-executed',
             sessionId: request.sessionId,
             execution: {
@@ -69,14 +75,14 @@ function conformanceWorker(): MobileWorkerClient {
         case 'close-session':
           sessions.delete(request.sessionId)
           return {
-            version: 1,
+            version: 2,
             type: 'session-closed',
             sessionId: request.sessionId,
           }
         case 'cancel-session':
           sessions.delete(request.sessionId)
           return {
-            version: 1,
+            version: 2,
             type: 'session-cancelled',
             sessionId: request.sessionId,
           }
@@ -100,7 +106,47 @@ defineAdapterConformanceSuite({
   executionTargetProfile: { id: 'android' },
   specification,
   scenario,
-  expectedCapabilities: ['android', 'android-emulator', 'screenshots'],
+  expectedCapabilities: [
+    'android',
+    'android-emulator',
+    'screenshots',
+    'device-logs',
+    'recordings',
+    'traces',
+  ],
+  replayActions: scenario.steps.map((step) => [
+    {
+      description: `Replay: ${step.text}`,
+      replay: {
+        kind: 'find',
+        query: step.text,
+        action: step.type === 'outcome' ? 'wait' : 'click',
+      },
+    },
+  ]),
+})
+
+defineAdapterConformanceSuite({
+  name: 'iOS mobile',
+  createAdapter: () =>
+    createMobileAdapter(
+      {
+        executionTarget: 'ios-simulator',
+        application: iosApplication,
+      },
+      conformanceWorker,
+    ),
+  executionTargetProfile: { id: 'ios' },
+  specification,
+  scenario,
+  expectedCapabilities: [
+    'ios',
+    'ios-simulator',
+    'screenshots',
+    'device-logs',
+    'recordings',
+    'traces',
+  ],
   replayActions: scenario.steps.map((step) => [
     {
       description: `Replay: ${step.text}`,

--- a/packages/mobile/src/mobile-adapter.test.ts
+++ b/packages/mobile/src/mobile-adapter.test.ts
@@ -24,6 +24,11 @@ const application = {
   binaryPath: '/tmp/checkout.apk',
 }
 
+const iosApplication = {
+  id: 'com.example.checkout',
+  binaryPath: '/tmp/Checkout.app',
+}
+
 function workerClient(
   overrides: Partial<MobileWorkerClient> = {},
 ): MobileWorkerClient {
@@ -38,7 +43,7 @@ function workerClient(
 
 test('discovers Android Emulator targets without exposing worker or vendor types', async () => {
   const request = mock(async () => ({
-    version: 1 as const,
+    version: 2 as const,
     type: 'targets-discovered' as const,
     targets: [
       {
@@ -60,6 +65,9 @@ test('discovers Android Emulator targets without exposing worker or vendor types
     'android',
     'android-emulator',
     'screenshots',
+    'device-logs',
+    'recordings',
+    'traces',
   ])
   expect(await adapter.discoverTargets()).toEqual([
     {
@@ -70,8 +78,85 @@ test('discovers Android Emulator targets without exposing worker or vendor types
     },
   ])
   expect(request).toHaveBeenCalledWith({
-    version: 1,
+    version: 2,
     type: 'discover-targets',
+    platform: 'android',
+  })
+})
+
+test('discovers iOS Simulator targets with target-specific capabilities and plans', async () => {
+  const requests: MobileWorkerRequest[] = []
+  const request: MobileWorkerClient['request'] = mock(async (message) => {
+    requests.push(message)
+    if (message.type === 'discover-targets') {
+      return {
+        version: 2 as const,
+        type: 'targets-discovered' as const,
+        targets: [
+          {
+            id: 'F2D95476-0A9E-4A8C-9F48-8C77B2F5B8D0',
+            name: 'iPhone 16 Pro',
+            state: 'booted' as const,
+            capabilities: ['ios', 'ios-simulator', 'screenshots'],
+          },
+        ],
+      }
+    }
+    if (message.type === 'open-session') {
+      return {
+        version: 2 as const,
+        type: 'session-opened' as const,
+        sessionId: message.sessionId,
+        targetId: 'F2D95476-0A9E-4A8C-9F48-8C77B2F5B8D0',
+      }
+    }
+    throw new Error(`Unexpected request ${message.type}`)
+  })
+  const adapter = createMobileAdapter(
+    {
+      executionTarget: 'ios-simulator',
+      application: iosApplication,
+      artifacts: ['device-log'],
+      redactions: [{ match: 'secret-value', replacement: '[REDACTED]' }],
+    },
+    () => workerClient({ request }),
+  )
+
+  expect(adapter.capabilities).toEqual([
+    'ios',
+    'ios-simulator',
+    'screenshots',
+    'device-logs',
+    'recordings',
+    'traces',
+  ])
+  expect(adapter.planFormatVersion).toBe('mobile.ios.1')
+  await expect(adapter.discoverTargets()).resolves.toEqual([
+    {
+      id: 'F2D95476-0A9E-4A8C-9F48-8C77B2F5B8D0',
+      name: 'iPhone 16 Pro',
+      state: 'booted',
+      capabilities: ['ios', 'ios-simulator', 'screenshots'],
+    },
+  ])
+  await adapter.openSession({
+    executionTargetProfile: { id: 'ios' },
+    specification,
+    scenario,
+  })
+
+  expect(requests[0]).toEqual({
+    version: 2,
+    type: 'discover-targets',
+    platform: 'ios',
+  })
+  expect(requests[1]).toMatchObject({
+    version: 2,
+    type: 'open-session',
+    platform: 'ios',
+    application: iosApplication,
+    artifacts: ['device-log'],
+    redactions: [{ match: 'secret-value', replacement: '[REDACTED]' }],
   })
 })
 
@@ -81,7 +166,7 @@ test('opens and closes one isolated Android logical session through the worker',
     requests.push(message)
     if (message.type === 'open-session') {
       return {
-        version: 1 as const,
+        version: 2 as const,
         type: 'session-opened' as const,
         sessionId: message.sessionId,
         targetId: 'emulator-5554',
@@ -89,7 +174,7 @@ test('opens and closes one isolated Android logical session through the worker',
     }
     if (message.type === 'close-session') {
       return {
-        version: 1 as const,
+        version: 2 as const,
         type: 'session-closed' as const,
         sessionId: message.sessionId,
       }
@@ -115,14 +200,14 @@ test('opens and closes one isolated Android logical session through the worker',
 
   expect(requests).toHaveLength(2)
   expect(requests[0]).toMatchObject({
-    version: 1,
+    version: 2,
     type: 'open-session',
     targetId: 'emulator-5554',
     application,
     mode: 'adaptive',
   })
   expect(requests[1]).toMatchObject({
-    version: 1,
+    version: 2,
     type: 'close-session',
   })
 })
@@ -133,7 +218,7 @@ test('executes mobile steps and returns common runner actions and artifacts', as
     requests.push(message)
     if (message.type === 'open-session') {
       return {
-        version: 1 as const,
+        version: 2 as const,
         type: 'session-opened' as const,
         sessionId: message.sessionId,
         targetId: 'emulator-5554',
@@ -141,7 +226,7 @@ test('executes mobile steps and returns common runner actions and artifacts', as
     }
     if (message.type === 'execute-step') {
       return {
-        version: 1 as const,
+        version: 2 as const,
         type: 'step-executed' as const,
         sessionId: message.sessionId,
         execution: {
@@ -158,13 +243,27 @@ test('executes mobile steps and returns common runner actions and artifacts', as
               path: '/tmp/artifacts/step-01.png',
               mediaType: 'image/png',
             },
+            {
+              kind: 'device-log' as const,
+              path: '/tmp/artifacts/session.log',
+              mediaType: 'text/plain',
+            },
+            {
+              kind: 'recording' as const,
+              path: '/tmp/artifacts/session.mp4',
+              mediaType: 'video/mp4',
+            },
+            {
+              kind: 'trace' as const,
+              path: '/tmp/artifacts/session.trace',
+            },
           ],
         },
       }
     }
     if (message.type === 'close-session') {
       return {
-        version: 1 as const,
+        version: 2 as const,
         type: 'session-closed' as const,
         sessionId: message.sessionId,
       }
@@ -198,10 +297,24 @@ test('executes mobile steps and returns common runner actions and artifacts', as
         path: '/tmp/artifacts/step-01.png',
         mediaType: 'image/png',
       },
+      {
+        kind: 'device-log',
+        path: '/tmp/artifacts/session.log',
+        mediaType: 'text/plain',
+      },
+      {
+        kind: 'recording',
+        path: '/tmp/artifacts/session.mp4',
+        mediaType: 'video/mp4',
+      },
+      {
+        kind: 'trace',
+        path: '/tmp/artifacts/session.trace',
+      },
     ],
   })
   expect(requests[1]).toMatchObject({
-    version: 1,
+    version: 2,
     type: 'execute-step',
     stepIndex: 0,
     step: { type: 'action', text: 'I pay' },
@@ -215,7 +328,7 @@ test('cancels the worker session on abort and disposes the worker before reuse',
     requests.push(message)
     if (message.type === 'open-session') {
       return {
-        version: 1 as const,
+        version: 2 as const,
         type: 'session-opened' as const,
         sessionId: message.sessionId,
         targetId: 'emulator-5554',
@@ -223,7 +336,7 @@ test('cancels the worker session on abort and disposes the worker before reuse',
     }
     if (message.type === 'cancel-session') {
       return {
-        version: 1 as const,
+        version: 2 as const,
         type: 'session-cancelled' as const,
         sessionId: message.sessionId,
       }
@@ -277,7 +390,7 @@ test('cancels installation when abort occurs while the logical session opens', a
       }
       if (message.type === 'cancel-session') {
         return {
-          version: 1,
+          version: 2,
           type: 'session-cancelled',
           sessionId: message.sessionId,
         }

--- a/packages/mobile/src/mobile-adapter.ts
+++ b/packages/mobile/src/mobile-adapter.ts
@@ -8,28 +8,77 @@ import {
   type AndroidApplication,
   type AndroidTarget,
   androidCapabilities,
+  type IosApplication,
+  type IosTarget,
+  iosCapabilities,
+  type MobileArtifactKind,
+  type MobilePlatform,
+  type MobileTextRedaction,
   type MobileWorkerResponse,
   mobileWorkerProtocolVersion,
 } from './worker-protocol'
 
-export type { AndroidApplication, AndroidTarget }
-export { androidCapabilities }
+export type {
+  AndroidApplication,
+  AndroidTarget,
+  IosApplication,
+  IosTarget,
+  MobileArtifactKind,
+  MobileTextRedaction,
+}
+export { androidCapabilities, iosCapabilities }
 
-export interface MobileAdapterOptions {
-  application: AndroidApplication
+interface MobileAdapterBaseOptions {
   targetId?: string
   artifactDirectory?: string
+  artifacts?: readonly MobileArtifactKind[]
+  redactions?: readonly MobileTextRedaction[]
   nodePath?: string
 }
 
-export interface MobileExecutionTargetAdapter extends ExecutionTargetAdapter {
-  discoverTargets(): Promise<AndroidTarget[]>
+export interface AndroidMobileAdapterOptions extends MobileAdapterBaseOptions {
+  executionTarget?: 'android-emulator'
+  application: AndroidApplication
 }
+
+export interface IosMobileAdapterOptions extends MobileAdapterBaseOptions {
+  executionTarget: 'ios-simulator'
+  application: IosApplication
+}
+
+export type MobileAdapterOptions =
+  | AndroidMobileAdapterOptions
+  | IosMobileAdapterOptions
+
+export interface MobileExecutionTargetAdapter extends ExecutionTargetAdapter {
+  discoverTargets(): Promise<Array<AndroidTarget | IosTarget>>
+}
+
+interface ExecutionTargetPolicy {
+  capabilities: readonly string[]
+  planFormatVersion: string
+  platform: MobilePlatform
+}
+
+const executionTargetPolicies = {
+  'android-emulator': {
+    capabilities: androidCapabilities,
+    planFormatVersion: 'mobile.android.1',
+    platform: 'android',
+  },
+  'ios-simulator': {
+    capabilities: iosCapabilities,
+    planFormatVersion: 'mobile.ios.1',
+    platform: 'ios',
+  },
+} as const satisfies Record<string, ExecutionTargetPolicy>
 
 export function createMobileAdapter(
   options: MobileAdapterOptions,
   workerFactory?: MobileWorkerFactory,
 ): MobileExecutionTargetAdapter {
+  const policy =
+    executionTargetPolicies[options.executionTarget ?? 'android-emulator']
   let worker: MobileWorkerClient | undefined
   const ensureWorker = () => {
     worker ??=
@@ -41,12 +90,13 @@ export function createMobileAdapter(
   }
 
   return {
-    capabilities: androidCapabilities,
-    planFormatVersion: 'mobile.android.1',
+    capabilities: policy.capabilities,
+    planFormatVersion: policy.planFormatVersion,
     async discoverTargets() {
       const response = await ensureWorker().request({
         version: mobileWorkerProtocolVersion,
         type: 'discover-targets',
+        platform: policy.platform,
       })
       if (response.type !== 'targets-discovered') {
         throw new Error(`Unexpected mobile worker response: ${response.type}`)
@@ -88,10 +138,18 @@ export function createMobileAdapter(
             version: mobileWorkerProtocolVersion,
             type: 'open-session',
             sessionId,
+            platform: policy.platform,
             targetId: options.targetId,
             application: options.application,
             mode: input.mode ?? 'adaptive',
             artifactDirectory: options.artifactDirectory,
+            artifacts: options.artifacts ? [...options.artifacts] : undefined,
+            redactions: options.redactions
+              ? options.redactions.map((redaction) => ({ ...redaction }))
+              : undefined,
+            requiredCapabilities: input.scenario.capabilityRequirements
+              ? [...input.scenario.capabilityRequirements]
+              : undefined,
             plan: input.plan
               ? {
                   steps: input.plan.steps.map((step) => ({

--- a/packages/mobile/src/worker-client.test.ts
+++ b/packages/mobile/src/worker-client.test.ts
@@ -11,9 +11,9 @@ test('launches the versioned worker protocol explicitly through Node', async () 
 
   try {
     expect(
-      await client.request({ version: 1, type: 'discover-targets' }),
+      await client.request({ version: 2, type: 'discover-targets' }),
     ).toEqual({
-      version: 1,
+      version: 2,
       type: 'targets-discovered',
       targets: [],
     })
@@ -34,7 +34,7 @@ test('rejects a request when disposal interrupts worker startup', async () => {
   const client = createNodeWorkerClient({
     workerEntry: new URL('../test/slow-worker.mjs', import.meta.url),
   })
-  const request = client.request({ version: 1, type: 'discover-targets' })
+  const request = client.request({ version: 2, type: 'discover-targets' })
   const rejection = request.catch((error: unknown) => error)
   await new Promise((resolve) => setTimeout(resolve, 10))
 

--- a/packages/mobile/src/worker-protocol.ts
+++ b/packages/mobile/src/worker-protocol.ts
@@ -1,23 +1,49 @@
 import { z } from 'zod'
 
-export const mobileWorkerProtocolVersion = 1 as const
+export const mobileWorkerProtocolVersion = 2 as const
 
 export const androidCapabilities = [
   'android',
   'android-emulator',
   'screenshots',
+  'device-logs',
+  'recordings',
+  'traces',
 ] as const
 
-const androidTargetSchema = z.strictObject({
+export const iosCapabilities = [
+  'ios',
+  'ios-simulator',
+  'screenshots',
+  'device-logs',
+  'recordings',
+  'traces',
+] as const
+
+const mobilePlatformSchema = z.enum(['android', 'ios'])
+
+const mobileTargetSchema = z.strictObject({
   id: z.string().min(1),
   name: z.string().min(1),
   state: z.enum(['booted', 'offline']),
   capabilities: z.array(z.string()),
 })
 
-const androidApplicationSchema = z.strictObject({
+const mobileApplicationSchema = z.strictObject({
   id: z.string().min(1),
   binaryPath: z.string().min(1),
+})
+
+const mobileArtifactKindSchema = z.enum([
+  'screenshot',
+  'trace',
+  'recording',
+  'device-log',
+])
+
+const mobileTextRedactionSchema = z.strictObject({
+  match: z.string().min(1),
+  replacement: z.string().optional(),
 })
 
 const workerResolvedActionSchema = z.strictObject({
@@ -43,7 +69,7 @@ const workerStepExecutionSchema = z.strictObject({
   artifacts: z
     .array(
       z.strictObject({
-        kind: z.enum(['screenshot', 'device-log']),
+        kind: mobileArtifactKindSchema,
         path: z.string(),
         mediaType: z.string().optional(),
       }),
@@ -63,15 +89,20 @@ export const mobileWorkerRequestSchema = z.discriminatedUnion('type', [
   z.strictObject({
     version: z.literal(mobileWorkerProtocolVersion),
     type: z.literal('discover-targets'),
+    platform: mobilePlatformSchema.optional(),
   }),
   z.strictObject({
     version: z.literal(mobileWorkerProtocolVersion),
     type: z.literal('open-session'),
     sessionId: z.string().min(1),
+    platform: mobilePlatformSchema.optional(),
     targetId: z.string().min(1).optional(),
-    application: androidApplicationSchema,
+    application: mobileApplicationSchema,
     mode: z.enum(['adaptive', 'replay']),
     artifactDirectory: z.string().min(1).optional(),
+    artifacts: z.array(mobileArtifactKindSchema).optional(),
+    redactions: z.array(mobileTextRedactionSchema).optional(),
+    requiredCapabilities: z.array(z.string().min(1)).optional(),
     plan: executionPlanSchema.optional(),
   }),
   z.strictObject({
@@ -97,7 +128,7 @@ export const mobileWorkerResponseSchema = z.discriminatedUnion('type', [
   z.strictObject({
     version: z.literal(mobileWorkerProtocolVersion),
     type: z.literal('targets-discovered'),
-    targets: z.array(androidTargetSchema),
+    targets: z.array(mobileTargetSchema),
   }),
   z.strictObject({
     version: z.literal(mobileWorkerProtocolVersion),
@@ -153,8 +184,15 @@ export const workerRequestMessageSchema = z.strictObject({
   payload: mobileWorkerRequestSchema,
 })
 
-export type AndroidTarget = z.infer<typeof androidTargetSchema>
-export type AndroidApplication = z.infer<typeof androidApplicationSchema>
+export type MobilePlatform = z.infer<typeof mobilePlatformSchema>
+export type MobileApplication = z.infer<typeof mobileApplicationSchema>
+export type MobileTarget = z.infer<typeof mobileTargetSchema>
+export type MobileArtifactKind = z.infer<typeof mobileArtifactKindSchema>
+export type MobileTextRedaction = z.infer<typeof mobileTextRedactionSchema>
+export type AndroidTarget = MobileTarget
+export type AndroidApplication = MobileApplication
+export type IosTarget = MobileTarget
+export type IosApplication = MobileApplication
 export type MobileStep = z.infer<typeof mobileStepSchema>
 export type WorkerResolvedAction = z.infer<typeof workerResolvedActionSchema>
 export type WorkerStepExecution = z.infer<typeof workerStepExecutionSchema>

--- a/packages/mobile/src/worker-runtime.test.ts
+++ b/packages/mobile/src/worker-runtime.test.ts
@@ -47,7 +47,7 @@ test('serializes mutable operations within one Android logical session', async (
     }),
   )
   await runtime.handle({
-    version: 1,
+    version: 2,
     type: 'open-session',
     sessionId: 'session-1',
     application,
@@ -55,14 +55,14 @@ test('serializes mutable operations within one Android logical session', async (
   })
 
   const first = runtime.handle({
-    version: 1,
+    version: 2,
     type: 'execute-step',
     sessionId: 'session-1',
     stepIndex: 0,
     step: { type: 'action', text: 'First action' },
   })
   const second = runtime.handle({
-    version: 1,
+    version: 2,
     type: 'execute-step',
     sessionId: 'session-1',
     stepIndex: 1,
@@ -93,7 +93,7 @@ test('supplies Replay plan actions to the matching step', async () => {
     }),
   )
   await runtime.handle({
-    version: 1,
+    version: 2,
     type: 'open-session',
     sessionId: 'session-1',
     application,
@@ -113,7 +113,7 @@ test('supplies Replay plan actions to the matching step', async () => {
   })
 
   await runtime.handle({
-    version: 1,
+    version: 2,
     type: 'execute-step',
     sessionId: 'session-1',
     stepIndex: 0,
@@ -127,6 +127,57 @@ test('supplies Replay plan actions to the matching step', async () => {
         replay: { kind: 'find', query: 'Saved', action: 'click' },
       },
     ],
+  ])
+})
+
+test('routes iOS discovery and logical sessions through the mobile gateway', async () => {
+  const discoveries: string[] = []
+  const openings: unknown[] = []
+  const runtime = new MobileWorkerRuntime(
+    gateway({
+      async discoverTargets(platform) {
+        discoveries.push(platform)
+        return []
+      },
+      async openSession(input) {
+        openings.push(input)
+        return { targetId: 'ios-simulator-1' }
+      },
+    }),
+  )
+
+  await runtime.handle({
+    version: 2,
+    type: 'discover-targets',
+    platform: 'ios',
+  })
+  await runtime.handle({
+    version: 2,
+    type: 'open-session',
+    sessionId: 'session-1',
+    platform: 'ios',
+    application: {
+      id: 'com.example.checkout',
+      binaryPath: '/tmp/Checkout.app',
+    },
+    mode: 'adaptive',
+  })
+
+  expect(discoveries).toEqual(['ios'])
+  expect(openings).toEqual([
+    {
+      sessionId: 'session-1',
+      platform: 'ios',
+      application: {
+        id: 'com.example.checkout',
+        binaryPath: '/tmp/Checkout.app',
+      },
+      targetId: undefined,
+      artifactDirectory: undefined,
+      artifacts: undefined,
+      redactions: undefined,
+      requiredCapabilities: undefined,
+    },
   ])
 })
 
@@ -148,7 +199,7 @@ test('cancellation stops the active device operation before the session can be r
     }),
   )
   const openRequest = {
-    version: 1 as const,
+    version: 2 as const,
     type: 'open-session' as const,
     sessionId: 'session-1',
     application,
@@ -156,7 +207,7 @@ test('cancellation stops the active device operation before the session can be r
   }
   await runtime.handle(openRequest)
   const execution = runtime.handle({
-    version: 1,
+    version: 2,
     type: 'execute-step',
     sessionId: 'session-1',
     stepIndex: 0,
@@ -166,7 +217,7 @@ test('cancellation stops the active device operation before the session can be r
 
   await expect(
     runtime.handle({
-      version: 1,
+      version: 2,
       type: 'cancel-session',
       sessionId: 'session-1',
     }),

--- a/packages/mobile/src/worker-runtime.ts
+++ b/packages/mobile/src/worker-runtime.ts
@@ -1,7 +1,10 @@
 import type {
-  AndroidApplication,
-  AndroidTarget,
+  MobileApplication,
+  MobileArtifactKind,
+  MobilePlatform,
   MobileStep,
+  MobileTarget,
+  MobileTextRedaction,
   MobileWorkerRequest,
   MobileWorkerResponse,
   WorkerResolvedAction,
@@ -11,9 +14,13 @@ import { mobileWorkerProtocolVersion } from './worker-protocol.ts'
 
 export interface OpenMobileGatewaySessionInput {
   sessionId: string
+  platform: MobilePlatform
   targetId?: string
-  application: AndroidApplication
+  application: MobileApplication
   artifactDirectory?: string
+  artifacts?: readonly MobileArtifactKind[]
+  redactions?: readonly MobileTextRedaction[]
+  requiredCapabilities?: readonly string[]
 }
 
 export interface ExecuteMobileGatewayStepInput {
@@ -24,7 +31,7 @@ export interface ExecuteMobileGatewayStepInput {
 }
 
 export interface MobileDeviceGateway {
-  discoverTargets(): Promise<AndroidTarget[]>
+  discoverTargets(platform: MobilePlatform): Promise<MobileTarget[]>
   openSession(
     input: OpenMobileGatewaySessionInput,
   ): Promise<{ targetId: string }>
@@ -59,7 +66,9 @@ export class MobileWorkerRuntime {
         return {
           version: mobileWorkerProtocolVersion,
           type: 'targets-discovered',
-          targets: await this.gateway.discoverTargets(),
+          targets: await this.gateway.discoverTargets(
+            request.platform ?? 'android',
+          ),
         }
       case 'open-session': {
         if (
@@ -72,9 +81,13 @@ export class MobileWorkerRuntime {
         }
         const opened = await this.gateway.openSession({
           sessionId: request.sessionId,
+          platform: request.platform ?? 'android',
           targetId: request.targetId,
           application: request.application,
           artifactDirectory: request.artifactDirectory,
+          artifacts: request.artifacts,
+          redactions: request.redactions,
+          requiredCapabilities: request.requiredCapabilities,
         })
         this.sessions.set(request.sessionId, {
           mode: request.mode,

--- a/packages/mobile/test/echo-worker.mjs
+++ b/packages/mobile/test/echo-worker.mjs
@@ -2,7 +2,7 @@ import { createInterface } from 'node:readline'
 
 process.stdout.write(
   `${JSON.stringify({
-    version: 1,
+    version: 2,
     type: 'worker-ready',
     nodeVersion: process.versions.node,
   })}\n`,
@@ -13,12 +13,12 @@ for await (const line of lines) {
   const message = JSON.parse(line)
   process.stdout.write(
     `${JSON.stringify({
-      version: 1,
+      version: 2,
       type: 'response',
       id: message.id,
       ok: true,
       payload: {
-        version: 1,
+        version: 2,
         type: 'targets-discovered',
         targets: [],
       },

--- a/packages/mobile/test/slow-worker.mjs
+++ b/packages/mobile/test/slow-worker.mjs
@@ -2,7 +2,7 @@ process.once('SIGTERM', () => process.exit(0))
 setTimeout(() => {
   process.stdout.write(
     `${JSON.stringify({
-      version: 1,
+      version: 2,
       type: 'worker-ready',
       nodeVersion: process.versions.node,
     })}\n`,


### PR DESCRIPTION
## Summary

- Add the iOS mobile adapter with simulator-backed execution.
- Implement agent-device gateway and worker runtime protocols.
- Document mobile adapter usage and expose the package entry points.
- Add adapter conformance, gateway, worker, and simulator smoke-test coverage.

## Testing

- Added unit, conformance, worker-runtime, gateway, and iOS simulator smoke tests.
- Not run (not requested).