### PR TITLE
Stream ordered Specification blocks during execution

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,11 @@ state colors in addition to symbols; redirected output is plain text, and
 `NO_COLOR` disables color explicitly. Long paths and Scenario names wrap without
 being truncated.
 
+In CI and other redirected output, each complete Specification block is written
+as soon as every earlier Specification is also complete. Output remains
+append-only while preserving the same deterministic order and content as the
+finished report.
+
 Use `--reporter ndjson` when an integration needs the versioned run-event and
 test-result records as newline-delimited JSON. The human reporter format is not
 a machine-readable contract.

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -241,6 +241,8 @@ async function run(argv: string[]): Promise<number> {
       options: args,
       signal: controller.signal,
       onEvent: reporter.event,
+      onSchedule: reporter.prepare,
+      onResult: reporter.complete,
     })
     reporter.start()
     const { runs, manifest } = await started.done

--- a/packages/cli/src/execute-run.ts
+++ b/packages/cli/src/execute-run.ts
@@ -5,7 +5,9 @@ import type {
   ExecutionTargetProfile,
   RunEvent,
   RunExtensions,
+  ScenarioCompletion,
   ScenarioRun,
+  ScheduledTestResult,
   TestResult,
   TestRunManifest,
 } from '@pickle-spec/runner'
