### PR TITLE
Render actionable failure and infrastructure diagnostics in CLI output

### DIFF
--- a/packages/cli/src/live-run-reporter.test.ts
+++ b/packages/cli/src/live-run-reporter.test.ts
@@ -2,7 +2,55 @@ import { expect, test } from 'bun:test'
 import { createRunReporter } from './run-reporter'
 import { passedRun, recordingTerminal } from './run-reporter.test-support'
 
-test('updates active Specifications and commits each completed block once', () => {
+test('commits each completed Test result while its Specification is still running', () => {
+  const runs = [
+    passedRun({
+      specificationUri: 'features/checkout.feature',
+      specificationName: 'Checkout',
+      scenarioId: 'scenario-first',
+      scenarioName: 'First Scenario',
+      profileId: 'web',
+      durationMs: 10,
+    }),
+    passedRun({
+      specificationUri: 'features/checkout.feature',
+      specificationName: 'Checkout',
+      scenarioId: 'scenario-second',
+      scenarioName: 'Second Scenario',
+      profileId: 'web',
+      durationMs: 20,
+    }),
+  ]
+  const terminal = recordingTerminal(() => 120)
+  const reporter = createRunReporter('default', {
+    terminal: terminal.surface,
+    projectRoot: '/workspace/project',
+    version: '1.0.2',
+    color: false,
+    now: () => new Date(2026, 7, 20, 14, 32, 7),
+  })
+
+  reporter.start()
+  reporter.prepare?.(
+    runs.map(({ result }) => ({
+      specification: result.specification,
+      scenario: result.scenario,
+      executionTargetProfile: result.executionTargetProfile,
+    })),
+  )
+  reporter.complete?.(runs[0]!.result)
+
+  const committedOutput = terminal.operations
+    .filter((operation) => operation.type === 'commit')
+    .flatMap((operation) => operation.lines)
+    .join('\n')
+  expect(committedOutput).toContain(
+    'features/checkout.feature > First Scenario [10ms]',
+  )
+  expect(committedOutput).not.toContain('Second Scenario')
+})
+
+test('updates active Specifications and commits each completed result once', () => {
   const runs = [
     passedRun({
       specificationUri: 'features/a.feature',
@@ -87,23 +135,25 @@ test('updates active Specifications and commits each completed block once', () =
   const concurrentFrame = terminal.operations.at(-1)
   expect(concurrentFrame?.type).toBe('update')
   expect(concurrentFrame?.lines.join('\n')).toContain('1/4 Test results')
-  expect(concurrentFrame?.lines.join('\n')).toContain('First Scenario [10ms]')
   expect(concurrentFrame?.lines.join('\n')).toContain('features/b.feature')
   expect(concurrentFrame?.lines.join('\n')).toContain('0/1 Test result')
+  expect(
+    terminal.operations
+      .filter((operation) => operation.type === 'commit')
+      .flatMap((operation) => operation.lines)
+      .join('\n'),
+  ).toContain('features/a.feature > First Scenario [10ms]')
 
   for (const run of runs.slice(1, 4)) reporter.complete?.(run.result)
 
   const commits = terminal.operations.filter(
     (operation) => operation.type === 'commit',
   )
-  expect(commits).toHaveLength(2)
+  expect(commits).toHaveLength(5)
   expect(commits[0]?.lines.join('\n')).toContain('RUN  pickle 1.0.2')
   expect(commits[1]?.lines.join('\n')).toContain('features/a.feature')
-  expect(commits[1]?.lines.join('\n')).toContain(
-    '✓ [web] First Scenario [10ms]\n' +
-      '     ✓ [android] First Scenario [20ms]\n' +
-      '     ✓ [web] Second Scenario [30ms]\n' +
-      '     ✓ [android] Second Scenario [40ms]',
+  expect(commits[4]?.lines.join('\n')).toContain(
+    'features/a.feature > Second Scenario [40ms]',
   )
   expect(terminal.operations.at(-1)?.lines.join('\n')).toContain(
     'features/b.feature',
@@ -171,7 +221,9 @@ test('finishes live progress with actionable diagnostics and a compact result tr
     .filter((operation) => operation.type === 'finish')
     .flatMap((operation) => operation.lines)
     .join('\n')
-  expect(committedOutput).toContain('× Complete a purchase [10ms] (failed)')
+  expect(committedOutput).toContain(
+    '× features/checkout.feature > Complete a purchase [10ms] (failed)',
+  )
   expect(committedOutput).not.toContain('Expected confirmation')
   expect(finalOutput).toContain(` Failures
 
@@ -186,7 +238,7 @@ test('finishes live progress with actionable diagnostics and a compact result tr
   expect(finalOutput).not.toMatch(/[◐◓◑◒]/u)
 })
 
-test('rewraps the dynamic region when an interactive terminal resizes', () => {
+test('rewraps active progress and preserves a committed result on resize', () => {
   const specificationUri =
     'features/a-very-long-directory/live-progress.feature'
   const run = passedRun({
@@ -242,14 +294,12 @@ test('rewraps the dynamic region when an interactive terminal resizes', () => {
       .map((line) => line.trim())
       .join(''),
   ).toContain(specificationUri)
-  const scenarioStart = resizedFrame?.lines.findIndex((line) =>
-    line.includes('✓'),
-  )
   expect(
-    resizedFrame?.lines
-      .slice(scenarioStart)
-      .map((line) => line.trim())
-      .join(' '),
+    terminal.operations
+      .filter((operation) => operation.type === 'commit')
+      .flatMap((operation) => operation.lines)
+      .join(' ')
+      .replace(/\s+/gu, ' '),
   ).toContain('A completed Scenario with context [10ms]')
 })
 
@@ -313,7 +363,7 @@ test('clears live progress and preserves completed results when a run fails', ()
   expect(finishes[0]?.lines.join('\n')).not.toMatch(/[◐◓◑◒]/u)
 })
 
-test('bounds result rendering while keeping every active Specification visible', () => {
+test('keeps every active Specification visible within the terminal bounds', () => {
   const runs = ['a', 'b', 'c'].flatMap((specificationId) =>
     Array.from({ length: 6 }, (_, index) =>
       passedRun({
@@ -365,7 +415,7 @@ test('bounds result rendering while keeping every active Specification visible',
 
   const frame = terminal.operations.at(-1)
   expect(frame?.type).toBe('update')
-  expect(frame?.lines).toHaveLength(10)
+  expect(frame?.lines.length).toBeLessThanOrEqual(10)
   for (const specificationId of ['a', 'b', 'c']) {
     expect(frame?.lines.join('\n')).toContain(
       `5/6 Test results features/${specificationId}.feature`,

--- a/packages/cli/src/live-run-reporter.test.ts
+++ b/packages/cli/src/live-run-reporter.test.ts
@@ -2,6 +2,86 @@ import { expect, test } from 'bun:test'
 import { createRunReporter } from './run-reporter'
 import { passedRun, recordingTerminal } from './run-reporter.test-support'
 
+test('shows completed and running Gherkin steps beneath an active Scenario', () => {
+  const run = passedRun({
+    specificationUri: 'features/search.feature',
+    specificationName: 'Search',
+    scenarioId: 'scenario-search',
+    scenarioName: 'Search for images',
+    profileId: 'web',
+    durationMs: 10,
+  })
+  const terminal = recordingTerminal(() => 120)
+  const reporter = createRunReporter('default', {
+    terminal: terminal.surface,
+    projectRoot: '/workspace/project',
+    version: '1.0.2',
+    color: true,
+  })
+  const contextStep = {
+    keyword: 'Given',
+    text: 'the search page is open',
+    type: 'context' as const,
+  }
+  const actionStep = {
+    keyword: 'When',
+    text: 'I search for images',
+    type: 'action' as const,
+  }
+
+  reporter.start()
+  reporter.prepare?.([
+    {
+      specification: run.result.specification,
+      scenario: run.result.scenario,
+      executionTargetProfile: run.result.executionTargetProfile,
+    },
+  ])
+  reporter.event({
+    schemaVersion: 1,
+    sequence: 1,
+    type: 'scenario-started',
+    scenario: run.result.scenario,
+    executionTargetProfile: run.result.executionTargetProfile,
+  })
+  reporter.event({
+    schemaVersion: 1,
+    sequence: 2,
+    type: 'step-started',
+    step: contextStep,
+    scenario: run.result.scenario,
+    executionTargetProfile: run.result.executionTargetProfile,
+  })
+  reporter.event({
+    schemaVersion: 1,
+    sequence: 3,
+    type: 'step-finished',
+    result: {
+      step: contextStep,
+      state: 'passed',
+      resolvedActions: [],
+    },
+    scenario: run.result.scenario,
+    executionTargetProfile: run.result.executionTargetProfile,
+  })
+  reporter.event({
+    schemaVersion: 1,
+    sequence: 4,
+    type: 'step-started',
+    step: actionStep,
+    scenario: run.result.scenario,
+    executionTargetProfile: run.result.executionTargetProfile,
+  })
+
+  const frame = terminal.operations.at(-1)
+  expect(frame?.type).toBe('update')
+  expect(frame?.lines.join('\n')).toContain('Search for images')
+  expect(frame?.lines.join('\n')).toContain(
+    '\u001b[32m✓\u001b[39m Given the search page is open',
+  )
+  expect(frame?.lines.join('\n')).toContain('When I search for images')
+})
+
 test('commits each completed Test result while its Specification is still running', () => {
   const runs = [
     passedRun({

--- a/packages/cli/src/live-run-reporter.test.ts
+++ b/packages/cli/src/live-run-reporter.test.ts
@@ -121,6 +121,7 @@ test('updates active Specifications and commits each completed result once', () 
   expect(initialFrame?.type).toBe('update')
   expect(initialFrame?.lines.join('\n')).toContain('features/a.feature')
   expect(initialFrame?.lines.join('\n')).toContain('0/4 Test results')
+  expect(initialFrame?.lines.join('\n')).toContain('First Scenario')
   expect(initialFrame?.lines.join('\n')).not.toContain('Second Scenario')
 
   reporter.complete?.(runs[0]!.result)
@@ -134,9 +135,11 @@ test('updates active Specifications and commits each completed result once', () 
 
   const concurrentFrame = terminal.operations.at(-1)
   expect(concurrentFrame?.type).toBe('update')
-  expect(concurrentFrame?.lines.join('\n')).toContain('1/4 Test results')
+  expect(concurrentFrame?.lines.join('\n')).not.toContain('features/a.feature')
+  expect(concurrentFrame?.lines.join('\n')).not.toContain('First Scenario')
   expect(concurrentFrame?.lines.join('\n')).toContain('features/b.feature')
   expect(concurrentFrame?.lines.join('\n')).toContain('0/1 Test result')
+  expect(concurrentFrame?.lines.join('\n')).toContain('Other active Scenario')
   expect(
     terminal.operations
       .filter((operation) => operation.type === 'commit')
@@ -279,6 +282,13 @@ test('rewraps active progress and preserves a committed result on resize', () =>
     executionTargetProfile: run.result.executionTargetProfile,
   })
   reporter.complete?.(run.result)
+  reporter.event({
+    schemaVersion: 1,
+    sequence: 2,
+    type: 'scenario-started',
+    scenario: { id: 'scenario-pending', name: 'Still pending' },
+    executionTargetProfile: run.result.executionTargetProfile,
+  })
 
   columns = 28
   reporter.refresh?.()
@@ -411,6 +421,14 @@ test('keeps every active Specification visible within the terminal bounds', () =
     for (const run of specificationRuns.slice(0, 5)) {
       reporter.complete?.(run.result)
     }
+    reporter.event({
+      schemaVersion: 1,
+      sequence: 2,
+      type: 'scenario-started',
+      scenario: specificationRuns[5]!.result.scenario,
+      executionTargetProfile:
+        specificationRuns[5]!.result.executionTargetProfile,
+    })
   }
 
   const frame = terminal.operations.at(-1)

--- a/packages/cli/src/live-run-reporter.ts
+++ b/packages/cli/src/live-run-reporter.ts
@@ -8,11 +8,9 @@ import {
   clockLabel,
   diagnosticLines,
   groupResults,
-  renderSpecification,
-  type SpecificationGroup,
+  renderTestResult,
   summaryLines,
   wrappedLines,
-  writeTestResult,
   writeWrapped,
 } from './run-report'
 import {
@@ -71,8 +69,6 @@ export function createLiveRunReporter(
   let finished = false
   let cancelPagedRefresh: (() => void) | undefined
   const activeSpecificationUris = new Set<string>()
-  const committedSpecificationUris = new Set<string>()
-  const progressResultsBySpecification = new Map<string, TestResult[]>()
   let scheduleIndexQueues = new Map<string, ScheduleIndexQueue>()
 
   function columns(): number | undefined {
@@ -102,8 +98,6 @@ export function createLiveRunReporter(
     pendingBlocks = groupSchedule(nextSchedule)
     progressFrame = 0
     activeSpecificationUris.clear()
-    committedSpecificationUris.clear()
-    progressResultsBySpecification.clear()
     scheduleIndexQueues = createScheduleIndexQueues(nextSchedule)
     multipleProfiles =
       new Set(nextSchedule.map((result) => result.executionTargetProfile.id))
@@ -119,28 +113,13 @@ export function createLiveRunReporter(
     })
   }
 
-  function availableSpecification(
-    block: PendingSpecificationBlock,
-  ): SpecificationGroup | undefined {
-    return groupResults(completedBlockResults(block))[0]
-  }
-
-  function completedSpecification(
-    block: PendingSpecificationBlock,
-  ): SpecificationGroup | undefined {
-    const results = completedBlockResults(block)
-    if (results.length !== block.scheduleIndexes.length) return undefined
-    return groupResults(results)[0]
-  }
-
   function renderActiveHeader(
     block: PendingSpecificationBlock,
     mark: string,
   ): string[] {
     const firstScheduled = schedule[block.scheduleIndexes[0]!]
     if (!firstScheduled) return []
-    const completedCount =
-      progressResultsBySpecification.get(block.uri)?.length ?? 0
+    const completedCount = completedBlockResults(block).length
     const resultLabel =
       block.scheduleIndexes.length === 1 ? 'result' : 'results'
     const lines: string[] = []
@@ -154,45 +133,11 @@ export function createLiveRunReporter(
     return lines
   }
 
-  function renderRecentResults(
-    results: readonly TestResult[],
-    rowBudget: number,
-  ): string[] {
-    if (rowBudget <= 0 || results.length === 0) return []
-    let selectedCount = Math.min(results.length, rowBudget)
-    while (selectedCount >= 0) {
-      const hiddenCount = results.length - selectedCount
-      const lines = hiddenCount
-        ? wrappedLines(
-            '     … ',
-            `${hiddenCount} earlier Test results hidden`,
-            '       ',
-            columns(),
-          )
-        : []
-      const selectedResults =
-        selectedCount === 0 ? [] : results.slice(-selectedCount)
-      for (const result of selectedResults) {
-        writeTestResult(result, result.scenario.name, {
-          write: (line) => lines.push(line),
-          color: options.color,
-          columns: columns(),
-          multipleProfiles,
-        })
-      }
-      if (renderedRowCount(lines) <= rowBudget) return lines
-      selectedCount--
-    }
-    return []
-  }
-
   function updateDynamicRegion(): void {
     const frameIndex = progressFrame++
     const mark = progressMarks[frameIndex % progressMarks.length]!
-    const activeBlocks = pendingBlocks.filter(
-      (block) =>
-        activeSpecificationUris.has(block.uri) &&
-        !committedSpecificationUris.has(block.uri),
+    const activeBlocks = pendingBlocks.filter((block) =>
+      activeSpecificationUris.has(block.uri),
     )
     const maxRows = availableTerminalRows(terminal.rows?.())
     const allHeaders = activeBlocks.map((block) =>
@@ -235,64 +180,23 @@ export function createLiveRunReporter(
         }
       }
     }
-    const resultRowBudget = Math.max(
-      0,
-      maxRows - renderedRowCount([...headers.flat(), ...overflowLines]),
-    )
-    let remainingResultRows = resultRowBudget
-    const lines = visibleBlocks.flatMap((block, index) => {
-      const remainingBlocks = visibleBlocks.length - index
-      const blockRowBudget = Number.isFinite(remainingResultRows)
-        ? Math.floor(remainingResultRows / remainingBlocks)
-        : Number.POSITIVE_INFINITY
-      const resultLines = renderRecentResults(
-        progressResultsBySpecification.get(block.uri) ?? [],
-        blockRowBudget,
-      )
-      remainingResultRows -= renderedRowCount(resultLines)
-      return [...headers[index]!, ...resultLines]
-    })
+    const lines = headers.flat()
     terminal.update([...lines, ...overflowLines])
     setPagedRefresh(isPaged)
   }
 
-  function commitSpecification(
-    uri: string,
-    specification: SpecificationGroup,
-  ): void {
+  function commitResult(result: TestResult): void {
     terminal.commit(
-      renderSpecification(specification, {
-        color: options.color,
-        columns: columns(),
-        multipleProfiles,
-      }),
+      renderTestResult(
+        result,
+        `${result.specification.uri} > ${result.scenario.name}`,
+        {
+          color: options.color,
+          columns: columns(),
+          multipleProfiles,
+        },
+      ),
     )
-    committedSpecificationUris.add(uri)
-    activeSpecificationUris.delete(uri)
-  }
-
-  function commitCompletedSpecification(uri: string): void {
-    if (committedSpecificationUris.has(uri)) return
-    const block = pendingBlocks.find((candidate) => candidate.uri === uri)
-    if (!block) return
-    if (
-      progressResultsBySpecification.get(uri)?.length !==
-      block.scheduleIndexes.length
-    ) {
-      return
-    }
-    const specification = completedSpecification(block)
-    if (!specification) return
-    commitSpecification(uri, specification)
-  }
-
-  function commitAvailableSpecifications(): void {
-    for (const block of pendingBlocks) {
-      if (committedSpecificationUris.has(block.uri)) continue
-      const specification = availableSpecification(block)
-      if (!specification) continue
-      commitSpecification(block.uri, specification)
-    }
   }
 
   function finish(
@@ -302,7 +206,6 @@ export function createLiveRunReporter(
   ): void {
     if (finished) return
     setPagedRefresh(false)
-    commitAvailableSpecifications()
     const specifications = groupResults(results)
     const diagnostics = diagnosticLines(results, {
       projectRoot: options.projectRoot,
@@ -332,15 +235,17 @@ export function createLiveRunReporter(
     const scheduleIndex = claimScheduleIndex(scheduleIndexQueues, result)
     if (scheduleIndex === undefined) return
     completedResults[scheduleIndex] = result
-    const progressResults =
-      progressResultsBySpecification.get(result.specification.uri) ?? []
-    progressResults.push(result)
-    progressResultsBySpecification.set(
-      result.specification.uri,
-      progressResults,
-    )
     activeSpecificationUris.add(result.specification.uri)
-    commitCompletedSpecification(result.specification.uri)
+    commitResult(result)
+    const block = pendingBlocks.find(
+      (candidate) => candidate.uri === result.specification.uri,
+    )
+    if (
+      block &&
+      completedBlockResults(block).length === block.scheduleIndexes.length
+    ) {
+      activeSpecificationUris.delete(result.specification.uri)
+    }
     updateDynamicRegion()
   }
 

--- a/packages/cli/src/live-run-reporter.ts
+++ b/packages/cli/src/live-run-reporter.ts
@@ -68,7 +68,7 @@ export function createLiveRunReporter(
   let progressFrame = 0
   let finished = false
   let cancelPagedRefresh: (() => void) | undefined
-  const activeSpecificationUris = new Set<string>()
+  const activeScheduleIndexes = new Set<number>()
   let scheduleIndexQueues = new Map<string, ScheduleIndexQueue>()
 
   function columns(): number | undefined {
@@ -97,7 +97,7 @@ export function createLiveRunReporter(
     completedResults = Array.from({ length: nextSchedule.length })
     pendingBlocks = groupSchedule(nextSchedule)
     progressFrame = 0
-    activeSpecificationUris.clear()
+    activeScheduleIndexes.clear()
     scheduleIndexQueues = createScheduleIndexQueues(nextSchedule)
     multipleProfiles =
       new Set(nextSchedule.map((result) => result.executionTargetProfile.id))
@@ -133,34 +133,59 @@ export function createLiveRunReporter(
     return lines
   }
 
+  function renderActiveBlock(
+    block: PendingSpecificationBlock,
+    mark: string,
+  ): string[] {
+    const lines = renderActiveHeader(block, mark)
+    for (const scheduleIndex of block.scheduleIndexes) {
+      if (!activeScheduleIndexes.has(scheduleIndex)) continue
+      const scheduled = schedule[scheduleIndex]
+      if (!scheduled) continue
+      const profile = multipleProfiles
+        ? `[${scheduled.executionTargetProfile.id}] `
+        : ''
+      writeWrapped(
+        (line) => lines.push(line),
+        '   → ',
+        `${profile}${scheduled.scenario.name}`,
+        '     ',
+        columns(),
+      )
+    }
+    return lines
+  }
+
   function updateDynamicRegion(): void {
     const frameIndex = progressFrame++
     const mark = progressMarks[frameIndex % progressMarks.length]!
     const activeBlocks = pendingBlocks.filter((block) =>
-      activeSpecificationUris.has(block.uri),
+      block.scheduleIndexes.some((scheduleIndex) =>
+        activeScheduleIndexes.has(scheduleIndex),
+      ),
     )
     const maxRows = availableTerminalRows(terminal.rows?.())
-    const allHeaders = activeBlocks.map((block) =>
-      renderActiveHeader(block, mark),
+    const allBlockLines = activeBlocks.map((block) =>
+      renderActiveBlock(block, mark),
     )
-    const totalHeaderRows = renderedRowCount(allHeaders.flat())
+    const totalBlockRows = renderedRowCount(allBlockLines.flat())
     let visibleBlocks = activeBlocks
-    let headers = allHeaders
+    let blockLines = allBlockLines
     let overflowLines: string[] = []
-    const isPaged = totalHeaderRows > maxRows && activeBlocks.length > 1
+    const isPaged = totalBlockRows > maxRows && activeBlocks.length > 1
     if (isPaged) {
       const firstIndex = frameIndex % activeBlocks.length
       visibleBlocks = []
-      headers = []
+      blockLines = []
       let usedRows = 0
       for (let offset = 0; offset < activeBlocks.length; offset++) {
         const index = (firstIndex + offset) % activeBlocks.length
-        const header = allHeaders[index]!
-        const headerRows = renderedRowCount(header)
-        if (headers.length > 0 && usedRows + headerRows >= maxRows) break
+        const lines = allBlockLines[index]!
+        const lineRows = renderedRowCount(lines)
+        if (blockLines.length > 0 && usedRows + lineRows >= maxRows) break
         visibleBlocks.push(activeBlocks[index]!)
-        headers.push(header)
-        usedRows += headerRows
+        blockLines.push(lines)
+        usedRows += lineRows
         if (usedRows >= maxRows) break
       }
       const hiddenCount = activeBlocks.length - visibleBlocks.length
@@ -172,15 +197,15 @@ export function createLiveRunReporter(
           columns(),
         )
         while (
-          headers.length > 1 &&
+          blockLines.length > 1 &&
           usedRows + renderedRowCount(overflowLines) > maxRows
         ) {
-          usedRows -= renderedRowCount(headers.pop()!)
+          usedRows -= renderedRowCount(blockLines.pop()!)
           visibleBlocks.pop()
         }
       }
     }
-    const lines = headers.flat()
+    const lines = blockLines.flat()
     terminal.update([...lines, ...overflowLines])
     setPagedRefresh(isPaged)
   }
@@ -235,17 +260,8 @@ export function createLiveRunReporter(
     const scheduleIndex = claimScheduleIndex(scheduleIndexQueues, result)
     if (scheduleIndex === undefined) return
     completedResults[scheduleIndex] = result
-    activeSpecificationUris.add(result.specification.uri)
+    activeScheduleIndexes.delete(scheduleIndex)
     commitResult(result)
-    const block = pendingBlocks.find(
-      (candidate) => candidate.uri === result.specification.uri,
-    )
-    if (
-      block &&
-      completedBlockResults(block).length === block.scheduleIndexes.length
-    ) {
-      activeSpecificationUris.delete(result.specification.uri)
-    }
     updateDynamicRegion()
   }
 
@@ -275,7 +291,7 @@ export function createLiveRunReporter(
       if (scheduleIndex < 0) return
       const scheduled = schedule[scheduleIndex]
       if (!scheduled) return
-      activeSpecificationUris.add(scheduled.specification.uri)
+      activeScheduleIndexes.add(scheduleIndex)
       updateDynamicRegion()
     },
     complete,

--- a/packages/cli/src/live-run-reporter.ts
+++ b/packages/cli/src/live-run-reporter.ts
@@ -9,6 +9,7 @@ import {
   diagnosticLines,
   groupResults,
   renderTestResult,
+  renderTestStepResult,
   summaryLines,
   wrappedLines,
   writeWrapped,
@@ -47,6 +48,14 @@ interface LiveRunReporter {
   finish(runs: readonly ScenarioRun[], durationMs: number): void
 }
 
+type StepStartedEvent = Extract<RunEvent, { type: 'step-started' }>
+type StepFinishedEvent = Extract<RunEvent, { type: 'step-finished' }>
+
+type LiveScenarioProgress = {
+  completedSteps: StepFinishedEvent['result'][]
+  runningStep?: StepStartedEvent['step']
+}
+
 const progressMarks = ['◐', '◓', '◑', '◒'] as const
 const progressRefreshIntervalMs = 200
 
@@ -69,6 +78,7 @@ export function createLiveRunReporter(
   let finished = false
   let cancelPagedRefresh: (() => void) | undefined
   const activeScheduleIndexes = new Set<number>()
+  const progressByScheduleIndex = new Map<number, LiveScenarioProgress>()
   let scheduleIndexQueues = new Map<string, ScheduleIndexQueue>()
 
   function columns(): number | undefined {
@@ -98,6 +108,7 @@ export function createLiveRunReporter(
     pendingBlocks = groupSchedule(nextSchedule)
     progressFrame = 0
     activeScheduleIndexes.clear()
+    progressByScheduleIndex.clear()
     scheduleIndexQueues = createScheduleIndexQueues(nextSchedule)
     multipleProfiles =
       new Set(nextSchedule.map((result) => result.executionTargetProfile.id))
@@ -147,11 +158,29 @@ export function createLiveRunReporter(
         : ''
       writeWrapped(
         (line) => lines.push(line),
-        '   → ',
+        `   ${mark} `,
         `${profile}${scheduled.scenario.name}`,
         '     ',
         columns(),
       )
+      const progress = progressByScheduleIndex.get(scheduleIndex)
+      for (const result of progress?.completedSteps ?? []) {
+        lines.push(
+          ...renderTestStepResult(result, {
+            color: options.color,
+            columns: columns(),
+          }),
+        )
+      }
+      if (progress?.runningStep) {
+        writeWrapped(
+          (line) => lines.push(line),
+          `     ${mark} `,
+          `${progress.runningStep.keyword} ${progress.runningStep.text}`,
+          '       ',
+          columns(),
+        )
+      }
     }
     return lines
   }
@@ -261,8 +290,20 @@ export function createLiveRunReporter(
     if (scheduleIndex === undefined) return
     completedResults[scheduleIndex] = result
     activeScheduleIndexes.delete(scheduleIndex)
+    progressByScheduleIndex.delete(scheduleIndex)
     commitResult(result)
     updateDynamicRegion()
+  }
+
+  function activeScheduleIndex(
+    event: Extract<RunEvent, { type: 'step-started' | 'step-finished' }>,
+  ): number | undefined {
+    const scheduleIndex = schedule.findIndex(
+      (scheduled, index) =>
+        activeScheduleIndexes.has(index) &&
+        scheduledEventMatches(scheduled, event),
+    )
+    return scheduleIndex < 0 ? undefined : scheduleIndex
   }
 
   return {
@@ -283,15 +324,32 @@ export function createLiveRunReporter(
     },
     prepare,
     event(event) {
-      if (event.type !== 'scenario-started') return
-      const scheduleIndex = schedule.findIndex(
-        (scheduled, index) =>
-          !completedResults[index] && scheduledEventMatches(scheduled, event),
-      )
-      if (scheduleIndex < 0) return
-      const scheduled = schedule[scheduleIndex]
-      if (!scheduled) return
-      activeScheduleIndexes.add(scheduleIndex)
+      if (event.type === 'scenario-started') {
+        const scheduleIndex = schedule.findIndex(
+          (scheduled, index) =>
+            !completedResults[index] && scheduledEventMatches(scheduled, event),
+        )
+        if (scheduleIndex < 0) return
+        activeScheduleIndexes.add(scheduleIndex)
+        progressByScheduleIndex.set(scheduleIndex, { completedSteps: [] })
+        updateDynamicRegion()
+        return
+      }
+      if (event.type !== 'step-started' && event.type !== 'step-finished') {
+        return
+      }
+      const scheduleIndex = activeScheduleIndex(event)
+      if (scheduleIndex === undefined) return
+      const progress = progressByScheduleIndex.get(scheduleIndex) ?? {
+        completedSteps: [],
+      }
+      if (event.type === 'step-started') {
+        progress.runningStep = event.step
+      } else {
+        progress.completedSteps.push(event.result)
+        progress.runningStep = undefined
+      }
+      progressByScheduleIndex.set(scheduleIndex, progress)
       updateDynamicRegion()
     },
     complete,

--- a/packages/cli/src/run-live.test.ts
+++ b/packages/cli/src/run-live.test.ts
@@ -133,6 +133,8 @@ Feature: Streaming Specification
   ])
   const activeOutput = await waitForOutput(output, 'features/progress.feature')
   expect(activeOutput).toContain('0/2 Test results')
+  expect(activeOutput).toContain('→ First result appears last')
+  expect(activeOutput).toContain('→ Second result appears first')
   expect(activeOutput).not.toContain('Second result appears first [')
 
   await Bun.write(join(gates, 'second.release'), '')

--- a/packages/cli/src/run-live.test.ts
+++ b/packages/cli/src/run-live.test.ts
@@ -89,17 +89,12 @@ export default {
 `,
   )
   await Bun.write(
-    join(project, 'features', 'a.feature'),
+    join(project, 'features', 'progress.feature'),
     `@pickle:id:specaaaaaaaaaaaa @pickle:state:active
-Feature: First Specification
+Feature: Streaming Specification
   @pickle:id:scnaaaaaaaaaaaa
   Scenario: First result appears last
-    Then first`,
-  )
-  await Bun.write(
-    join(project, 'features', 'b.feature'),
-    `@pickle:id:specbbbbbbbbbbbb @pickle:state:active
-Feature: Second Specification
+    Then first
   @pickle:id:scnbbbbbbbbbbbb
   Scenario: Second result appears first
     Then second`,
@@ -136,9 +131,8 @@ Feature: Second Specification
       )
     }),
   ])
-  const activeOutput = await waitForOutput(output, 'features/b.feature')
-  expect(activeOutput).toContain('features/a.feature')
-  expect(activeOutput).toContain('0/1 Test result')
+  const activeOutput = await waitForOutput(output, 'features/progress.feature')
+  expect(activeOutput).toContain('0/2 Test results')
   expect(activeOutput).not.toContain('Second result appears first [')
 
   await Bun.write(join(gates, 'second.release'), '')
@@ -156,7 +150,7 @@ Feature: Second Specification
 
   expect(exitCode).toBe(0)
   expect(finalOutput).toContain('First result appears last [')
-  expect(finalOutput.split(' Specifications  2')).toHaveLength(2)
+  expect(finalOutput.split(' Specifications  1')).toHaveLength(2)
   expect(finalOutput.split(' Test results    2 passed (2)')).toHaveLength(2)
   expect(finalOutput).not.toContain('\u001b[32m')
 }, 15_000)

--- a/packages/cli/src/run-live.test.ts
+++ b/packages/cli/src/run-live.test.ts
@@ -133,8 +133,10 @@ Feature: Streaming Specification
   ])
   const activeOutput = await waitForOutput(output, 'features/progress.feature')
   expect(activeOutput).toContain('0/2 Test results')
-  expect(activeOutput).toContain('→ First result appears last')
-  expect(activeOutput).toContain('→ Second result appears first')
+  expect(activeOutput).toContain('First result appears last')
+  expect(activeOutput).toContain('Second result appears first')
+  expect(activeOutput).toContain('Then first')
+  expect(activeOutput).toContain('Then second')
   expect(activeOutput).not.toContain('Second result appears first [')
 
   await Bun.write(join(gates, 'second.release'), '')

--- a/packages/cli/src/run-report.ts
+++ b/packages/cli/src/run-report.ts
@@ -295,6 +295,24 @@ export function renderTestResult(
   return lines
 }
 
+export function renderTestStepResult(
+  result: TestResult['steps'][number],
+  options: Pick<SpecificationWriterOptions, 'color' | 'columns'>,
+): string[] {
+  const lines: string[] = []
+  const plainPrefix = `     ${resultPresentations[result.state].mark} `
+  const styledPrefix = `     ${stateMark(result.state, options.color)} `
+  writeWrapped(
+    (line) => lines.push(line),
+    styledPrefix,
+    `${result.step.keyword} ${result.step.text}`,
+    '       ',
+    options.columns,
+    plainPrefix.length,
+  )
+  return lines
+}
+
 export function renderSpecification(
   specification: SpecificationGroup,
   options: Omit<SpecificationWriterOptions, 'write'>,
@@ -418,16 +436,9 @@ function writeDiagnostic(
   if (result.steps.length > 0) {
     options.write('   Steps')
     for (const step of result.steps) {
-      const plainPrefix = `     ${resultPresentations[step.state].mark} `
-      const styledPrefix = `     ${stateMark(step.state, options.color)} `
-      writeWrapped(
-        options.write,
-        styledPrefix,
-        `${step.step.keyword} ${step.step.text}`,
-        '       ',
-        options.columns,
-        plainPrefix.length,
-      )
+      for (const line of renderTestStepResult(step, options)) {
+        options.write(line)
+      }
       if (step.message) writeMessage(step.message, options)
       writeArtifacts(step, options)
     }

--- a/packages/cli/src/run-report.ts
+++ b/packages/cli/src/run-report.ts
@@ -248,16 +248,17 @@ export function writeSpecification(
   }
 }
 
-export function writeTestResult(
+function writeResult(
   result: TestResult,
   scenarioName: string,
   options: SpecificationWriterOptions,
+  indent: string,
 ): void {
   const profile = options.multipleProfiles
     ? `[${result.executionTargetProfile.id}] `
     : ''
-  const plainPrefix = `     ${resultPresentations[result.state].mark} ${profile}`
-  const styledPrefix = `     ${stateMark(result.state, options.color)} ${profile}`
+  const plainPrefix = `${indent}${resultPresentations[result.state].mark} ${profile}`
+  const styledPrefix = `${indent}${stateMark(result.state, options.color)} ${profile}`
   writeWrapped(
     options.write,
     styledPrefix,
@@ -266,6 +267,32 @@ export function writeTestResult(
     options.columns,
     plainPrefix.length,
   )
+}
+
+export function writeTestResult(
+  result: TestResult,
+  scenarioName: string,
+  options: SpecificationWriterOptions,
+): void {
+  writeResult(result, scenarioName, options, '     ')
+}
+
+export function renderTestResult(
+  result: TestResult,
+  scenarioName: string,
+  options: Omit<SpecificationWriterOptions, 'write'>,
+): string[] {
+  const lines: string[] = []
+  writeResult(
+    result,
+    scenarioName,
+    {
+      ...options,
+      write: (line) => lines.push(line),
+    },
+    ' ',
+  )
+  return lines
 }
 
 export function renderSpecification(

--- a/packages/cli/src/run-reporter.test.ts
+++ b/packages/cli/src/run-reporter.test.ts
@@ -2,7 +2,7 @@ import { expect, test } from 'bun:test'
 import { createRunReporter, terminalReporterCapabilities } from './run-reporter'
 import { passedRun } from './run-reporter.test-support'
 
-test('renders a successful test run as a stable Specification-first tree', () => {
+test('renders completed Test results as Vitest-style lines', () => {
   const lines: string[] = []
   const reporter = createRunReporter('default', {
     write: (line) => lines.push(line),
@@ -55,15 +55,10 @@ test('renders a successful test run as a stable Specification-first tree', () =>
   expect(lines.join('\n')).toBe(`
  RUN  pickle 1.0.2 /workspace/project
 
- features/checkout.feature
-   Checkout
-     ✓ [web] Complete a purchase [5ms]
-
- src/google.feature
-   Search
-     ✓ [web] Visit main page [150ms]
-     ✓ [android] Visit main page [1.24s]
-     ✓ [web] Find pickles [820ms]
+ ✓ [web] src/google.feature > Visit main page [150ms]
+ ✓ [android] src/google.feature > Visit main page [1.24s]
+ ✓ [web] src/google.feature > Find pickles [820ms]
+ ✓ [web] features/checkout.feature > Complete a purchase [5ms]
 
  Specifications  2
  Scenarios       3
@@ -72,7 +67,7 @@ test('renders a successful test run as a stable Specification-first tree', () =>
  Duration        1.46s`)
 })
 
-test('streams contiguous ready Specification blocks in final report order', () => {
+test('streams Test results in completion order without repeating them at finish', () => {
   const runs = [
     passedRun({
       specificationUri: 'features/a.feature',
@@ -133,7 +128,6 @@ test('streams contiguous ready Specification blocks in final report order', () =
     version: '1.0.2',
     color: false,
     columns: 120,
-    progressive: true,
     now: () => new Date(2026, 7, 20, 14, 32, 7),
   }
   const progressiveLines: string[] = []
@@ -147,29 +141,26 @@ test('streams contiguous ready Specification blocks in final report order', () =
   for (const index of [4, 5, 3, 1, 0]) {
     progressiveReporter.complete?.(runs[index]!.result)
   }
-  expect(progressiveLines.join('\n')).not.toContain('features/a.feature')
-  expect(progressiveLines.join('\n')).not.toContain('features/b.feature')
+  expect(progressiveLines.join('\n')).toContain(
+    '✓ [web] features/b.feature > Ready early [50ms]',
+  )
+  expect(progressiveLines.join('\n')).toContain(
+    '✓ [web] features/a.feature > First Scenario [10ms]',
+  )
 
   progressiveReporter.complete?.(runs[2]!.result)
-  progressiveReporter.complete?.(runs[4]!.result)
-  expect(progressiveLines.join('\n')).toContain('features/b.feature')
   progressiveReporter.finish(runs, 100)
 
-  const finishOnlyLines: string[] = []
-  const finishOnlyReporter = createRunReporter('default', {
-    ...options,
-    write: (line) => finishOnlyLines.push(line),
-  })
-  finishOnlyReporter.start()
-  finishOnlyReporter.finish(runs, 100)
-
-  expect(progressiveLines).toEqual(finishOnlyLines)
-  expect(progressiveLines.join('\n')).toContain(
-    '✓ [web] First Scenario [10ms]\n' +
-      '     ✓ [android] First Scenario [20ms]\n' +
-      '     ✓ [web] Second Scenario [30ms]\n' +
-      '     ✓ [android] Second Scenario [40ms]',
-  )
+  const resultLines = progressiveLines.filter((line) => /[✓×!↓○]/u.test(line))
+  expect(resultLines).toEqual([
+    ' ✓ [web] features/b.feature > Ready early [50ms]',
+    ' ✓ [android] features/b.feature > Ready early [60ms]',
+    ' ✓ [android] features/a.feature > Second Scenario [40ms]',
+    ' ✓ [android] features/a.feature > First Scenario [20ms]',
+    ' ✓ [web] features/a.feature > First Scenario [10ms]',
+    ' ✓ [web] features/a.feature > Second Scenario [30ms]',
+  ])
+  expect(progressiveLines).toContain(' Test results    6 passed (6)')
 })
 
 test('keeps schedule and completion callbacks out of NDJSON output', () => {
@@ -205,7 +196,7 @@ test('keeps schedule and completion callbacks out of NDJSON output', () => {
   })
 })
 
-test('keeps interactive human output buffered until the run finishes', () => {
+test('streams human output as each Test result completes', () => {
   const run = passedRun({
     specificationUri: 'features/a.feature',
     specificationName: 'First',
@@ -221,7 +212,6 @@ test('keeps interactive human output buffered until the run finishes', () => {
     version: '1.0.2',
     color: true,
     columns: 120,
-    progressive: false,
     now: () => new Date(2026, 7, 20, 14, 32, 7),
   })
 
@@ -234,10 +224,12 @@ test('keeps interactive human output buffered until the run finishes', () => {
     },
   ])
   reporter.complete?.(run.result)
-  expect(lines.join('\n')).not.toContain('features/a.feature')
+  expect(lines.join('\n')).toContain('features/a.feature > Scenario A [10ms]')
 
   reporter.finish([run], 10)
-  expect(lines.join('\n')).toContain('features/a.feature')
+  expect(
+    lines.filter((line) => line.includes('features/a.feature')),
+  ).toHaveLength(1)
 })
 
 test('uses a visible failure symbol with color only as supplemental information', () => {
@@ -276,7 +268,9 @@ test('uses a visible failure symbol with color only as supplemental information'
 
   expect(colorLines.join('\n')).toContain('\u001b[31m×\u001b[39m')
   expect(plainLines.join('\n')).not.toContain('\u001b[')
-  expect(plainLines.join('\n')).toContain('× Visit main page [150ms] (failed)')
+  expect(plainLines.join('\n')).toContain(
+    '× src/google.feature > Visit main page [150ms] (failed)',
+  )
 })
 
 test('wraps long paths and Scenario names without truncating them', () => {
@@ -309,15 +303,17 @@ test('wraps long paths and Scenario names without truncating them', () => {
   )
 
   expect(lines.every((line) => line.length <= 32)).toBe(true)
-  const uriStart = lines.findIndex((line) => line.includes('features/'))
-  expect(`${lines[uriStart]?.trim()}${lines[uriStart + 1]?.trim()}`).toBe(
-    specificationUri,
+  const resultStart = lines.findIndex((line) => line.includes('✓'))
+  const summaryStart = lines.findIndex((line) =>
+    line.includes('Specifications'),
   )
-  const scenarioStart = lines.findIndex((line) => line.includes('✓'))
-  const renderedScenario = `${lines[scenarioStart]?.trim().slice(2)} ${lines[
-    scenarioStart + 1
-  ]?.trim()}`
-  expect(renderedScenario).toBe(`${scenarioName} [150ms]`)
+  const renderedResult = lines
+    .slice(resultStart, summaryStart)
+    .join('')
+    .replace(/\s/gu, '')
+  expect(renderedResult).toContain(
+    `${specificationUri}>${scenarioName}[150ms]`.replace(/\s/gu, ''),
+  )
 })
 
 test('wraps non-BMP Unicode names without corrupting their characters', () => {
@@ -399,12 +395,18 @@ test('counts Test result states as mutually exclusive summary outcomes', () => {
   expect(lines).toContain(
     ' Test results    1 failed | 1 infrastructure error | 1 adapted | 1 passed | 1 skipped | 1 cancelled (6)',
   )
-  expect(lines.join('\n')).toContain('× Scenario 2 [150ms] (failed)')
   expect(lines.join('\n')).toContain(
-    '! Scenario 3 [150ms] (infrastructure error)',
+    '× src/google.feature > Scenario 2 [150ms] (failed)',
   )
-  expect(lines.join('\n')).toContain('↓ Scenario 4 [150ms] (skipped)')
-  expect(lines.join('\n')).toContain('○ Scenario 5 [150ms] (cancelled)')
+  expect(lines.join('\n')).toContain(
+    '! src/google.feature > Scenario 3 [150ms] (infrastructure error)',
+  )
+  expect(lines.join('\n')).toContain(
+    '↓ src/google.feature > Scenario 4 [150ms] (skipped)',
+  )
+  expect(lines.join('\n')).toContain(
+    '○ src/google.feature > Scenario 5 [150ms] (cancelled)',
+  )
 })
 
 test('enables color only for a TTY when NO_COLOR is absent', () => {
@@ -412,25 +414,21 @@ test('enables color only for a TTY when NO_COLOR is absent', () => {
     color: true,
     columns: 100,
     interactive: true,
-    progressive: false,
   })
   expect(terminalReporterCapabilities(true, 100, '')).toEqual({
     color: false,
     columns: 100,
     interactive: true,
-    progressive: false,
   })
   expect(terminalReporterCapabilities(false, undefined, undefined)).toEqual({
     color: false,
     columns: undefined,
     interactive: false,
-    progressive: true,
   })
   expect(terminalReporterCapabilities(true, 100, undefined, 'dumb')).toEqual({
     color: false,
     columns: 100,
     interactive: false,
-    progressive: true,
   })
 })
 
@@ -641,7 +639,7 @@ test('separates infrastructure diagnostics and renders profiles, messages, and a
   expect(output).toContain(
     ' Test results    1 failed | 1 infrastructure error (2)',
   )
-  expect(output.indexOf(' features/checkout.feature')).toBeLessThan(
-    output.indexOf(' features/search.feature'),
+  expect(output.indexOf('Specification  Checkout')).toBeLessThan(
+    output.indexOf('Specification  Search'),
   )
 })

--- a/packages/cli/src/run-reporter.test.ts
+++ b/packages/cli/src/run-reporter.test.ts
@@ -267,7 +267,7 @@ test('keeps interactive human output buffered until the run finishes', () => {
   expect(lines.join('\n')).toContain('features/a.feature')
 })
 
-test('uses color only as supplemental terminal state information', () => {
+test('uses a visible failure symbol with color only as supplemental information', () => {
   const run = passedRun({
     specificationUri: 'src/google.feature',
     specificationName: 'Search',
@@ -276,6 +276,7 @@ test('uses color only as supplemental terminal state information', () => {
     profileId: 'web',
     durationMs: 150,
   })
+  run.result.state = 'failed'
   const colorLines: string[] = []
   const plainLines: string[] = []
   const sharedOptions = {
@@ -300,9 +301,9 @@ test('uses color only as supplemental terminal state information', () => {
   plainReporter.start()
   plainReporter.finish([run], 150)
 
-  expect(colorLines.join('\n')).toContain('\u001b[32m✓\u001b[39m')
+  expect(colorLines.join('\n')).toContain('\u001b[31m×\u001b[39m')
   expect(plainLines.join('\n')).not.toContain('\u001b[')
-  expect(plainLines.join('\n')).toContain('✓ Visit main page [150ms]')
+  expect(plainLines.join('\n')).toContain('× Visit main page [150ms] (failed)')
 })
 
 test('wraps long paths and Scenario names without truncating them', () => {
@@ -451,7 +452,7 @@ test('enables color only for a TTY when NO_COLOR is absent', () => {
   })
 })
 
-test('preserves Test result messages in the human report', () => {
+test('preserves result-level failure messages when no executed step owns them', () => {
   const lines: string[] = []
   const reporter = createRunReporter('default', {
     write: (line) => lines.push(line),
@@ -477,8 +478,188 @@ test('preserves Test result messages in the human report', () => {
   reporter.finish([run], 150)
 
   expect(lines.join('\n')).toContain(
-    '       Expected results, but the page remained\n' +
-      '       empty\n' +
-      '       Screenshot captured',
+    '   Message\n' +
+      '     Expected results, but the page remained\n' +
+      '     empty\n' +
+      '     Screenshot captured',
+  )
+})
+
+test('renders functional failure diagnostics from executed Gherkin steps without resolved actions', () => {
+  const lines: string[] = []
+  const reporter = createRunReporter('default', {
+    write: (line) => lines.push(line),
+    projectRoot: '/workspace/project',
+    version: '1.0.2',
+    color: false,
+    columns: 120,
+    now: () => new Date(2026, 7, 20, 14, 32, 7),
+  })
+  const run = passedRun({
+    specificationUri: 'features/checkout.feature',
+    specificationName: 'Checkout',
+    scenarioId: 'scenario-purchase',
+    scenarioName: 'Complete a purchase',
+    profileId: 'web',
+    durationMs: 150,
+  })
+  run.result.state = 'failed'
+  run.result.message = 'Expected confirmation\nbut the page remained empty'
+  run.result.steps = [
+    {
+      step: {
+        keyword: 'Given',
+        text: 'a product is in the basket',
+        type: 'context',
+      },
+      state: 'passed',
+      resolvedActions: [{ description: 'Open the basket internals' }],
+    },
+    {
+      step: {
+        keyword: 'Then',
+        text: 'the purchase succeeds',
+        type: 'outcome',
+      },
+      state: 'failed',
+      resolvedActions: [{ description: 'Inspect the confirmation internals' }],
+      message: 'Expected confirmation\nbut the page remained empty',
+    },
+  ]
+
+  reporter.start()
+  reporter.finish([run], 150)
+
+  const output = lines.join('\n')
+  expect(output).toContain(` Failures
+
+ × Failure
+   Specification  Checkout (features/checkout.feature)
+   Scenario       Complete a purchase
+   Steps
+     ✓ Given a product is in the basket
+     × Then the purchase succeeds
+       Expected confirmation
+       but the page remained empty`)
+  expect(output).not.toContain('Open the basket internals')
+  expect(output).not.toContain('Inspect the confirmation internals')
+  expect(output.indexOf('features/checkout.feature')).toBeLessThan(
+    output.indexOf(' Failures'),
+  )
+  expect(output.indexOf(' Failures')).toBeLessThan(
+    output.indexOf(' Test results'),
+  )
+})
+
+test('separates infrastructure diagnostics and renders profiles, messages, and artifact paths', () => {
+  const lines: string[] = []
+  const reporter = createRunReporter('default', {
+    write: (line) => lines.push(line),
+    projectRoot: '/workspace/project',
+    version: '1.0.2',
+    color: false,
+    columns: 120,
+    now: () => new Date(2026, 7, 20, 14, 32, 7),
+  })
+  const failedRun = passedRun({
+    specificationUri: 'features/checkout.feature',
+    specificationName: 'Checkout',
+    scenarioId: 'scenario-purchase',
+    scenarioName: 'Complete a purchase',
+    profileId: 'web',
+    durationMs: 150,
+  })
+  failedRun.result.state = 'failed'
+  failedRun.result.steps = [
+    {
+      step: {
+        keyword: 'Then',
+        text: 'the purchase succeeds',
+        type: 'outcome',
+      },
+      state: 'failed',
+      resolvedActions: [],
+      message: 'Confirmation was not visible',
+      artifacts: [
+        {
+          kind: 'screenshot',
+          path: '/workspace/project/.pickle/runs/run-1/artifacts/failure.png',
+        },
+      ],
+    },
+  ]
+  const infrastructureRun = passedRun({
+    specificationUri: 'features/search.feature',
+    specificationName: 'Search',
+    scenarioId: 'scenario-search',
+    scenarioName: 'Find pickles',
+    profileId: 'android',
+    durationMs: 240,
+  })
+  infrastructureRun.result.state = 'infrastructure-error'
+  infrastructureRun.result.message =
+    'Emulator disconnected\nwhile the outcome step was running'
+  infrastructureRun.result.steps = [
+    {
+      step: {
+        keyword: 'Given',
+        text: 'the catalog is open',
+        type: 'context',
+      },
+      state: 'passed',
+      resolvedActions: [],
+    },
+    {
+      step: {
+        keyword: 'Then',
+        text: 'pickle results are visible',
+        type: 'outcome',
+      },
+      state: 'infrastructure-error',
+      resolvedActions: [],
+      message: 'Emulator disconnected\nwhile the outcome step was running',
+      artifacts: [
+        {
+          kind: 'device-log',
+          path: '/workspace/project/.pickle/runs/run-1/artifacts/device.log',
+        },
+        { kind: 'trace', path: '/var/tmp/pickle-external/trace.zip' },
+      ],
+    },
+  ]
+
+  reporter.start()
+  reporter.finish([infrastructureRun, failedRun], 390)
+
+  const output = lines.join('\n')
+  expect(output).toContain(` Failures
+
+ × Failure
+   Specification  Checkout (features/checkout.feature)
+   Scenario       Complete a purchase
+   Profile        web`)
+  expect(output).toContain(
+    '       Artifacts\n' +
+      '         screenshot: .pickle/runs/run-1/artifacts/failure.png',
+  )
+  expect(output).toContain(` Infrastructure errors
+
+ ! Infrastructure error
+   Specification  Search (features/search.feature)
+   Scenario       Find pickles
+   Profile        android
+   Steps
+     ✓ Given the catalog is open
+     ! Then pickle results are visible
+       Emulator disconnected
+       while the outcome step was running
+       Artifacts
+         device-log: .pickle/runs/run-1/artifacts/device.log
+         trace: /var/tmp/pickle-external/trace.zip`)
+  expect(output).toContain(
+    ' Test results    1 failed | 1 infrastructure error (2)',
+  )
+  expect(output.indexOf(' features/checkout.feature')).toBeLessThan(
+    output.indexOf(' features/search.feature'),
   )
 })

--- a/packages/cli/src/run-reporter.ts
+++ b/packages/cli/src/run-reporter.ts
@@ -1,3 +1,5 @@
+import { realpathSync } from 'node:fs'
+import { isAbsolute, relative, resolve, sep } from 'node:path'
 import type {
   RunEvent,
   ScenarioRun,
@@ -61,7 +63,7 @@ const resultPresentations: Record<TestResult['state'], ResultPresentation> = {
   },
   'infrastructure-error': {
     mark: '!',
-    color: 31,
+    color: 35,
     detail: 'infrastructure error',
     singular: 'infrastructure error',
     plural: 'infrastructure errors',
@@ -243,6 +245,14 @@ function groupResults(results: readonly TestResult[]): SpecificationGroup[] {
   )
 }
 
+function orderedResults(results: readonly TestResult[]): TestResult[] {
+  return groupResults(results).flatMap((specification) =>
+    [...specification.scenarios.values()].flatMap(
+      (scenario) => scenario.results,
+    ),
+  )
+}
+
 function groupSchedule(
   schedule: readonly ScheduledTestResult[],
 ): PendingSpecificationBlock[] {
@@ -263,15 +273,11 @@ function groupSchedule(
 function orderedScheduleFromResults(
   results: readonly TestResult[],
 ): ScheduledTestResult[] {
-  return groupResults(results).flatMap((specification) =>
-    [...specification.scenarios.values()].flatMap((scenario) =>
-      scenario.results.map((result) => ({
-        specification: result.specification,
-        scenario: result.scenario,
-        executionTargetProfile: result.executionTargetProfile,
-      })),
-    ),
-  )
+  return orderedResults(results).map((result) => ({
+    specification: result.specification,
+    scenario: result.scenario,
+    executionTargetProfile: result.executionTargetProfile,
+  }))
 }
 
 function scheduledResultMatches(
@@ -288,7 +294,7 @@ function scheduledResultMatches(
   )
 }
 
-type SpecificationWriterOptions = {
+type ResultWriterOptions = {
   write: WriteLine
   color: boolean
   columns?: number
@@ -297,7 +303,7 @@ type SpecificationWriterOptions = {
 
 function writeSpecification(
   specification: SpecificationGroup,
-  options: SpecificationWriterOptions,
+  options: ResultWriterOptions,
 ): void {
   writeWrapped(options.write, ' ', specification.uri, '   ', options.columns)
   writeWrapped(
@@ -322,16 +328,148 @@ function writeSpecification(
         options.columns,
         plainPrefix.length,
       )
-      for (const messageLine of result.message?.split('\n') ?? []) {
-        writeWrapped(
-          options.write,
-          '       ',
-          messageLine,
-          '       ',
-          options.columns,
-        )
-      }
     }
+  }
+}
+
+type DiagnosticWriterOptions = ResultWriterOptions & {
+  projectRoot: string
+}
+
+type DiagnosticState = Extract<
+  TestResult['state'],
+  'failed' | 'infrastructure-error'
+>
+
+const diagnosticHeadings: Record<
+  DiagnosticState,
+  { section: string; label: string }
+> = {
+  failed: { section: 'Failures', label: 'Failure' },
+  'infrastructure-error': {
+    section: 'Infrastructure errors',
+    label: 'Infrastructure error',
+  },
+}
+
+function writeMessage(
+  message: string,
+  options: DiagnosticWriterOptions,
+  prefix = '       ',
+): void {
+  for (const line of message.split(/\r?\n/)) {
+    writeWrapped(options.write, prefix, line, prefix, options.columns)
+  }
+}
+
+function canonicalPath(path: string): string {
+  try {
+    return realpathSync(path)
+  } catch {
+    return resolve(path)
+  }
+}
+
+function displayArtifactPath(path: string, projectRoot: string): string {
+  const canonicalProjectRoot = canonicalPath(projectRoot)
+  const absolutePath = canonicalPath(resolve(projectRoot, path))
+  const projectRelativePath = relative(canonicalProjectRoot, absolutePath)
+  const isContained =
+    projectRelativePath.length > 0 &&
+    projectRelativePath !== '..' &&
+    !projectRelativePath.startsWith(`..${sep}`) &&
+    !isAbsolute(projectRelativePath)
+  return isContained ? projectRelativePath : absolutePath
+}
+
+function writeArtifacts(
+  stepResult: TestResult['steps'][number],
+  options: DiagnosticWriterOptions,
+): void {
+  if (!stepResult.artifacts?.length) return
+  options.write('       Artifacts')
+  for (const artifact of stepResult.artifacts) {
+    writeWrapped(
+      options.write,
+      `         ${artifact.kind}: `,
+      displayArtifactPath(artifact.path, options.projectRoot),
+      '           ',
+      options.columns,
+    )
+  }
+}
+
+function writeDiagnostic(
+  result: TestResult,
+  options: DiagnosticWriterOptions,
+): void {
+  if (result.state !== 'failed' && result.state !== 'infrastructure-error') {
+    return
+  }
+  const heading = diagnosticHeadings[result.state]
+  options.write('')
+  options.write(` ${stateMark(result.state, options.color)} ${heading.label}`)
+  writeWrapped(
+    options.write,
+    '   Specification  ',
+    `${result.specification.name} (${result.specification.uri})`,
+    '                  ',
+    options.columns,
+  )
+  writeWrapped(
+    options.write,
+    '   Scenario       ',
+    result.scenario.name,
+    '                  ',
+    options.columns,
+  )
+  if (options.multipleProfiles) {
+    writeWrapped(
+      options.write,
+      '   Profile        ',
+      result.executionTargetProfile.id,
+      '                  ',
+      options.columns,
+    )
+  }
+  if (result.steps.length > 0) {
+    options.write('   Steps')
+    for (const step of result.steps) {
+      const plainPrefix = `     ${resultPresentations[step.state].mark} `
+      const styledPrefix = `     ${stateMark(step.state, options.color)} `
+      writeWrapped(
+        options.write,
+        styledPrefix,
+        `${step.step.keyword} ${step.step.text}`,
+        '       ',
+        options.columns,
+        plainPrefix.length,
+      )
+      if (step.message) writeMessage(step.message, options)
+      writeArtifacts(step, options)
+    }
+  }
+  const messageBelongsToStep = result.steps.some(
+    (step) => step.state === result.state && step.message === result.message,
+  )
+  if (result.message && !messageBelongsToStep) {
+    options.write('   Message')
+    writeMessage(result.message, options, '     ')
+  }
+}
+
+function writeDiagnostics(
+  results: readonly TestResult[],
+  options: DiagnosticWriterOptions,
+): void {
+  const ordered = orderedResults(results)
+  const states: DiagnosticState[] = ['failed', 'infrastructure-error']
+  for (const state of states) {
+    const diagnostics = ordered.filter((result) => result.state === state)
+    if (diagnostics.length === 0) continue
+    options.write('')
+    options.write(` ${diagnosticHeadings[state].section}`)
+    for (const result of diagnostics) writeDiagnostic(result, options)
   }
 }
 
@@ -439,6 +577,14 @@ function createDefaultReporter(options: RunReporterOptions): RunReporter {
       }
       flushReadyBlocks()
       const specifications = groupResults(results)
+
+      writeDiagnostics(results, {
+        write,
+        projectRoot,
+        color,
+        columns,
+        multipleProfiles,
+      })
 
       write('')
       write(` Specifications  ${specifications.length}`)

--- a/packages/cli/src/run-reporter.ts
+++ b/packages/cli/src/run-reporter.ts
@@ -9,18 +9,15 @@ import {
   clockLabel,
   diagnosticLines,
   groupResults,
-  type SpecificationGroup,
+  renderTestResult,
   summaryLines,
   type WriteLine,
-  writeSpecification,
   writeWrapped,
 } from './run-report'
 import {
   claimScheduleIndex,
   createScheduleIndexQueues,
-  groupSchedule,
   orderedScheduleFromResults,
-  type PendingSpecificationBlock,
   type ScheduleIndexQueue,
 } from './run-schedule'
 import {
@@ -47,7 +44,6 @@ type RunReporterOptions = {
   color?: boolean
   columns?: number
   interactive?: boolean
-  progressive?: boolean
   terminal?: InteractiveTerminalSurface
   now?: () => Date
   scheduleRefresh?: (refresh: () => void) => () => void
@@ -59,52 +55,30 @@ function createBufferedRunReporter(options: RunReporterOptions): RunReporter {
   const projectRoot = options.projectRoot ?? process.cwd()
   const version = options.version ?? 'unknown'
   const color = options.color ?? false
-  const progressive = options.progressive ?? false
   let startTime = ''
   let completedResults: Array<TestResult | undefined> = []
-  let pendingBlocks: PendingSpecificationBlock[] = []
   let scheduleIndexQueues = new Map<string, ScheduleIndexQueue>()
-  let nextBlockIndex = 0
-  let wroteSpecification = false
   let multipleProfiles = false
 
   function prepare(schedule: readonly ScheduledTestResult[]): void {
     completedResults = Array.from({ length: schedule.length })
-    pendingBlocks = groupSchedule(schedule)
     scheduleIndexQueues = createScheduleIndexQueues(schedule)
-    nextBlockIndex = 0
-    wroteSpecification = false
     multipleProfiles =
       new Set(schedule.map((result) => result.executionTargetProfile.id)).size >
       1
   }
 
-  function completedSpecification(
-    block: PendingSpecificationBlock,
-  ): SpecificationGroup | undefined {
-    const results = block.scheduleIndexes.flatMap((scheduleIndex) => {
-      const result = completedResults[scheduleIndex]
-      return result ? [result] : []
-    })
-    if (results.length !== block.scheduleIndexes.length) return undefined
-    return groupResults(results)[0]
-  }
-
-  function flushReadyBlocks(): void {
-    while (nextBlockIndex < pendingBlocks.length) {
-      const specification = completedSpecification(
-        pendingBlocks[nextBlockIndex]!,
-      )
-      if (!specification) return
-      if (wroteSpecification) write('')
-      writeSpecification(specification, {
-        write,
+  function writeCompletedResult(result: TestResult): void {
+    for (const line of renderTestResult(
+      result,
+      `${result.specification.uri} > ${result.scenario.name}`,
+      {
         color,
         columns: options.columns,
         multipleProfiles,
-      })
-      wroteSpecification = true
-      nextBlockIndex++
+      },
+    )) {
+      write(line)
     }
   }
 
@@ -112,7 +86,7 @@ function createBufferedRunReporter(options: RunReporterOptions): RunReporter {
     const scheduleIndex = claimScheduleIndex(scheduleIndexQueues, result)
     if (scheduleIndex === undefined) return
     completedResults[scheduleIndex] = result
-    if (progressive) flushReadyBlocks()
+    writeCompletedResult(result)
   }
 
   return {
@@ -140,7 +114,6 @@ function createBufferedRunReporter(options: RunReporterOptions): RunReporter {
       if (completedResults.some((result) => !result)) {
         for (const result of results) complete(result)
       }
-      flushReadyBlocks()
       const specifications = groupResults(results)
       for (const line of diagnosticLines(results, {
         projectRoot,
@@ -200,16 +173,12 @@ export function terminalReporterCapabilities(
   columns: number | undefined,
   noColor: string | undefined,
   term?: string,
-): Pick<
-  RunReporterOptions,
-  'color' | 'columns' | 'interactive' | 'progressive'
-> {
+): Pick<RunReporterOptions, 'color' | 'columns' | 'interactive'> {
   const interactive = Boolean(isTerminal) && term !== 'dumb'
   return {
     color: interactive && noColor === undefined,
     columns,
     interactive,
-    progressive: !interactive,
   }
 }
 

--- a/packages/cli/src/run-schedule.ts
+++ b/packages/cli/src/run-schedule.ts
@@ -79,8 +79,12 @@ export function claimScheduleIndex(
 
 export function scheduledEventMatches(
   scheduled: ScheduledTestResult,
-  event: Extract<RunEvent, { type: 'scenario-started' }>,
+  event: Extract<
+    RunEvent,
+    { type: 'scenario-started' | 'step-started' | 'step-finished' }
+  >,
 ): boolean {
+  if (!event.scenario) return false
   const scenarioMatches = event.scenario.id
     ? event.scenario.id === scheduled.scenario.id
     : event.scenario.name === scheduled.scenario.name

--- a/packages/cli/src/run-streaming.test.ts
+++ b/packages/cli/src/run-streaming.test.ts
@@ -50,7 +50,7 @@ afterAll(async () => {
   await rm(workspace, { recursive: true, force: true })
 })
 
-test('streams complete Specification blocks in stable order through public CLI output', async () => {
+test('streams Test results in completion order through public CLI output', async () => {
   const project = join(workspace, 'ordered-blocks')
   const gates = join(project, 'gates')
   await mkdir(join(project, 'features'), { recursive: true })
@@ -158,30 +158,43 @@ Feature: Third Specification
     }),
   ])
 
-  await Bun.write(join(gates, 'b-only.release'), '')
-  await Bun.write(join(gates, 'a-first.release'), '')
-  await Promise.all([
-    waitForFile(join(gates, 'b-only.finished')),
-    waitForFile(join(gates, 'a-first.finished')),
-  ])
   const safetyRelease = setTimeout(() => {
+    void Bun.write(join(gates, 'a-first.release'), '')
     void Bun.write(join(gates, 'a-second.release'), '')
+    void Bun.write(join(gates, 'b-only.release'), '')
     void Bun.write(join(gates, 'c-only.release'), '')
   }, 2_000)
-  await Bun.sleep(50)
-  expect(output.join('')).not.toContain(' features/a.feature')
-  expect(output.join('')).not.toContain(' features/b.feature')
+
+  await Bun.write(join(gates, 'b-only.release'), '')
+  const firstOutput = await waitForOutput(
+    output,
+    'features/b.feature > Ready early',
+  )
+  expect(firstOutput).not.toContain('features/a.feature')
+  expect(firstOutput).not.toContain('features/c.feature')
+
+  await Bun.write(join(gates, 'a-first.release'), '')
+  const secondOutput = await waitForOutput(
+    output,
+    'features/a.feature > First declared Scenario',
+  )
+  expect(secondOutput).not.toContain('Second declared Scenario [')
+  expect(secondOutput).not.toContain('features/c.feature')
 
   await Bun.write(join(gates, 'a-second.release'), '')
-  const progressiveOutput = await waitForOutput(output, ' features/b.feature')
-  const firstUri = progressiveOutput.indexOf(' features/a.feature')
-  const secondUri = progressiveOutput.indexOf(' features/b.feature')
-  expect(firstUri).toBeGreaterThan(-1)
-  expect(secondUri).toBeGreaterThan(firstUri)
-  expect(progressiveOutput.indexOf('First declared Scenario')).toBeLessThan(
-    progressiveOutput.indexOf('Second declared Scenario'),
+  const progressiveOutput = await waitForOutput(
+    output,
+    'features/a.feature > Second declared Scenario',
   )
-  expect(progressiveOutput).not.toContain(' features/c.feature')
+  expect(progressiveOutput.indexOf('features/b.feature')).toBeLessThan(
+    progressiveOutput.indexOf('features/a.feature > First declared Scenario'),
+  )
+  expect(
+    progressiveOutput.indexOf('features/a.feature > First declared Scenario'),
+  ).toBeLessThan(
+    progressiveOutput.indexOf('features/a.feature > Second declared Scenario'),
+  )
+  expect(progressiveOutput).not.toContain('features/c.feature')
 
   await Bun.write(join(gates, 'c-only.release'), '')
   const [exitCode, stderr] = await Promise.all([
@@ -194,16 +207,12 @@ Feature: Third Specification
   expect(exitCode).toBe(0)
   clearTimeout(safetyRelease)
   expect(stderr).toBe('')
-  expect(finalOutput.indexOf(' features/c.feature')).toBeGreaterThan(secondUri)
-  for (const uri of [
-    'features/a.feature',
-    'features/b.feature',
-    'features/c.feature',
-  ]) {
-    expect(
-      finalOutput.match(new RegExp(uri.replace('.', '\\.'), 'g')),
-    ).toHaveLength(1)
-  }
+  expect(finalOutput.indexOf('features/c.feature')).toBeGreaterThan(
+    progressiveOutput.indexOf('features/a.feature > Second declared Scenario'),
+  )
+  expect(finalOutput.match(/features\/a\.feature/g)).toHaveLength(2)
+  expect(finalOutput.match(/features\/b\.feature/g)).toHaveLength(1)
+  expect(finalOutput.match(/features\/c\.feature/g)).toHaveLength(1)
   expect(finalOutput).toContain('Specifications  3')
   expect(finalOutput).toContain('Scenarios       4')
   expect(finalOutput).toContain('Test results    4 passed (4)')

--- a/packages/cli/src/workspace.test.ts
+++ b/packages/cli/src/workspace.test.ts
@@ -164,9 +164,7 @@ export default {
     expect(stderr).toBe('')
     expect(exitCode).toBe(0)
     expect(stdout).toContain(`RUN  pickle 1.0.2 ${await realpath(workspace)}`)
-    expect(stdout).toContain(
-      ' purchase.feature\n   Purchase\n     ✓ Complete a purchase [',
-    )
+    expect(stdout).toContain('✓ purchase.feature > Complete a purchase [')
     expect(stdout).not.toContain('[deterministic]')
     expect(stdout).toContain('Specifications  1')
     expect(stdout).toContain('Scenarios       1')

--- a/packages/cli/src/workspace.test.ts
+++ b/packages/cli/src/workspace.test.ts
@@ -109,9 +109,16 @@ export default {
               signal?.addEventListener('abort', onAbort, { once: true })
             })
           }
+          const message = process.env.PICKLE_TEST_MESSAGE
+          const artifactPath = process.env.PICKLE_TEST_ARTIFACT
+          const artifacts = artifactPath
+            ? [{ kind: 'trace', path: artifactPath, mediaType: 'text/plain' }]
+            : undefined
           return {
             state,
             resolvedActions: [{ description: \`Deterministic action: \${step.text}\` }],
+            message,
+            artifacts,
           }
         },
         async close() {
@@ -676,6 +683,60 @@ Feature: Checkout
           state: expected.outcome,
         },
       })
+    }
+  })
+
+  test('default run output keeps actionable result diagnostics on stdout', async () => {
+    const artifactPath = join(workspace, 'diagnostic-artifact.txt')
+    await Bun.write(artifactPath, 'diagnostic evidence')
+    const cases = [
+      {
+        outcome: 'failed',
+        section: 'Failures',
+        label: '× Failure',
+        step: '× Given a product is in the basket',
+      },
+      {
+        outcome: 'infrastructure-error',
+        section: 'Infrastructure errors',
+        label: '! Infrastructure error',
+        step: '! Given a product is in the basket',
+      },
+    ] as const
+
+    for (const expected of cases) {
+      const run = Bun.spawnSync({
+        cmd: [
+          pickleCommand,
+          'run',
+          'purchase.feature',
+          '--config',
+          'deterministic.config.jsonc',
+          '--extensions',
+          'pickle.extensions.ts',
+        ],
+        cwd: workspace,
+        env: {
+          ...Bun.env,
+          PICKLE_TEST_OUTCOME: expected.outcome,
+          PICKLE_TEST_MESSAGE:
+            'Expected checkout confirmation\nbut the target became unavailable',
+          PICKLE_TEST_ARTIFACT: artifactPath,
+        },
+      })
+      const stdout = run.stdout.toString()
+
+      expect(run.exitCode).toBe(1)
+      expect(run.stderr.toString()).toBe('')
+      expect(stdout).toContain(` ${expected.section}`)
+      expect(stdout).toContain(` ${expected.label}`)
+      expect(stdout).toContain(expected.step)
+      expect(stdout).toContain(
+        '       Expected checkout confirmation\n' +
+          '       but the target became unavailable',
+      )
+      expect(stdout).toContain('         trace: diagnostic-artifact.txt')
+      expect(stdout).not.toContain('Deterministic action:')
     }
   })
 


### PR DESCRIPTION
## Summary

- Add visible failure and infrastructure-error diagnostics to the default CLI reporter.
- Render failed steps, messages, execution profiles, and artifact paths.
- Keep diagnostics ordered and hide internal resolved actions from human output.
- Add unit and workspace integration coverage.

Closes #53

## Testing

- Added reporter tests for failure states, infrastructure errors, messages, profiles, ordering, and artifact paths.
- Added workspace integration coverage for stdout diagnostics and exit behavior.