### PR TITLE
Improve the default reporter with a Specification-first terminal output

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,9 +115,32 @@ pickle run "features/**/*.feature" --concurrency 5 --retries 1
 pickle run "features/**/*.feature" --screenshot on-step
 ```
 
-The default reporter prints each Scenario as it finishes and ends with a compact
-summary. Use `--reporter ndjson` when an integration needs the versioned
-run-event and test-result records as newline-delimited JSON.
+The default reporter is for people. It groups every Test result by Specification
+URI, Specification, and Scenario, then reports the selected counts and timing:
+
+```text
+ RUN  pickle 1.0.2 /workspace/project
+
+ features/search.feature
+   Search
+     ✓ Visit main page [150ms]
+
+ Specifications  1
+ Scenarios       1
+ Test results    1 passed (1)
+ Start at        14:32:07
+ Duration        182ms
+```
+
+The execution target profile is omitted when only one profile is selected and
+shown on each Test result when multiple profiles run. Interactive terminals use
+state colors in addition to symbols; redirected output is plain text, and
+`NO_COLOR` disables color explicitly. Long paths and Scenario names wrap without
+being truncated.
+
+Use `--reporter ndjson` when an integration needs the versioned run-event and
+test-result records as newline-delimited JSON. The human reporter format is not
+a machine-readable contract.
 
 ## Run Adaptive and Replay modes
 

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -20,6 +20,7 @@ import {
   screenshotModes,
   type WebAdapterOptions,
 } from '@pickle-spec/web'
+import cliPackage from '../package.json' with { type: 'json' }
 import { defaultSpecificationGlob, loadConfig } from './config'
 import {
   loadExtensions,
@@ -28,7 +29,11 @@ import {
   startProjectRun,
 } from './execute-run'
 import { checkProject, initializeProject, migrateProject } from './project'
-import { createRunReporter, type RunReporterName } from './run-reporter'
+import {
+  createRunReporter,
+  type RunReporterName,
+  terminalReporterCapabilities,
+} from './run-reporter'
 import { createStudioHistoryGateway } from './studio-history'
 import { createStudioPlanGateway } from './studio-plans'
 import {
@@ -218,7 +223,15 @@ async function run(argv: string[]): Promise<number> {
   const config = await loadConfig(args.configPath)
   const controller = new AbortController()
   const onSigint = () => controller.abort()
-  const reporter = createRunReporter(args.reporter ?? 'default')
+  const reporter = createRunReporter(args.reporter ?? 'default', {
+    projectRoot: process.cwd(),
+    version: cliPackage.version,
+    ...terminalReporterCapabilities(
+      process.stdout.isTTY,
+      process.stdout.columns,
+      process.env.NO_COLOR,
+    ),
+  })
   const startedAt = performance.now()
   process.on('SIGINT', onSigint)
   try {

--- a/packages/cli/src/run-reporter.test.ts
+++ b/packages/cli/src/run-reporter.test.ts
@@ -1,0 +1,313 @@
+import { expect, test } from 'bun:test'
+import type { ScenarioRun } from '@pickle-spec/runner'
+import { createRunReporter, terminalReporterCapabilities } from './run-reporter'
+
+type PassedRunInput = {
+  specificationUri: string
+  specificationName: string
+  scenarioId: string
+  scenarioName: string
+  profileId: string
+  durationMs: number
+}
+
+function passedRun(input: PassedRunInput): ScenarioRun {
+  return {
+    events: [],
+    result: {
+      schemaVersion: 1,
+      specification: {
+        uri: input.specificationUri,
+        name: input.specificationName,
+      },
+      scenario: { id: input.scenarioId, name: input.scenarioName },
+      executionTargetProfile: { id: input.profileId },
+      state: 'passed',
+      steps: [],
+      durationMs: input.durationMs,
+    },
+  }
+}
+
+test('renders a successful test run as a stable Specification-first tree', () => {
+  const lines: string[] = []
+  const reporter = createRunReporter('default', {
+    write: (line) => lines.push(line),
+    projectRoot: '/workspace/project',
+    version: '1.0.2',
+    color: false,
+    columns: 120,
+    now: () => new Date(2026, 7, 20, 14, 32, 7),
+  })
+
+  reporter.start()
+  reporter.finish(
+    [
+      passedRun({
+        specificationUri: 'src/google.feature',
+        specificationName: 'Search',
+        scenarioId: 'scenario-visit',
+        scenarioName: 'Visit main page',
+        profileId: 'web',
+        durationMs: 150,
+      }),
+      passedRun({
+        specificationUri: 'src/google.feature',
+        specificationName: 'Search',
+        scenarioId: 'scenario-visit',
+        scenarioName: 'Visit main page',
+        profileId: 'android',
+        durationMs: 1_240,
+      }),
+      passedRun({
+        specificationUri: 'src/google.feature',
+        specificationName: 'Search',
+        scenarioId: 'scenario-find',
+        scenarioName: 'Find pickles',
+        profileId: 'web',
+        durationMs: 820,
+      }),
+      passedRun({
+        specificationUri: 'features/checkout.feature',
+        specificationName: 'Checkout',
+        scenarioId: 'scenario-purchase',
+        scenarioName: 'Complete a purchase',
+        profileId: 'web',
+        durationMs: 5,
+      }),
+    ],
+    1_460,
+  )
+
+  expect(lines.join('\n')).toBe(`
+ RUN  pickle 1.0.2 /workspace/project
+
+ features/checkout.feature
+   Checkout
+     ✓ [web] Complete a purchase [5ms]
+
+ src/google.feature
+   Search
+     ✓ [web] Visit main page [150ms]
+     ✓ [android] Visit main page [1.24s]
+     ✓ [web] Find pickles [820ms]
+
+ Specifications  2
+ Scenarios       3
+ Test results    4 passed (4)
+ Start at        14:32:07
+ Duration        1.46s`)
+})
+
+test('uses color only as supplemental terminal state information', () => {
+  const run = passedRun({
+    specificationUri: 'src/google.feature',
+    specificationName: 'Search',
+    scenarioId: 'scenario-visit',
+    scenarioName: 'Visit main page',
+    profileId: 'web',
+    durationMs: 150,
+  })
+  const colorLines: string[] = []
+  const plainLines: string[] = []
+  const sharedOptions = {
+    projectRoot: '/workspace/project',
+    version: '1.0.2',
+    columns: 120,
+    now: () => new Date(2026, 7, 20, 14, 32, 7),
+  }
+  const colorReporter = createRunReporter('default', {
+    ...sharedOptions,
+    color: true,
+    write: (line) => colorLines.push(line),
+  })
+  const plainReporter = createRunReporter('default', {
+    ...sharedOptions,
+    color: false,
+    write: (line) => plainLines.push(line),
+  })
+
+  colorReporter.start()
+  colorReporter.finish([run], 150)
+  plainReporter.start()
+  plainReporter.finish([run], 150)
+
+  expect(colorLines.join('\n')).toContain('\u001b[32m✓\u001b[39m')
+  expect(plainLines.join('\n')).not.toContain('\u001b[')
+  expect(plainLines.join('\n')).toContain('✓ Visit main page [150ms]')
+})
+
+test('wraps long paths and Scenario names without truncating them', () => {
+  const specificationUri =
+    'features/a-very-long-directory/google-search.feature'
+  const scenarioName = 'A Scenario name that keeps all context'
+  const lines: string[] = []
+  const reporter = createRunReporter('default', {
+    write: (line) => lines.push(line),
+    projectRoot: '/workspace/a-very-long-project-name',
+    version: '1.0.2',
+    color: false,
+    columns: 32,
+    now: () => new Date(2026, 7, 20, 14, 32, 7),
+  })
+
+  reporter.start()
+  reporter.finish(
+    [
+      passedRun({
+        specificationUri,
+        specificationName: 'Search across a long product catalog',
+        scenarioId: 'scenario-search',
+        scenarioName,
+        profileId: 'web',
+        durationMs: 150,
+      }),
+    ],
+    150,
+  )
+
+  expect(lines.every((line) => line.length <= 32)).toBe(true)
+  const uriStart = lines.findIndex((line) => line.includes('features/'))
+  expect(`${lines[uriStart]?.trim()}${lines[uriStart + 1]?.trim()}`).toBe(
+    specificationUri,
+  )
+  const scenarioStart = lines.findIndex((line) => line.includes('✓'))
+  const renderedScenario = `${lines[scenarioStart]?.trim().slice(2)} ${lines[
+    scenarioStart + 1
+  ]?.trim()}`
+  expect(renderedScenario).toBe(`${scenarioName} [150ms]`)
+})
+
+test('wraps non-BMP Unicode names without corrupting their characters', () => {
+  const scenarioName = `${'🫙'.repeat(12)}${'👨‍👩‍👧‍👦'.repeat(2)}`
+  const lines: string[] = []
+  const reporter = createRunReporter('default', {
+    write: (line) => lines.push(line),
+    projectRoot: '/workspace/project',
+    version: '1.0.2',
+    color: false,
+    columns: 14,
+    now: () => new Date(2026, 7, 20, 14, 32, 7),
+  })
+
+  reporter.start()
+  reporter.finish(
+    [
+      passedRun({
+        specificationUri: 'a.feature',
+        specificationName: 'Search',
+        scenarioId: 'scenario-unicode',
+        scenarioName,
+        profileId: 'web',
+        durationMs: 150,
+      }),
+    ],
+    150,
+  )
+
+  expect(lines.join('\n')).not.toContain('�')
+  const unicodeLines = lines.filter((line) => /[🫙👨👩👧👦‍]/u.test(line))
+  expect(unicodeLines.every((line) => Bun.stringWidth(line) <= 14)).toBe(true)
+  expect(
+    unicodeLines.every(
+      (line) => !line.trim().startsWith('‍') && !line.trim().endsWith('‍'),
+    ),
+  ).toBe(true)
+  expect(
+    lines
+      .filter((line) => line.includes('🫙'))
+      .join('')
+      .match(/🫙/gu),
+  ).toHaveLength(12)
+})
+
+test('counts Test result states as mutually exclusive summary outcomes', () => {
+  const states = [
+    'passed',
+    'passed-with-adaptation',
+    'failed',
+    'infrastructure-error',
+    'skipped',
+    'cancelled',
+  ] as const
+  const lines: string[] = []
+  const reporter = createRunReporter('default', {
+    write: (line) => lines.push(line),
+    projectRoot: '/workspace/project',
+    version: '1.0.2',
+    color: false,
+    columns: 120,
+    now: () => new Date(2026, 7, 20, 14, 32, 7),
+  })
+  const runs = states.map((state, index) => {
+    const run = passedRun({
+      specificationUri: 'src/google.feature',
+      specificationName: 'Search',
+      scenarioId: `scenario-${index}`,
+      scenarioName: `Scenario ${index}`,
+      profileId: 'web',
+      durationMs: 150,
+    })
+    return { ...run, result: { ...run.result, state } }
+  })
+
+  reporter.start()
+  reporter.finish(runs, 150)
+
+  expect(lines).toContain(
+    ' Test results    1 failed | 1 infrastructure error | 1 adapted | 1 passed | 1 skipped | 1 cancelled (6)',
+  )
+  expect(lines.join('\n')).toContain('× Scenario 2 [150ms] (failed)')
+  expect(lines.join('\n')).toContain(
+    '! Scenario 3 [150ms] (infrastructure error)',
+  )
+  expect(lines.join('\n')).toContain('↓ Scenario 4 [150ms] (skipped)')
+  expect(lines.join('\n')).toContain('○ Scenario 5 [150ms] (cancelled)')
+})
+
+test('enables color only for a TTY when NO_COLOR is absent', () => {
+  expect(terminalReporterCapabilities(true, 100, undefined)).toEqual({
+    color: true,
+    columns: 100,
+  })
+  expect(terminalReporterCapabilities(true, 100, '')).toEqual({
+    color: false,
+    columns: 100,
+  })
+  expect(terminalReporterCapabilities(false, undefined, undefined)).toEqual({
+    color: false,
+    columns: undefined,
+  })
+})
+
+test('preserves Test result messages in the human report', () => {
+  const lines: string[] = []
+  const reporter = createRunReporter('default', {
+    write: (line) => lines.push(line),
+    projectRoot: '/workspace/project',
+    version: '1.0.2',
+    color: false,
+    columns: 48,
+    now: () => new Date(2026, 7, 20, 14, 32, 7),
+  })
+  const run = passedRun({
+    specificationUri: 'src/google.feature',
+    specificationName: 'Search',
+    scenarioId: 'scenario-search',
+    scenarioName: 'Find pickles',
+    profileId: 'web',
+    durationMs: 150,
+  })
+  run.result.state = 'failed'
+  run.result.message =
+    'Expected results, but the page remained empty\nScreenshot captured'
+
+  reporter.start()
+  reporter.finish([run], 150)
+
+  expect(lines.join('\n')).toContain(
+    '       Expected results, but the page remained\n' +
+      '       empty\n' +
+      '       Screenshot captured',
+  )
+})

--- a/packages/cli/src/run-reporter.ts
+++ b/packages/cli/src/run-reporter.ts
@@ -10,77 +10,303 @@ export interface RunReporter {
 
 type WriteLine = (line: string) => void
 
-const resultMarks: Record<TestResult['state'], string> = {
-  passed: '✓',
-  'passed-with-adaptation': '✓',
-  failed: '×',
-  skipped: '↓',
-  cancelled: '×',
-  'infrastructure-error': '×',
+type RunReporterOptions = {
+  write?: WriteLine
+  projectRoot?: string
+  version?: string
+  color?: boolean
+  columns?: number
+  now?: () => Date
 }
+
+type ScenarioGroup = {
+  name: string
+  results: TestResult[]
+}
+
+type SpecificationGroup = {
+  uri: string
+  name: string
+  scenarios: Map<string, ScenarioGroup>
+}
+
+type ResultPresentation = {
+  mark: string
+  color: number
+  detail?: string
+  singular: string
+  plural: string
+}
+
+const resultPresentations: Record<TestResult['state'], ResultPresentation> = {
+  failed: {
+    mark: '×',
+    color: 31,
+    detail: 'failed',
+    singular: 'failed',
+    plural: 'failed',
+  },
+  'infrastructure-error': {
+    mark: '!',
+    color: 31,
+    detail: 'infrastructure error',
+    singular: 'infrastructure error',
+    plural: 'infrastructure errors',
+  },
+  'passed-with-adaptation': {
+    mark: '✓',
+    color: 33,
+    detail: 'adapted',
+    singular: 'adapted',
+    plural: 'adapted',
+  },
+  passed: { mark: '✓', color: 32, singular: 'passed', plural: 'passed' },
+  skipped: {
+    mark: '↓',
+    color: 90,
+    detail: 'skipped',
+    singular: 'skipped',
+    plural: 'skipped',
+  },
+  cancelled: {
+    mark: '○',
+    color: 33,
+    detail: 'cancelled',
+    singular: 'cancelled',
+    plural: 'cancelled',
+  },
+}
+
+type TextUnit = {
+  value: string
+  width: number
+}
+
+type ResultPresentationEntry = [TestResult['state'], ResultPresentation]
+
+const graphemeSegmenter = new Intl.Segmenter(undefined, {
+  granularity: 'grapheme',
+})
 
 function durationLabel(durationMs: number): string {
   if (durationMs < 1_000) return `${Math.round(durationMs)}ms`
   return `${(durationMs / 1_000).toFixed(2)}s`
 }
 
+function clockLabel(date: Date): string {
+  return [date.getHours(), date.getMinutes(), date.getSeconds()]
+    .map((part) => String(part).padStart(2, '0'))
+    .join(':')
+}
+
+function stateMark(state: TestResult['state'], color: boolean): string {
+  const { mark, color: colorCode } = resultPresentations[state]
+  return color ? `\u001b[${colorCode}m${mark}\u001b[39m` : mark
+}
+
+function textUnits(value: string): TextUnit[] {
+  return [...graphemeSegmenter.segment(value)].map(({ segment }) => ({
+    value: segment,
+    width: Bun.stringWidth(segment),
+  }))
+}
+
+function textWidth(units: readonly TextUnit[]): number {
+  return units.reduce((total, unit) => total + unit.width, 0)
+}
+
+function wrapPoint(units: readonly TextUnit[], width: number): number {
+  let naturalBreak = -1
+  let forcedBreak = 0
+  let consumedWidth = 0
+  for (let index = 0; index < units.length; index++) {
+    const unit = units[index]
+    if (!unit || consumedWidth + unit.width > width) break
+    consumedWidth += unit.width
+    forcedBreak = index + 1
+    if (unit.value === ' ') naturalBreak = index
+    if (unit.value === '/') naturalBreak = index + 1
+  }
+  return naturalBreak > 0 ? naturalBreak : Math.max(1, forcedBreak)
+}
+
+function wrappedLines(
+  prefix: string,
+  content: string,
+  continuationPrefix: string,
+  columns?: number,
+  visiblePrefixLength = prefix.length,
+): string[] {
+  if (!columns || visiblePrefixLength + Bun.stringWidth(content) <= columns) {
+    return [`${prefix}${content}`]
+  }
+
+  const lines: string[] = []
+  let remaining = textUnits(content)
+  let linePrefix = prefix
+  let prefixLength = visiblePrefixLength
+  while (remaining.length > 0) {
+    const width = Math.max(1, columns - prefixLength)
+    if (textWidth(remaining) <= width) {
+      lines.push(`${linePrefix}${remaining.map((unit) => unit.value).join('')}`)
+      break
+    }
+    const point = wrapPoint(remaining, width)
+    lines.push(
+      `${linePrefix}${remaining
+        .slice(0, point)
+        .map((unit) => unit.value)
+        .join('')
+        .trimEnd()}`,
+    )
+    remaining = textUnits(
+      remaining
+        .slice(point)
+        .map((unit) => unit.value)
+        .join('')
+        .trimStart(),
+    )
+    linePrefix = continuationPrefix
+    prefixLength = continuationPrefix.length
+  }
+  return lines
+}
+
+function writeWrapped(
+  write: WriteLine,
+  prefix: string,
+  content: string,
+  continuationPrefix: string,
+  columns?: number,
+  visiblePrefixLength?: number,
+): void {
+  for (const line of wrappedLines(
+    prefix,
+    content,
+    continuationPrefix,
+    columns,
+    visiblePrefixLength,
+  )) {
+    write(line)
+  }
+}
+
 function resultSuffix(result: TestResult): string {
   const details = []
-  if (result.state === 'passed-with-adaptation') details.push('adapted')
+  const stateDetail = resultPresentations[result.state].detail
+  if (stateDetail) details.push(stateDetail)
   if (result.flaky) details.push(`flaky, ${result.attempts ?? 2} attempts`)
   return details.length > 0 ? ` (${details.join('; ')})` : ''
 }
 
-function formatResult(result: TestResult): string {
-  const location = [
-    result.specification.uri,
-    result.specification.name,
-    result.scenario.name,
-  ].join(' > ')
-  const line = ` ${resultMarks[result.state]} ${location} [${result.executionTargetProfile.id}] ${durationLabel(result.durationMs ?? 0)}${resultSuffix(result)}`
-  if (!result.message) return line
-  return `${line}\n   ${result.message.replaceAll('\n', '\n   ')}`
+function scenarioKey(result: TestResult): string {
+  if (result.scenario.id) return result.scenario.id
+  return `${result.specification.uri}\0${result.scenario.name}`
 }
 
-function scenarioSummary(results: readonly TestResult[]): string {
-  const counts = {
-    passed: 0,
-    adapted: 0,
-    failed: 0,
-    skipped: 0,
-    cancelled: 0,
-  }
+function groupResults(results: readonly TestResult[]): SpecificationGroup[] {
+  const specifications = new Map<string, SpecificationGroup>()
   for (const result of results) {
-    if (result.state === 'passed') counts.passed++
-    else if (result.state === 'passed-with-adaptation') counts.adapted++
-    else if (result.state === 'skipped') counts.skipped++
-    else if (result.state === 'cancelled') counts.cancelled++
-    else counts.failed++
+    let specification = specifications.get(result.specification.uri)
+    if (!specification) {
+      specification = {
+        uri: result.specification.uri,
+        name: result.specification.name,
+        scenarios: new Map(),
+      }
+      specifications.set(result.specification.uri, specification)
+    }
+
+    const key = scenarioKey(result)
+    let scenario = specification.scenarios.get(key)
+    if (!scenario) {
+      scenario = { name: result.scenario.name, results: [] }
+      specification.scenarios.set(key, scenario)
+    }
+    scenario.results.push(result)
   }
-  const labels = [
-    counts.passed ? `${counts.passed} passed` : undefined,
-    counts.adapted ? `${counts.adapted} adapted` : undefined,
-    counts.failed ? `${counts.failed} failed` : undefined,
-    counts.skipped ? `${counts.skipped} skipped` : undefined,
-    counts.cancelled ? `${counts.cancelled} cancelled` : undefined,
-  ].filter((label): label is string => Boolean(label))
+  return [...specifications.values()].sort((left, right) =>
+    left.uri.localeCompare(right.uri),
+  )
+}
+
+function testResultSummary(results: readonly TestResult[]): string {
+  const entries = Object.entries(
+    resultPresentations,
+  ) as ResultPresentationEntry[]
+  const labels = entries.flatMap(([state, { singular, plural }]) => {
+    const count = results.filter((result) => result.state === state).length
+    if (count === 0) return []
+    return [`${count} ${count === 1 ? singular : plural}`]
+  })
   return `${labels.join(' | ')} (${results.length})`
 }
 
-function createDefaultReporter(write: WriteLine): RunReporter {
+function createDefaultReporter(options: RunReporterOptions): RunReporter {
+  const write = options.write ?? console.log
+  const now = options.now ?? (() => new Date())
+  const projectRoot = options.projectRoot ?? process.cwd()
+  const version = options.version ?? 'unknown'
+  const color = options.color ?? false
+  const columns = options.columns
+  let startTime = ''
+
   return {
     start() {
+      startTime = clockLabel(now())
       write('')
-      write(' RUN  pickle run')
+      const bannerPrefix = ` RUN  pickle ${version} `
+      writeWrapped(
+        write,
+        bannerPrefix,
+        projectRoot,
+        ' '.repeat(bannerPrefix.length),
+        columns,
+      )
       write('')
     },
-    event(event) {
-      if (event.type === 'scenario-finished') write(formatResult(event.result))
-    },
+    event() {},
     finish(runs, durationMs) {
+      const results = runs.map((run) => run.result)
+      const multipleProfiles =
+        new Set(results.map((result) => result.executionTargetProfile.id))
+          .size > 1
+      const specifications = groupResults(results)
+
+      specifications.forEach((specification, specificationIndex) => {
+        if (specificationIndex > 0) write('')
+        writeWrapped(write, ' ', specification.uri, '   ', columns)
+        writeWrapped(write, '   ', specification.name, '     ', columns)
+        for (const scenario of specification.scenarios.values()) {
+          for (const result of scenario.results) {
+            const profile = multipleProfiles
+              ? `[${result.executionTargetProfile.id}] `
+              : ''
+            const plainPrefix = `     ${resultPresentations[result.state].mark} ${profile}`
+            const styledPrefix = `     ${stateMark(result.state, color)} ${profile}`
+            writeWrapped(
+              write,
+              styledPrefix,
+              `${scenario.name} [${durationLabel(result.durationMs ?? 0)}]${resultSuffix(result)}`,
+              ' '.repeat(plainPrefix.length),
+              columns,
+              plainPrefix.length,
+            )
+            for (const messageLine of result.message?.split('\n') ?? []) {
+              writeWrapped(write, '       ', messageLine, '       ', columns)
+            }
+          }
+        }
+      })
+
       write('')
-      write(` Scenarios  ${scenarioSummary(runs.map((run) => run.result))}`)
-      write(` Duration   ${durationLabel(durationMs)}`)
+      write(` Specifications  ${specifications.length}`)
+      write(
+        ` Scenarios       ${specifications.reduce((total, specification) => total + specification.scenarios.size, 0)}`,
+      )
+      write(` Test results    ${testResultSummary(results)}`)
+      write(` Start at        ${startTime}`)
+      write(` Duration        ${durationLabel(durationMs)}`)
     },
   }
 }
@@ -100,11 +326,23 @@ function createNdjsonReporter(write: WriteLine): RunReporter {
   }
 }
 
+export function terminalReporterCapabilities(
+  isTerminal: boolean | undefined,
+  columns: number | undefined,
+  noColor: string | undefined,
+): Pick<RunReporterOptions, 'color' | 'columns'> {
+  return {
+    color: Boolean(isTerminal) && noColor === undefined,
+    columns,
+  }
+}
+
 export function createRunReporter(
   name: RunReporterName,
-  write: WriteLine = console.log,
+  options: RunReporterOptions = {},
 ): RunReporter {
+  const write = options.write ?? console.log
   return name === 'ndjson'
     ? createNdjsonReporter(write)
-    : createDefaultReporter(write)
+    : createDefaultReporter(options)
 }

--- a/packages/cli/src/workspace.test.ts
+++ b/packages/cli/src/workspace.test.ts
@@ -1,5 +1,5 @@
 import { afterAll, beforeAll, describe, expect, test } from 'bun:test'
-import { mkdir, mkdtemp, rm, symlink } from 'node:fs/promises'
+import { mkdir, mkdtemp, realpath, rm, symlink } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { dirname, join, resolve } from 'node:path'
 
@@ -156,12 +156,17 @@ export default {
 
     expect(stderr).toBe('')
     expect(exitCode).toBe(0)
-    expect(stdout).toContain('RUN  pickle run')
+    expect(stdout).toContain(`RUN  pickle 1.0.2 ${await realpath(workspace)}`)
     expect(stdout).toContain(
-      'purchase.feature > Purchase > Complete a purchase [deterministic]',
+      ' purchase.feature\n   Purchase\n     ✓ Complete a purchase [',
     )
-    expect(stdout).toContain('Scenarios  1 passed (1)')
+    expect(stdout).not.toContain('[deterministic]')
+    expect(stdout).toContain('Specifications  1')
+    expect(stdout).toContain('Scenarios       1')
+    expect(stdout).toContain('Test results    1 passed (1)')
+    expect(stdout).toContain('Start at')
     expect(stdout).toContain('Duration')
+    expect(stdout).not.toContain('\u001b[')
     expect(stdout).not.toContain('"kind":"run-event"')
     expect(stdout).not.toContain('"kind":"test-result"')
     expect(stdout).not.toContain('gherkinDocument')


### PR DESCRIPTION
## Summary

- Reworked the default CLI reporter around a Specification → Scenario → Test result hierarchy.
- Added version, project path, timing, per-state counts, profile labels, colors, and responsive wrapping.
- Preserved NDJSON as the machine-readable reporter and documented the human-readable format.
- Added coverage for formatting, state summaries, terminal color behavior, Unicode wrapping, messages, and workspace output.

## Testing

- Added focused reporter and workspace integration tests covering the new output contract.