@@ -15,12 +17,14 @@ import {
   openTestRunStore,
   resolveRunConfiguration,
   runScenarios,
+  scheduleScenarios,
   selectRerunResults,
   validateTargetSelection,
 } from '@pickle-spec/runner'
 import {
   parseSpecification,
   resolveScenarioId,
+  type ScenarioSelection,
   type SelectionOptions,
   selectScenarios,
   validateSpecificationMetadata,
@@ -63,6 +67,18 @@ export interface StartedProjectRun {
     runs: ScenarioRun[]
     manifest: TestRunManifest
   }>
+}
+
+type StartProjectRunInput = {
+  root: string
+  config: PickleConfig
+  options?: ProjectRunOptions
+  signal?: AbortSignal
+  onEvent?: (event: RunEvent) => void | Promise<void>
+  onSchedule?: (
+    schedule: readonly ScheduledTestResult[],
+  ) => void | Promise<void>
+  onResult?: (result: TestResult) => void | Promise<void>
 }
 
 export async function loadExtensions(
@@ -281,13 +297,9 @@ export async function loadPersistedRun(root: string, runId: string) {
   return { manifest, events }
 }
 
-export async function startProjectRun(input: {
-  root: string
-  config: PickleConfig
-  options?: ProjectRunOptions
-  signal?: AbortSignal
-  onEvent?: (event: RunEvent) => void | Promise<void>
-}): Promise<StartedProjectRun> {
+export async function startProjectRun(
+  input: StartProjectRunInput,
+): Promise<StartedProjectRun> {
   const args = input.options ?? {}
   const root = input.root
   const store = openTestRunStore({
@@ -426,6 +438,27 @@ export async function startProjectRun(input: {
         ),
       )
       validateTargetSelection(selections, resolvedConfiguration.targets)
+      const includeTarget = selectedResults
+        ? (
+            selection: ScenarioSelection,
+            executionTargetProfile: ExecutionTargetProfile,
+          ) =>
+            selectedResults.some(
+              (result) =>
+                result.executionTargetProfile.id ===
+                  executionTargetProfile.id &&
+                selectionMatchesResult(selection, result),
+            )
+        : undefined
+      await input.onSchedule?.(
+        scheduleScenarios({
+          selections,
+          executionTargetProfiles: resolvedConfiguration.targets.map(
+            ({ executionTargetProfile }) => executionTargetProfile,
+          ),
+          includeTarget,
+        }),
+      )
       server = await startServer({
         ...input.config.server,
         ...(args.reuseServer ? { reuseExisting: true } : {}),
@@ -448,6 +481,10 @@ export async function startProjectRun(input: {
         ci: Boolean(process.env.CI),
         signal: input.signal,
         onEvent,
+        onResult: input.onResult
+          ? (completion: ScenarioCompletion) =>
+              input.onResult?.(completion.result)
+          : undefined,
       }
       const runs = selectedResults
         ? await runSelectedResultPairs({

--- a/packages/cli/src/run-reporter.test.ts
+++ b/packages/cli/src/run-reporter.test.ts
@@ -99,6 +99,174 @@ test('renders a successful test run as a stable Specification-first tree', () =>
  Duration        1.46s`)
 })
 
+test('streams contiguous ready Specification blocks in final report order', () => {
+  const runs = [
+    passedRun({
+      specificationUri: 'features/a.feature',
+      specificationName: 'First',
+      scenarioId: 'scenario-a-one',
+      scenarioName: 'First Scenario',
+      profileId: 'web',
+      durationMs: 10,
+    }),
+    passedRun({
+      specificationUri: 'features/a.feature',
+      specificationName: 'First',
+      scenarioId: 'scenario-a-one',
+      scenarioName: 'First Scenario',
+      profileId: 'android',
+      durationMs: 20,
+    }),
+    passedRun({
+      specificationUri: 'features/a.feature',
+      specificationName: 'First',
+      scenarioId: 'scenario-a-two',
+      scenarioName: 'Second Scenario',
+      profileId: 'web',
+      durationMs: 30,
+    }),
+    passedRun({
+      specificationUri: 'features/a.feature',
+      specificationName: 'First',
+      scenarioId: 'scenario-a-two',
+      scenarioName: 'Second Scenario',
+      profileId: 'android',
+      durationMs: 40,
+    }),
+    passedRun({
+      specificationUri: 'features/b.feature',
+      specificationName: 'Second',
+      scenarioId: 'scenario-b',
+      scenarioName: 'Ready early',
+      profileId: 'web',
+      durationMs: 50,
+    }),
+    passedRun({
+      specificationUri: 'features/b.feature',
+      specificationName: 'Second',
+      scenarioId: 'scenario-b',
+      scenarioName: 'Ready early',
+      profileId: 'android',
+      durationMs: 60,
+    }),
+  ]
+  const schedule = runs.map(({ result }) => ({
+    specification: result.specification,
+    scenario: result.scenario,
+    executionTargetProfile: result.executionTargetProfile,
+  }))
+  const options = {
+    projectRoot: '/workspace/project',
+    version: '1.0.2',
+    color: false,
+    columns: 120,
+    progressive: true,
+    now: () => new Date(2026, 7, 20, 14, 32, 7),
+  }
+  const progressiveLines: string[] = []
+  const progressiveReporter = createRunReporter('default', {
+    ...options,
+    write: (line) => progressiveLines.push(line),
+  })
+
+  progressiveReporter.start()
+  progressiveReporter.prepare?.(schedule)
+  for (const index of [4, 5, 3, 1, 0]) {
+    progressiveReporter.complete?.(runs[index]!.result)
+  }
+  expect(progressiveLines.join('\n')).not.toContain('features/a.feature')
+  expect(progressiveLines.join('\n')).not.toContain('features/b.feature')
+
+  progressiveReporter.complete?.(runs[2]!.result)
+  progressiveReporter.complete?.(runs[4]!.result)
+  expect(progressiveLines.join('\n')).toContain('features/b.feature')
+  progressiveReporter.finish(runs, 100)
+
+  const finishOnlyLines: string[] = []
+  const finishOnlyReporter = createRunReporter('default', {
+    ...options,
+    write: (line) => finishOnlyLines.push(line),
+  })
+  finishOnlyReporter.start()
+  finishOnlyReporter.finish(runs, 100)
+
+  expect(progressiveLines).toEqual(finishOnlyLines)
+  expect(progressiveLines.join('\n')).toContain(
+    '✓ [web] First Scenario [10ms]\n' +
+      '     ✓ [android] First Scenario [20ms]\n' +
+      '     ✓ [web] Second Scenario [30ms]\n' +
+      '     ✓ [android] Second Scenario [40ms]',
+  )
+})
+
+test('keeps schedule and completion callbacks out of NDJSON output', () => {
+  const run = passedRun({
+    specificationUri: 'features/a.feature',
+    specificationName: 'First',
+    scenarioId: 'scenario-a',
+    scenarioName: 'Scenario A',
+    profileId: 'web',
+    durationMs: 10,
+  })
+  const lines: string[] = []
+  const reporter = createRunReporter('ndjson', {
+    write: (line) => lines.push(line),
+  })
+
+  reporter.start()
+  reporter.prepare?.([
+    {
+      specification: run.result.specification,
+      scenario: run.result.scenario,
+      executionTargetProfile: run.result.executionTargetProfile,
+    },
+  ])
+  reporter.complete?.(run.result)
+  expect(lines).toEqual([])
+
+  reporter.finish([run], 10)
+  expect(lines).toHaveLength(1)
+  expect(JSON.parse(lines[0]!)).toEqual({
+    kind: 'test-result',
+    result: run.result,
+  })
+})
+
+test('keeps interactive human output buffered until the run finishes', () => {
+  const run = passedRun({
+    specificationUri: 'features/a.feature',
+    specificationName: 'First',
+    scenarioId: 'scenario-a',
+    scenarioName: 'Scenario A',
+    profileId: 'web',
+    durationMs: 10,
+  })
+  const lines: string[] = []
+  const reporter = createRunReporter('default', {
+    write: (line) => lines.push(line),
+    projectRoot: '/workspace/project',
+    version: '1.0.2',
+    color: true,
+    columns: 120,
+    progressive: false,
+    now: () => new Date(2026, 7, 20, 14, 32, 7),
+  })
+
+  reporter.start()
+  reporter.prepare?.([
+    {
+      specification: run.result.specification,
+      scenario: run.result.scenario,
+      executionTargetProfile: run.result.executionTargetProfile,
+    },
+  ])
+  reporter.complete?.(run.result)
+  expect(lines.join('\n')).not.toContain('features/a.feature')
+
+  reporter.finish([run], 10)
+  expect(lines.join('\n')).toContain('features/a.feature')
+})
+
 test('uses color only as supplemental terminal state information', () => {
   const run = passedRun({
     specificationUri: 'src/google.feature',
@@ -269,14 +437,17 @@ test('enables color only for a TTY when NO_COLOR is absent', () => {
   expect(terminalReporterCapabilities(true, 100, undefined)).toEqual({
     color: true,
     columns: 100,
+    progressive: false,
   })
   expect(terminalReporterCapabilities(true, 100, '')).toEqual({
     color: false,
     columns: 100,
+    progressive: false,
   })
   expect(terminalReporterCapabilities(false, undefined, undefined)).toEqual({
     color: false,
     columns: undefined,
+    progressive: true,
   })
 })
 

--- a/packages/cli/src/run-reporter.ts
+++ b/packages/cli/src/run-reporter.ts
@@ -1,10 +1,17 @@
-import type { RunEvent, ScenarioRun, TestResult } from '@pickle-spec/runner'
+import type {
+  RunEvent,
+  ScenarioRun,
+  ScheduledTestResult,
+  TestResult,
+} from '@pickle-spec/runner'
 
 export type RunReporterName = 'default' | 'ndjson'
 
 export interface RunReporter {
   start(): void
+  prepare?(schedule: readonly ScheduledTestResult[]): void
   event(event: RunEvent): void
+  complete?(result: TestResult): void
   finish(runs: readonly ScenarioRun[], durationMs: number): void
 }
 
@@ -16,6 +23,7 @@ type RunReporterOptions = {
   version?: string
   color?: boolean
   columns?: number
+  progressive?: boolean
   now?: () => Date
 }
 
@@ -28,6 +36,11 @@ type SpecificationGroup = {
   uri: string
   name: string
   scenarios: Map<string, ScenarioGroup>
+}
+
+type PendingSpecificationBlock = {
+  uri: string
+  scheduleIndexes: number[]
 }
 
 type ResultPresentation = {
@@ -230,6 +243,98 @@ function groupResults(results: readonly TestResult[]): SpecificationGroup[] {
   )
 }
 
+function groupSchedule(
+  schedule: readonly ScheduledTestResult[],
+): PendingSpecificationBlock[] {
+  const blocks = new Map<string, PendingSpecificationBlock>()
+  schedule.forEach((result, scheduleIndex) => {
+    let block = blocks.get(result.specification.uri)
+    if (!block) {
+      block = { uri: result.specification.uri, scheduleIndexes: [] }
+      blocks.set(result.specification.uri, block)
+    }
+    block.scheduleIndexes.push(scheduleIndex)
+  })
+  return [...blocks.values()].sort((left, right) =>
+    left.uri.localeCompare(right.uri),
+  )
+}
+
+function orderedScheduleFromResults(
+  results: readonly TestResult[],
+): ScheduledTestResult[] {
+  return groupResults(results).flatMap((specification) =>
+    [...specification.scenarios.values()].flatMap((scenario) =>
+      scenario.results.map((result) => ({
+        specification: result.specification,
+        scenario: result.scenario,
+        executionTargetProfile: result.executionTargetProfile,
+      })),
+    ),
+  )
+}
+
+function scheduledResultMatches(
+  scheduled: ScheduledTestResult,
+  result: TestResult,
+): boolean {
+  const scenarioMatches = scheduled.scenario.id
+    ? scheduled.scenario.id === result.scenario.id
+    : scheduled.scenario.name === result.scenario.name
+  return (
+    scheduled.specification.uri === result.specification.uri &&
+    scenarioMatches &&
+    scheduled.executionTargetProfile.id === result.executionTargetProfile.id
+  )
+}
+
+type SpecificationWriterOptions = {
+  write: WriteLine
+  color: boolean
+  columns?: number
+  multipleProfiles: boolean
+}
+
+function writeSpecification(
+  specification: SpecificationGroup,
+  options: SpecificationWriterOptions,
+): void {
+  writeWrapped(options.write, ' ', specification.uri, '   ', options.columns)
+  writeWrapped(
+    options.write,
+    '   ',
+    specification.name,
+    '     ',
+    options.columns,
+  )
+  for (const scenario of specification.scenarios.values()) {
+    for (const result of scenario.results) {
+      const profile = options.multipleProfiles
+        ? `[${result.executionTargetProfile.id}] `
+        : ''
+      const plainPrefix = `     ${resultPresentations[result.state].mark} ${profile}`
+      const styledPrefix = `     ${stateMark(result.state, options.color)} ${profile}`
+      writeWrapped(
+        options.write,
+        styledPrefix,
+        `${scenario.name} [${durationLabel(result.durationMs ?? 0)}]${resultSuffix(result)}`,
+        ' '.repeat(plainPrefix.length),
+        options.columns,
+        plainPrefix.length,
+      )
+      for (const messageLine of result.message?.split('\n') ?? []) {
+        writeWrapped(
+          options.write,
+          '       ',
+          messageLine,
+          '       ',
+          options.columns,
+        )
+      }
+    }
+  }
+}
+
 function testResultSummary(results: readonly TestResult[]): string {
   const entries = Object.entries(
     resultPresentations,
@@ -249,7 +354,65 @@ function createDefaultReporter(options: RunReporterOptions): RunReporter {
   const version = options.version ?? 'unknown'
   const color = options.color ?? false
   const columns = options.columns
+  const progressive = options.progressive ?? false
   let startTime = ''
+  let schedule: readonly ScheduledTestResult[] = []
+  let completedResults: Array<TestResult | undefined> = []
+  let pendingBlocks: PendingSpecificationBlock[] = []
+  let nextBlockIndex = 0
+  let wroteSpecification = false
+  let multipleProfiles = false
+
+  function prepare(nextSchedule: readonly ScheduledTestResult[]): void {
+    schedule = nextSchedule
+    completedResults = Array.from({ length: nextSchedule.length })
+    pendingBlocks = groupSchedule(nextSchedule)
+    nextBlockIndex = 0
+    wroteSpecification = false
+    multipleProfiles =
+      new Set(nextSchedule.map((result) => result.executionTargetProfile.id))
+        .size > 1
+  }
+
+  function flushReadyBlocks(): void {
+    while (nextBlockIndex < pendingBlocks.length) {
+      const block = pendingBlocks[nextBlockIndex]!
+      const results = block.scheduleIndexes.map(
+        (scheduleIndex) => completedResults[scheduleIndex],
+      )
+      if (results.some((result) => !result)) return
+      const [specification] = groupResults(results as TestResult[])
+      if (!specification) return
+      if (wroteSpecification) write('')
+      writeSpecification(specification, {
+        write,
+        color,
+        columns,
+        multipleProfiles,
+      })
+      wroteSpecification = true
+      nextBlockIndex++
+    }
+  }
+
+  function complete(result: TestResult): void {
+    const scheduleIndex = schedule.findIndex(
+      (scheduled, index) =>
+        !completedResults[index] && scheduledResultMatches(scheduled, result),
+    )
+    if (scheduleIndex < 0) {
+      if (
+        schedule.some((scheduled) => scheduledResultMatches(scheduled, result))
+      ) {
+        return
+      }
+      throw new Error(
+        `Completed unscheduled Scenario "${result.scenario.name}" for execution target profile "${result.executionTargetProfile.id}"`,
+      )
+    }
+    completedResults[scheduleIndex] = result
+    if (progressive) flushReadyBlocks()
+  }
 
   return {
     start() {
@@ -265,39 +428,17 @@ function createDefaultReporter(options: RunReporterOptions): RunReporter {
       )
       write('')
     },
+    prepare,
     event() {},
+    complete,
     finish(runs, durationMs) {
       const results = runs.map((run) => run.result)
-      const multipleProfiles =
-        new Set(results.map((result) => result.executionTargetProfile.id))
-          .size > 1
+      if (schedule.length === 0) prepare(orderedScheduleFromResults(results))
+      if (completedResults.some((result) => !result)) {
+        for (const result of results) complete(result)
+      }
+      flushReadyBlocks()
       const specifications = groupResults(results)
-
-      specifications.forEach((specification, specificationIndex) => {
-        if (specificationIndex > 0) write('')
-        writeWrapped(write, ' ', specification.uri, '   ', columns)
-        writeWrapped(write, '   ', specification.name, '     ', columns)
-        for (const scenario of specification.scenarios.values()) {
-          for (const result of scenario.results) {
-            const profile = multipleProfiles
-              ? `[${result.executionTargetProfile.id}] `
-              : ''
-            const plainPrefix = `     ${resultPresentations[result.state].mark} ${profile}`
-            const styledPrefix = `     ${stateMark(result.state, color)} ${profile}`
-            writeWrapped(
-              write,
-              styledPrefix,
-              `${scenario.name} [${durationLabel(result.durationMs ?? 0)}]${resultSuffix(result)}`,
-              ' '.repeat(plainPrefix.length),
-              columns,
-              plainPrefix.length,
-            )
-            for (const messageLine of result.message?.split('\n') ?? []) {
-              writeWrapped(write, '       ', messageLine, '       ', columns)
-            }
-          }
-        }
-      })
 
       write('')
       write(` Specifications  ${specifications.length}`)
@@ -330,10 +471,11 @@ export function terminalReporterCapabilities(
   isTerminal: boolean | undefined,
   columns: number | undefined,
   noColor: string | undefined,
-): Pick<RunReporterOptions, 'color' | 'columns'> {
+): Pick<RunReporterOptions, 'color' | 'columns' | 'progressive'> {
   return {
     color: Boolean(isTerminal) && noColor === undefined,
     columns,
+    progressive: !isTerminal,
   }
 }
 

--- a/packages/cli/src/run-streaming.test.ts
+++ b/packages/cli/src/run-streaming.test.ts
@@ -1,0 +1,211 @@
+import { afterAll, beforeAll, expect, test } from 'bun:test'
+import { mkdir, mkdtemp, rm, symlink } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join, resolve } from 'node:path'
+
+let workspace: string
+let pickleCommand: string
+
+type PackageManifest = {
+  bin: { pickle: string }
+}
+
+async function waitForFile(path: string): Promise<void> {
+  const deadline = Date.now() + 5_000
+  while (!(await Bun.file(path).exists())) {
+    if (Date.now() >= deadline) throw new Error(`Timed out waiting for ${path}`)
+    await Bun.sleep(5)
+  }
+}
+
+async function waitForOutput(
+  output: readonly string[],
+  expected: string,
+): Promise<string> {
+  const deadline = Date.now() + 5_000
+  while (!output.join('').includes(expected)) {
+    if (Date.now() >= deadline) {
+      throw new Error(`Timed out waiting for output: ${expected}`)
+    }
+    await Bun.sleep(5)
+  }
+  return output.join('')
+}
+
+beforeAll(async () => {
+  workspace = await mkdtemp(join(tmpdir(), 'pickle-run-streaming-'))
+  const packageDirectory = resolve(import.meta.dir, '..')
+  const packageManifest = (await Bun.file(
+    join(packageDirectory, 'package.json'),
+  ).json()) as PackageManifest
+  pickleCommand = join(workspace, 'node_modules', '.bin', 'pickle')
+  await mkdir(join(workspace, 'node_modules', '.bin'), { recursive: true })
+  await symlink(
+    resolve(packageDirectory, packageManifest.bin.pickle),
+    pickleCommand,
+  )
+})
+
+afterAll(async () => {
+  await rm(workspace, { recursive: true, force: true })
+})
+
+test('streams complete Specification blocks in stable order through public CLI output', async () => {
+  const project = join(workspace, 'ordered-blocks')
+  const gates = join(project, 'gates')
+  await mkdir(join(project, 'features'), { recursive: true })
+  await mkdir(gates, { recursive: true })
+  await Bun.write(
+    join(project, 'pickle.config.jsonc'),
+    JSON.stringify({
+      schemaVersion: 1,
+      specifications: 'features/**/*.feature',
+      executionTargetProfile: { id: 'deterministic' },
+      concurrency: 4,
+    }),
+  )
+  await Bun.write(
+    join(project, 'pickle.extensions.ts'),
+    `
+const gateDirectory = process.env.PICKLE_TEST_GATE_DIRECTORY
+
+export default {
+  adapter: {
+    async openSession() {
+      return {
+        async executeStep(step, signal) {
+          const gateName = step.text
+          await Bun.write(\`\${gateDirectory}/\${gateName}.started\`, '')
+          while (!(await Bun.file(\`\${gateDirectory}/\${gateName}.release\`).exists())) {
+            if (signal?.aborted) {
+              throw new DOMException('Scenario cancelled', 'AbortError')
+            }
+            await Bun.sleep(5)
+          }
+          await Bun.write(\`\${gateDirectory}/\${gateName}.finished\`, '')
+          return { state: 'passed', resolvedActions: [] }
+        },
+        async close() {},
+      }
+    },
+  },
+}
+`,
+  )
+  await Bun.write(
+    join(project, 'features', 'a.feature'),
+    `@pickle:id:specaaaaaaaaaaaa @pickle:state:active
+Feature: First Specification
+  @pickle:id:scnaaaaaaaaaaaa
+  Scenario: First declared Scenario
+    Then a-first
+
+  @pickle:id:scnbbbbbbbbbbbb
+  Scenario: Second declared Scenario
+    Then a-second`,
+  )
+  await Bun.write(
+    join(project, 'features', 'b.feature'),
+    `@pickle:id:speccccccccccccc @pickle:state:active
+Feature: Second Specification
+  @pickle:id:scncccccccccccc
+  Scenario: Ready early
+    Then b-only`,
+  )
+  await Bun.write(
+    join(project, 'features', 'c.feature'),
+    `@pickle:id:specdddddddddddd @pickle:state:active
+Feature: Third Specification
+  @pickle:id:scndddddddddddd
+  Scenario: Keeps the run open
+    Then c-only`,
+  )
+
+  const child = Bun.spawn({
+    cmd: [pickleCommand, 'run'],
+    cwd: project,
+    env: {
+      ...Bun.env,
+      CI: 'true',
+      PICKLE_TEST_GATE_DIRECTORY: gates,
+    },
+    stdout: 'pipe',
+    stderr: 'pipe',
+  })
+  const output: string[] = []
+  const decoder = new TextDecoder()
+  const stderrOutput = new Response(child.stderr).text()
+  const consumeStdout = (async () => {
+    const reader = child.stdout.getReader()
+    while (true) {
+      const { done, value } = await reader.read()
+      if (done) break
+      output.push(decoder.decode(value, { stream: true }))
+    }
+    output.push(decoder.decode())
+  })()
+
+  await Promise.race([
+    Promise.all(
+      ['a-first', 'a-second', 'b-only', 'c-only'].map((name) =>
+        waitForFile(join(gates, `${name}.started`)),
+      ),
+    ),
+    child.exited.then(async (exitCode) => {
+      throw new Error(
+        `pickle run exited before all Scenarios started (${exitCode}): ${await stderrOutput}`,
+      )
+    }),
+  ])
+
+  await Bun.write(join(gates, 'b-only.release'), '')
+  await Bun.write(join(gates, 'a-first.release'), '')
+  await Promise.all([
+    waitForFile(join(gates, 'b-only.finished')),
+    waitForFile(join(gates, 'a-first.finished')),
+  ])
+  const safetyRelease = setTimeout(() => {
+    void Bun.write(join(gates, 'a-second.release'), '')
+    void Bun.write(join(gates, 'c-only.release'), '')
+  }, 2_000)
+  await Bun.sleep(50)
+  expect(output.join('')).not.toContain(' features/a.feature')
+  expect(output.join('')).not.toContain(' features/b.feature')
+
+  await Bun.write(join(gates, 'a-second.release'), '')
+  const progressiveOutput = await waitForOutput(output, ' features/b.feature')
+  const firstUri = progressiveOutput.indexOf(' features/a.feature')
+  const secondUri = progressiveOutput.indexOf(' features/b.feature')
+  expect(firstUri).toBeGreaterThan(-1)
+  expect(secondUri).toBeGreaterThan(firstUri)
+  expect(progressiveOutput.indexOf('First declared Scenario')).toBeLessThan(
+    progressiveOutput.indexOf('Second declared Scenario'),
+  )
+  expect(progressiveOutput).not.toContain(' features/c.feature')
+
+  await Bun.write(join(gates, 'c-only.release'), '')
+  const [exitCode, stderr] = await Promise.all([
+    child.exited,
+    stderrOutput,
+    consumeStdout,
+  ])
+  const finalOutput = output.join('')
+
+  expect(exitCode).toBe(0)
+  clearTimeout(safetyRelease)
+  expect(stderr).toBe('')
+  expect(finalOutput.indexOf(' features/c.feature')).toBeGreaterThan(secondUri)
+  for (const uri of [
+    'features/a.feature',
+    'features/b.feature',
+    'features/c.feature',
+  ]) {
+    expect(
+      finalOutput.match(new RegExp(uri.replace('.', '\\.'), 'g')),
+    ).toHaveLength(1)
+  }
+  expect(finalOutput).toContain('Specifications  3')
+  expect(finalOutput).toContain('Scenarios       4')
+  expect(finalOutput).toContain('Test results    4 passed (4)')
+  expect(finalOutput).not.toContain('\u001b')
+}, 15_000)

--- a/packages/cli/src/workspace.test.ts
+++ b/packages/cli/src/workspace.test.ts
@@ -941,7 +941,17 @@ Feature: Search
           android: { adapter: 'android', capabilities: ['geolocation'] },
         },
       },
-      specification: validSpecification,
+      specification: {
+        path: 'features/example.feature',
+        source: `@pickle:id:specaaaaaaaaaaaa @pickle:state:active
+Feature: Example
+  @pickle:id:scnbbbbbbbbbbbb
+  Scenario: Validate project
+    Then validation succeeds
+  @pickle:id:scncccccccccccc
+  Scenario: Validate another behavior
+    Then another validation succeeds`,
+      },
       extensions: `
 export default {
   adapters: {
@@ -1002,6 +1012,60 @@ export default {
     ).toEqual([
       ['Validate project', 'web', 'passed'],
       ['Validate project', 'android', 'passed'],
+      ['Validate another behavior', 'web', 'passed'],
+      ['Validate another behavior', 'android', 'passed'],
+    ])
+
+    const [sourceManifest] = [
+      ...new Bun.Glob('*/manifest.json').scanSync({
+        cwd: join(project, '.pickle', 'runs'),
+      }),
+    ]
+    const sourceId = dirname(sourceManifest!)
+    const rerun = Bun.spawnSync({
+      cmd: [pickleCommand, 'run', '--rerun', sourceId, '--reporter', 'ndjson'],
+      cwd: project,
+      env: { ...Bun.env },
+    })
+    const rerunRecords = rerun.stdout
+      .toString()
+      .trim()
+      .split('\n')
+      .filter(Boolean)
+      .map((line) => JSON.parse(line))
+    const rerunResults = rerunRecords.filter(
+      (record) => record.kind === 'test-result',
+    )
+    const rerunFinishedEvents = rerunRecords.filter(
+      (record) =>
+        record.kind === 'run-event' &&
+        record.event.type === 'scenario-finished',
+    )
+
+    expect(rerun.stderr.toString()).toBe('')
+    expect(rerun.exitCode).toBe(0)
+    expect(
+      rerunResults.map((record) => [
+        record.result.scenario.name,
+        record.result.executionTargetProfile.id,
+      ]),
+    ).toEqual([
+      ['Validate project', 'web'],
+      ['Validate another behavior', 'web'],
+      ['Validate project', 'android'],
+      ['Validate another behavior', 'android'],
+    ])
+    expect(
+      rerunFinishedEvents.map((record) => [
+        record.event.result.scenario.name,
+        record.event.result.executionTargetProfile.id,
+        record.event.scheduleIndex,
+      ]),
+    ).toEqual([
+      ['Validate project', 'web', 0],
+      ['Validate another behavior', 'web', 1],
+      ['Validate project', 'android', 0],
+      ['Validate another behavior', 'android', 1],
     ])
   })
 

--- a/packages/runner/index.ts
+++ b/packages/runner/index.ts
@@ -81,8 +81,18 @@ export type {
   TestResultState,
 } from './src/run-scenario'
 export { isEvidenceState, runScenario } from './src/run-scenario'
-export type { RunScenariosInput, RunTarget } from './src/run-scenarios'
-export { runScenarios, validateTargetSelection } from './src/run-scenarios'
+export type {
+  RunScenariosInput,
+  RunScheduleInput,
+  RunTarget,
+  ScenarioCompletion,
+  ScheduledTestResult,
+} from './src/run-scenarios'
+export {
+  runScenarios,
+  scheduleScenarios,
+  validateTargetSelection,
+} from './src/run-scenarios'
 export type {
   ArtifactCapturePolicy,
   CreateTestRunOptions,

--- a/packages/runner/src/run-scenarios.test.ts
+++ b/packages/runner/src/run-scenarios.test.ts
@@ -1,6 +1,10 @@
 import { expect, mock, test } from 'bun:test'
 import type { ScenarioSelection } from '@pickle-spec/spec'
-import { type ExecutionTargetAdapter, runScenarios } from '../index'
+import {
+  type ExecutionTargetAdapter,
+  runScenarios,
+  scheduleScenarios,
+} from '../index'
 
 const selections: ScenarioSelection[] = ['First', 'Ignored', 'Third'].map(
   (name, index) => {
@@ -61,6 +65,65 @@ test('runs selected Scenarios concurrently while preserving stable test-result o
   ])
   expect(maximumActive).toBe(2)
   expect(openSession).toHaveBeenCalledTimes(2)
+})
+
+test('plans Scenario results in declaration and configured profile order', () => {
+  const schedule = scheduleScenarios({
+    selections: [selections[0]!, selections[2]!],
+    executionTargetProfiles: [{ id: 'web' }, { id: 'android' }],
+    includeTarget: (selection, executionTargetProfile) =>
+      !(
+        selection.scenario.name === 'Third' &&
+        executionTargetProfile.id === 'android'
+      ),
+  })
+
+  expect(
+    schedule.map(({ scenario, executionTargetProfile }) => [
+      scenario.name,
+      executionTargetProfile.id,
+    ]),
+  ).toEqual([
+    ['First', 'web'],
+    ['First', 'android'],
+    ['Third', 'web'],
+  ])
+})
+
+test('reports one final completion after retry attempt events', async () => {
+  let attempt = 0
+  const attemptStates: string[] = []
+  const completedResults: Array<{ state: string; attempts?: number }> = []
+  const adapter: ExecutionTargetAdapter = {
+    async openSession() {
+      attempt++
+      return {
+        async executeStep() {
+          if (attempt === 1) throw new Error('Execution target stopped')
+          return { state: 'passed', resolvedActions: [] }
+        },
+        async close() {},
+      }
+    },
+  }
+
+  await runScenarios({
+    selections: [selections[0]!],
+    executionTargetProfile: { id: 'web' },
+    adapter,
+    retry: { infrastructureErrors: 1 },
+    onEvent(event) {
+      if (event.type === 'scenario-finished') {
+        attemptStates.push(event.result.state)
+      }
+    },
+    onResult({ result }) {
+      completedResults.push({ state: result.state, attempts: result.attempts })
+    },
+  })
+
+  expect(attemptStates).toEqual(['infrastructure-error', 'passed'])
+  expect(completedResults).toEqual([{ state: 'passed', attempts: 2 }])
 })
 
 test('rejects a target that lacks a Scenario capability requirement before opening a session', async () => {

--- a/packages/runner/src/run-scenarios.ts
+++ b/packages/runner/src/run-scenarios.ts
@@ -7,11 +7,37 @@ import {
   type RunEvent,
   runScenario,
   type ScenarioRun,
+  type TestResult,
 } from './run-scenario'
 
 export interface RunTarget {
   executionTargetProfile: ExecutionTargetProfile
   adapter: ExecutionTargetAdapter
+}
+
+export interface ScenarioCompletion {
+  result: TestResult
+  scheduleIndex: number
+}
+
+export type ScheduledTestResult = {
+  specification: TestResult['specification']
+  scenario: TestResult['scenario']
+  executionTargetProfile: TestResult['executionTargetProfile']
+}
+
+export interface RunScheduleInput {
+  selections: readonly ScenarioSelection[]
+  executionTargetProfiles: readonly ExecutionTargetProfile[]
+  includeTarget?: (
+    selection: ScenarioSelection,
+    executionTargetProfile: ExecutionTargetProfile,
+  ) => boolean
+}
+
+type ScheduledScenarioTarget = {
+  selection: ScenarioSelection
+  target: RunTarget
 }
 
 export interface RunScenariosInput extends ExecutionPolicy {
@@ -28,6 +54,40 @@ export interface RunScenariosInput extends ExecutionPolicy {
     event: RunEvent,
     selection: ScenarioSelection,
   ) => void | Promise<void>
+  onResult?: (completion: ScenarioCompletion) => void | Promise<void>
+}
+
+function scenarioTargets(
+  selections: readonly ScenarioSelection[],
+  targets: readonly RunTarget[],
+): ScheduledScenarioTarget[] {
+  return selections.flatMap((selection) =>
+    targets.map((target) => ({ selection, target })),
+  )
+}
+
+export function scheduleScenarios(
+  input: RunScheduleInput,
+): ScheduledTestResult[] {
+  return input.selections.flatMap((selection) =>
+    input.executionTargetProfiles.flatMap((executionTargetProfile) =>
+      input.includeTarget?.(selection, executionTargetProfile) === false
+        ? []
+        : [
+            {
+              specification: {
+                uri: selection.specification.source.uri,
+                name: selection.specification.name,
+              },
+              scenario: {
+                id: selection.scenario.id,
+                name: selection.scenario.name,
+              },
+              executionTargetProfile,
+            },
+          ],
+    ),
+  )
 }
 
 function availableCapabilities(target: RunTarget): Set<string> {
@@ -88,18 +148,16 @@ export async function runScenarios(
   const targets = resolveTargets(input)
   validateTargetSelection(input.selections, targets)
 
-  const scenarioTargets = input.selections.flatMap((selection) =>
-    targets.map((target) => ({ selection, target })),
-  )
-  const runs = new Array<ScenarioRun>(scenarioTargets.length)
+  const scheduledTargets = scenarioTargets(input.selections, targets)
+  const runs = new Array<ScenarioRun>(scheduledTargets.length)
   let nextIndex = 0
-  const workerCount = Math.min(concurrency, scenarioTargets.length)
+  const workerCount = Math.min(concurrency, scheduledTargets.length)
 
   async function work(): Promise<void> {
-    while (nextIndex < scenarioTargets.length) {
+    while (nextIndex < scheduledTargets.length) {
       const index = nextIndex++
-      const { selection, target } = scenarioTargets[index]!
-      runs[index] = await runScenario({
+      const { selection, target } = scheduledTargets[index]!
+      const run = await runScenario({
         specification: selection.specification,
         scenario: selection.scenario,
         executionTargetProfile: target.executionTargetProfile,
@@ -119,6 +177,11 @@ export async function runScenarios(
                 selection,
               )
           : undefined,
+      })
+      runs[index] = run
+      await input.onResult?.({
+        result: run.result,
+        scheduleIndex: index,
       })
     }
   }


### PR DESCRIPTION
## Summary

- Preserve Specification block order when selecting and running scenarios
- Stream scenario execution events through the CLI reporter
- Add coverage for ordered runs, streaming output, workspace behavior, and reporter formatting
- Document the updated execution behavior in the README

## Testing

- Added and ran focused CLI and runner tests
- Lint, typecheck, and test validation passed