### PR TITLE
Report CLI run results truthfully

### DIFF
--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -44,6 +44,7 @@ import {
   studioRunReadiness,
   studioRunSelection,
 } from './studio-project'
+import { evaluateTestRunExitStatus } from './test-run-exit-status'
 
 interface RunArguments {
   pattern?: string
@@ -263,18 +264,12 @@ async function run(argv: string[]): Promise<number> {
       maxBytes: config.retention?.maxBytes,
     })
 
-    reporter.finish(runs, performance.now() - startedAt)
-    const states = runs.map(({ result }) => result.state)
-    if (states.includes('cancelled')) return 130
-    if (
-      states.includes('failed') ||
-      states.includes('infrastructure-error') ||
-      (config.policy?.adaptedResults === 'reject' &&
-        states.includes('passed-with-adaptation'))
-    ) {
-      return 1
-    }
-    return 0
+    const exitStatus = evaluateTestRunExitStatus(
+      runs.map(({ result }) => result),
+      config.policy?.adaptedResults,
+    )
+    reporter.finish(runs, performance.now() - startedAt, exitStatus)
+    return exitStatus.exitCode
   } catch (error) {
     reporter.fail?.(error, performance.now() - startedAt)
     throw error

--- a/packages/cli/src/live-run-reporter.test.ts
+++ b/packages/cli/src/live-run-reporter.test.ts
@@ -1,6 +1,10 @@
 import { expect, test } from 'bun:test'
 import { createRunReporter } from './run-reporter'
-import { passedRun, recordingTerminal } from './run-reporter.test-support'
+import {
+  finishReporter,
+  passedRun,
+  recordingTerminal,
+} from './run-reporter.test-support'
 
 test('shows completed and running Gherkin steps beneath an active Scenario', () => {
   const run = passedRun({
@@ -243,7 +247,7 @@ test('updates active Specifications and commits each completed result once', () 
   )
 
   reporter.complete?.(runs[4]!.result)
-  reporter.finish(runs, 50)
+  finishReporter(reporter, runs, 50)
 
   const finishes = terminal.operations.filter(
     (operation) => operation.type === 'finish',
@@ -294,7 +298,7 @@ test('finishes live progress with actionable diagnostics and a compact result tr
   })
 
   reporter.start()
-  reporter.finish([run], 10)
+  finishReporter(reporter, [run], 10)
 
   const committedOutput = terminal.operations
     .filter((operation) => operation.type === 'commit')
@@ -319,6 +323,41 @@ test('finishes live progress with actionable diagnostics and a compact result tr
        but the page remained empty`)
   expect(finalOutput).not.toContain('Inspect internal selectors')
   expect(finalOutput).not.toMatch(/[◐◓◑◒]/u)
+})
+
+test('finishes live progress with a prominent adaptation-policy rejection', () => {
+  const run = passedRun({
+    specificationUri: 'features/checkout.feature',
+    specificationName: 'Checkout',
+    scenarioId: 'scenario-purchase',
+    scenarioName: 'Complete a purchase',
+    profileId: 'web',
+    durationMs: 10,
+  })
+  run.result.state = 'passed-with-adaptation'
+  const terminal = recordingTerminal(() => 120)
+  const reporter = createRunReporter('default', {
+    terminal: terminal.surface,
+    projectRoot: '/workspace/project',
+    version: '1.0.2',
+    color: false,
+    now: () => new Date(2026, 7, 20, 14, 32, 7),
+  })
+
+  reporter.start()
+  reporter.finish([run], 10, {
+    exitCode: 1,
+    rejectedAdaptedResults: 1,
+  })
+
+  const finalOutput = terminal.operations
+    .filter((operation) => operation.type === 'finish')
+    .flatMap((operation) => operation.lines)
+    .join('\n')
+  expect(finalOutput).toContain('! Adaptation policy rejected the Test run')
+  expect(finalOutput).toContain(
+    'The Test result remains adapted and pickle run exits with code 1.',
+  )
 })
 
 test('rewraps active progress and preserves a committed result on resize', () => {

--- a/packages/cli/src/live-run-reporter.ts
+++ b/packages/cli/src/live-run-reporter.ts
@@ -1,6 +1,5 @@
 import type {
   RunEvent,
-  ScenarioRun,
   ScheduledTestResult,
   TestResult,
 } from '@pickle-spec/runner'
@@ -8,12 +7,14 @@ import {
   clockLabel,
   diagnosticLines,
   groupResults,
+  policyLines,
   renderTestResult,
   renderTestStepResult,
   summaryLines,
   wrappedLines,
   writeWrapped,
 } from './run-report'
+import type { RunReporter } from './run-reporter'
 import {
   claimScheduleIndex,
   createScheduleIndexQueues,
@@ -28,6 +29,7 @@ import {
   type InteractiveTerminalSurface,
   renderedTerminalRows,
 } from './terminal-surface'
+import type { TestRunExitStatus } from './test-run-exit-status'
 
 type LiveRunReporterOptions = {
   terminal: InteractiveTerminalSurface
@@ -36,16 +38,6 @@ type LiveRunReporterOptions = {
   color: boolean
   now(): Date
   scheduleRefresh?: (refresh: () => void) => () => void
-}
-
-interface LiveRunReporter {
-  start(): void
-  prepare(schedule: readonly ScheduledTestResult[]): void
-  event(event: RunEvent): void
-  complete(result: TestResult): void
-  fail(error: unknown, durationMs: number): void
-  refresh(): void
-  finish(runs: readonly ScenarioRun[], durationMs: number): void
 }
 
 type StepStartedEvent = Extract<RunEvent, { type: 'step-started' }>
@@ -67,7 +59,7 @@ function schedulePagedRefresh(refresh: () => void): () => void {
 
 export function createLiveRunReporter(
   options: LiveRunReporterOptions,
-): LiveRunReporter {
+): RunReporter {
   const { terminal } = options
   let startTime = ''
   let schedule: readonly ScheduledTestResult[] = []
@@ -253,10 +245,11 @@ export function createLiveRunReporter(
     )
   }
 
-  function finish(
+  function finishOutput(
     results: readonly TestResult[],
     durationMs: number,
-    error?: unknown,
+    summaryNotice: readonly string[],
+    resultPolicyLines: readonly string[],
   ): void {
     if (finished) return
     setPagedRefresh(false)
@@ -268,21 +261,36 @@ export function createLiveRunReporter(
       multipleProfiles,
     })
     const summary = summaryLines(specifications, results, startTime, durationMs)
-    if (error !== undefined) {
-      const message = error instanceof Error ? error.message : String(error)
-      summary.splice(
-        1,
-        0,
-        ...wrappedLines(
-          ' Run failed      ',
-          message,
-          '                 ',
-          columns(),
-        ),
-      )
-    }
-    terminal.finish([...diagnostics, ...summary])
+    summary.splice(1, 0, ...summaryNotice)
+    terminal.finish([...diagnostics, ...resultPolicyLines, ...summary])
     finished = true
+  }
+
+  function finishFailure(
+    results: readonly TestResult[],
+    durationMs: number,
+    error: unknown,
+  ): void {
+    const message = error instanceof Error ? error.message : String(error)
+    finishOutput(
+      results,
+      durationMs,
+      wrappedLines(
+        ' Run failed      ',
+        message,
+        '                 ',
+        columns(),
+      ),
+      [],
+    )
+  }
+
+  function finishTestRun(
+    results: readonly TestResult[],
+    durationMs: number,
+    exitStatus: TestRunExitStatus,
+  ): void {
+    finishOutput(results, durationMs, [], policyLines(exitStatus, columns()))
   }
 
   function complete(result: TestResult): void {
@@ -357,16 +365,16 @@ export function createLiveRunReporter(
       const results = completedResults.flatMap((result) =>
         result ? [result] : [],
       )
-      finish(results, durationMs, error)
+      finishFailure(results, durationMs, error)
     },
     refresh: updateDynamicRegion,
-    finish(runs, durationMs) {
+    finish(runs, durationMs, exitStatus) {
       const results = runs.map((run) => run.result)
       if (schedule.length === 0) prepare(orderedScheduleFromResults(results))
       if (completedResults.some((result) => !result)) {
         for (const result of results) complete(result)
       }
-      finish(results, durationMs)
+      finishTestRun(results, durationMs, exitStatus)
     },
   }
 }

--- a/packages/cli/src/run-report.ts
+++ b/packages/cli/src/run-report.ts
@@ -1,6 +1,7 @@
 import { realpathSync } from 'node:fs'
 import { isAbsolute, relative, resolve, sep } from 'node:path'
 import type { TestResult } from '@pickle-spec/runner'
+import type { TestRunExitStatus } from './test-run-exit-status'
 
 export type WriteLine = (line: string) => void
 
@@ -23,6 +24,8 @@ type ResultPresentation = {
   plural: string
 }
 
+type PropertyPresentation = Pick<ResultPresentation, 'mark' | 'color'>
+
 const resultPresentations: Record<TestResult['state'], ResultPresentation> = {
   failed: {
     mark: '×',
@@ -39,13 +42,19 @@ const resultPresentations: Record<TestResult['state'], ResultPresentation> = {
     plural: 'infrastructure errors',
   },
   'passed-with-adaptation': {
-    mark: '✓',
+    mark: '~',
     color: 33,
     detail: 'adapted',
     singular: 'adapted',
     plural: 'adapted',
   },
-  passed: { mark: '✓', color: 32, singular: 'passed', plural: 'passed' },
+  passed: {
+    mark: '✓',
+    color: 32,
+    detail: 'passed',
+    singular: 'passed',
+    plural: 'passed',
+  },
   skipped: {
     mark: '↓',
     color: 90,
@@ -61,6 +70,8 @@ const resultPresentations: Record<TestResult['state'], ResultPresentation> = {
     plural: 'cancelled',
   },
 }
+
+const flakyPresentation: PropertyPresentation = { mark: '↻', color: 36 }
 
 type TextUnit = {
   value: string
@@ -91,9 +102,17 @@ export function clockLabel(date: Date): string {
     .join(':')
 }
 
+function presentationMark(
+  presentation: PropertyPresentation,
+  color: boolean,
+): string {
+  return color
+    ? `\u001b[${presentation.color}m${presentation.mark}\u001b[39m`
+    : presentation.mark
+}
+
 function stateMark(state: TestResult['state'], color: boolean): string {
-  const { mark, color: colorCode } = resultPresentations[state]
-  return color ? `\u001b[${colorCode}m${mark}\u001b[39m` : mark
+  return presentationMark(resultPresentations[state], color)
 }
 
 function textUnits(value: string): TextUnit[] {
@@ -190,9 +209,17 @@ export function writeWrapped(
 
 function resultSuffix(result: TestResult): string {
   const details = []
-  const stateDetail = resultPresentations[result.state].detail
+  const skipReason =
+    result.state === 'skipped'
+      ? result.message?.split(/\r?\n/, 1)[0]?.trim()
+      : undefined
+  const stateDetail = skipReason
+    ? `skipped: ${skipReason}`
+    : resultPresentations[result.state].detail
   if (stateDetail) details.push(stateDetail)
-  if (result.flaky) details.push(`flaky, ${result.attempts ?? 2} attempts`)
+  if (result.flaky) {
+    details.push(`flaky, ${result.attempts ?? 2} attempts`)
+  }
   return details.length > 0 ? ` (${details.join('; ')})` : ''
 }
 
@@ -257,8 +284,12 @@ function writeResult(
   const profile = options.multipleProfiles
     ? `[${result.executionTargetProfile.id}] `
     : ''
-  const plainPrefix = `${indent}${resultPresentations[result.state].mark} ${profile}`
-  const styledPrefix = `${indent}${stateMark(result.state, options.color)} ${profile}`
+  const plainFlakyMark = result.flaky ? flakyPresentation.mark : ''
+  const styledFlakyMark = result.flaky
+    ? presentationMark(flakyPresentation, options.color)
+    : ''
+  const plainPrefix = `${indent}${resultPresentations[result.state].mark}${plainFlakyMark} ${profile}`
+  const styledPrefix = `${indent}${stateMark(result.state, options.color)}${styledFlakyMark} ${profile}`
   writeWrapped(
     options.write,
     styledPrefix,
@@ -472,6 +503,37 @@ export function diagnosticLines(
   return lines
 }
 
+export function policyLines(
+  exitStatus: TestRunExitStatus,
+  columns?: number,
+): string[] {
+  const count = exitStatus.rejectedAdaptedResults
+  if (count === 0) return []
+  const resultLabel = count === 1 ? 'Test result' : 'Test results'
+  const reference = count === 1 ? 'The Test result' : 'These Test results'
+  return [
+    '',
+    ...wrappedLines(
+      ' ! ',
+      'Adaptation policy rejected the Test run',
+      '   ',
+      columns,
+    ),
+    ...wrappedLines(
+      '   ',
+      `${count} adapted ${resultLabel} passed, but policy.adaptedResults is set to reject.`,
+      '   ',
+      columns,
+    ),
+    ...wrappedLines(
+      '   ',
+      `${reference} remains adapted and pickle run exits with code ${exitStatus.exitCode}.`,
+      '   ',
+      columns,
+    ),
+  ]
+}
+
 function testResultSummary(results: readonly TestResult[]): string {
   const entries = Object.entries(
     resultPresentations,
@@ -490,11 +552,13 @@ export function summaryLines(
   startTime: string,
   durationMs: number,
 ): string[] {
+  const flakyResults = results.filter((result) => result.flaky).length
   return [
     '',
     ` Specifications  ${specifications.length}`,
     ` Scenarios       ${specifications.reduce((total, specification) => total + specification.scenarios.size, 0)}`,
     ` Test results    ${testResultSummary(results)}`,
+    ...(flakyResults > 0 ? [` Flaky results   ${flakyResults}`] : []),
     ` Start at        ${startTime}`,
     ` Duration        ${durationLabel(durationMs)}`,
   ]

--- a/packages/cli/src/run-reporter.test-support.ts
+++ b/packages/cli/src/run-reporter.test-support.ts
@@ -1,5 +1,7 @@
 import type { ScenarioRun } from '@pickle-spec/runner'
+import type { RunReporter } from './run-reporter'
 import type { InteractiveTerminalSurface } from './terminal-surface'
+import { evaluateTestRunExitStatus } from './test-run-exit-status'
 
 type TerminalOperation = {
   type: 'commit' | 'finish' | 'update'
@@ -59,4 +61,16 @@ export function passedRun(input: PassedRunInput): ScenarioRun {
       durationMs: input.durationMs,
     },
   }
+}
+
+export function finishReporter(
+  reporter: RunReporter,
+  runs: readonly ScenarioRun[],
+  durationMs: number,
+): void {
+  reporter.finish(
+    runs,
+    durationMs,
+    evaluateTestRunExitStatus(runs.map(({ result }) => result)),
+  )
 }

--- a/packages/cli/src/run-reporter.test.ts
+++ b/packages/cli/src/run-reporter.test.ts
@@ -1,6 +1,6 @@
 import { expect, test } from 'bun:test'
 import { createRunReporter, terminalReporterCapabilities } from './run-reporter'
-import { passedRun } from './run-reporter.test-support'
+import { finishReporter, passedRun } from './run-reporter.test-support'
 
 test('renders completed Test results as Vitest-style lines', () => {
   const lines: string[] = []
@@ -14,7 +14,8 @@ test('renders completed Test results as Vitest-style lines', () => {
   })
 
   reporter.start()
-  reporter.finish(
+  finishReporter(
+    reporter,
     [
       passedRun({
         specificationUri: 'src/google.feature',
@@ -55,10 +56,10 @@ test('renders completed Test results as Vitest-style lines', () => {
   expect(lines.join('\n')).toBe(`
  RUN  pickle 1.0.2 /workspace/project
 
- ✓ [web] src/google.feature > Visit main page [150ms]
- ✓ [android] src/google.feature > Visit main page [1.24s]
- ✓ [web] src/google.feature > Find pickles [820ms]
- ✓ [web] features/checkout.feature > Complete a purchase [5ms]
+ ✓ [web] src/google.feature > Visit main page [150ms] (passed)
+ ✓ [android] src/google.feature > Visit main page [1.24s] (passed)
+ ✓ [web] src/google.feature > Find pickles [820ms] (passed)
+ ✓ [web] features/checkout.feature > Complete a purchase [5ms] (passed)
 
  Specifications  2
  Scenarios       3
@@ -149,16 +150,16 @@ test('streams Test results in completion order without repeating them at finish'
   )
 
   progressiveReporter.complete?.(runs[2]!.result)
-  progressiveReporter.finish(runs, 100)
+  finishReporter(progressiveReporter, runs, 100)
 
   const resultLines = progressiveLines.filter((line) => /[✓×!↓○]/u.test(line))
   expect(resultLines).toEqual([
-    ' ✓ [web] features/b.feature > Ready early [50ms]',
-    ' ✓ [android] features/b.feature > Ready early [60ms]',
-    ' ✓ [android] features/a.feature > Second Scenario [40ms]',
-    ' ✓ [android] features/a.feature > First Scenario [20ms]',
-    ' ✓ [web] features/a.feature > First Scenario [10ms]',
-    ' ✓ [web] features/a.feature > Second Scenario [30ms]',
+    ' ✓ [web] features/b.feature > Ready early [50ms] (passed)',
+    ' ✓ [android] features/b.feature > Ready early [60ms] (passed)',
+    ' ✓ [android] features/a.feature > Second Scenario [40ms] (passed)',
+    ' ✓ [android] features/a.feature > First Scenario [20ms] (passed)',
+    ' ✓ [web] features/a.feature > First Scenario [10ms] (passed)',
+    ' ✓ [web] features/a.feature > Second Scenario [30ms] (passed)',
   ])
   expect(progressiveLines).toContain(' Test results    6 passed (6)')
 })
@@ -188,7 +189,7 @@ test('keeps schedule and completion callbacks out of NDJSON output', () => {
   reporter.complete?.(run.result)
   expect(lines).toEqual([])
 
-  reporter.finish([run], 10)
+  finishReporter(reporter, [run], 10)
   expect(lines).toHaveLength(1)
   expect(JSON.parse(lines[0]!)).toEqual({
     kind: 'test-result',
@@ -226,7 +227,7 @@ test('streams human output as each Test result completes', () => {
   reporter.complete?.(run.result)
   expect(lines.join('\n')).toContain('features/a.feature > Scenario A [10ms]')
 
-  reporter.finish([run], 10)
+  finishReporter(reporter, [run], 10)
   expect(
     lines.filter((line) => line.includes('features/a.feature')),
   ).toHaveLength(1)
@@ -262,14 +263,58 @@ test('uses a visible failure symbol with color only as supplemental information'
   })
 
   colorReporter.start()
-  colorReporter.finish([run], 150)
+  finishReporter(colorReporter, [run], 150)
   plainReporter.start()
-  plainReporter.finish([run], 150)
+  finishReporter(plainReporter, [run], 150)
 
   expect(colorLines.join('\n')).toContain('\u001b[31m×\u001b[39m')
   expect(plainLines.join('\n')).not.toContain('\u001b[')
   expect(plainLines.join('\n')).toContain(
     '× src/google.feature > Visit main page [150ms] (failed)',
+  )
+})
+
+test('gives flaky metadata its own readable symbol and supplemental color', () => {
+  const run = passedRun({
+    specificationUri: 'src/google.feature',
+    specificationName: 'Search',
+    scenarioId: 'scenario-visit',
+    scenarioName: 'Visit main page',
+    profileId: 'web',
+    durationMs: 150,
+  })
+  run.result.flaky = true
+  run.result.attempts = 2
+  const colorLines: string[] = []
+  const plainLines: string[] = []
+  const sharedOptions = {
+    projectRoot: '/workspace/project',
+    version: '1.0.2',
+    columns: 120,
+    now: () => new Date(2026, 7, 20, 14, 32, 7),
+  }
+  const colorReporter = createRunReporter('default', {
+    ...sharedOptions,
+    color: true,
+    write: (line) => colorLines.push(line),
+  })
+  const plainReporter = createRunReporter('default', {
+    ...sharedOptions,
+    color: false,
+    write: (line) => plainLines.push(line),
+  })
+
+  colorReporter.start()
+  finishReporter(colorReporter, [run], 150)
+  plainReporter.start()
+  finishReporter(plainReporter, [run], 150)
+
+  expect(colorLines.join('\n')).toContain(
+    '\u001b[32m✓\u001b[39m\u001b[36m↻\u001b[39m src/google.feature > Visit main page [150ms] (passed; flaky, 2 attempts)',
+  )
+  expect(plainLines.join('\n')).not.toContain('\u001b[')
+  expect(plainLines.join('\n')).toContain(
+    '✓↻ src/google.feature > Visit main page [150ms] (passed; flaky, 2 attempts)',
   )
 })
 
@@ -288,7 +333,8 @@ test('wraps long paths and Scenario names without truncating them', () => {
   })
 
   reporter.start()
-  reporter.finish(
+  finishReporter(
+    reporter,
     [
       passedRun({
         specificationUri,
@@ -329,7 +375,8 @@ test('wraps non-BMP Unicode names without corrupting their characters', () => {
   })
 
   reporter.start()
-  reporter.finish(
+  finishReporter(
+    reporter,
     [
       passedRun({
         specificationUri: 'a.feature',
@@ -383,29 +430,48 @@ test('counts Test result states as mutually exclusive summary outcomes', () => {
       specificationName: 'Search',
       scenarioId: `scenario-${index}`,
       scenarioName: `Scenario ${index}`,
-      profileId: 'web',
+      profileId: index % 2 === 0 ? 'web' : 'android',
       durationMs: 150,
     })
-    return { ...run, result: { ...run.result, state } }
+    return {
+      ...run,
+      result: {
+        ...run.result,
+        state,
+        ...(state === 'skipped'
+          ? { message: 'Scenario is tagged @ignore' }
+          : {}),
+        ...(state === 'passed' || state === 'passed-with-adaptation'
+          ? { flaky: true, attempts: index + 2 }
+          : {}),
+      },
+    }
   })
 
   reporter.start()
-  reporter.finish(runs, 150)
+  finishReporter(reporter, runs, 150)
 
   expect(lines).toContain(
     ' Test results    1 failed | 1 infrastructure error | 1 adapted | 1 passed | 1 skipped | 1 cancelled (6)',
   )
+  expect(lines).toContain(' Flaky results   2')
   expect(lines.join('\n')).toContain(
-    '× src/google.feature > Scenario 2 [150ms] (failed)',
+    '~↻ [android] src/google.feature > Scenario 1 [150ms] (adapted; flaky, 3 attempts)',
   )
   expect(lines.join('\n')).toContain(
-    '! src/google.feature > Scenario 3 [150ms] (infrastructure error)',
+    '✓↻ [web] src/google.feature > Scenario 0 [150ms] (passed; flaky, 2 attempts)',
   )
   expect(lines.join('\n')).toContain(
-    '↓ src/google.feature > Scenario 4 [150ms] (skipped)',
+    '× [web] src/google.feature > Scenario 2 [150ms] (failed)',
   )
   expect(lines.join('\n')).toContain(
-    '○ src/google.feature > Scenario 5 [150ms] (cancelled)',
+    '! [android] src/google.feature > Scenario 3 [150ms] (infrastructure error)',
+  )
+  expect(lines.join('\n')).toContain(
+    '↓ [web] src/google.feature > Scenario 4 [150ms] (skipped: Scenario is tagged @ignore)',
+  )
+  expect(lines.join('\n')).toContain(
+    '○ [android] src/google.feature > Scenario 5 [150ms] (cancelled)',
   )
 })
 
@@ -455,7 +521,7 @@ test('preserves result-level failure messages when no executed step owns them', 
     'Expected results, but the page remained empty\nScreenshot captured'
 
   reporter.start()
-  reporter.finish([run], 150)
+  finishReporter(reporter, [run], 150)
 
   expect(lines.join('\n')).toContain(
     '   Message\n' +
@@ -508,7 +574,7 @@ test('renders functional failure diagnostics from executed Gherkin steps without
   ]
 
   reporter.start()
-  reporter.finish([run], 150)
+  finishReporter(reporter, [run], 150)
 
   const output = lines.join('\n')
   expect(output).toContain(` Failures
@@ -609,7 +675,7 @@ test('separates infrastructure diagnostics and renders profiles, messages, and a
   ]
 
   reporter.start()
-  reporter.finish([infrastructureRun, failedRun], 390)
+  finishReporter(reporter, [infrastructureRun, failedRun], 390)
 
   const output = lines.join('\n')
   expect(output).toContain(` Failures

--- a/packages/cli/src/run-reporter.ts
+++ b/packages/cli/src/run-reporter.ts
@@ -9,6 +9,7 @@ import {
   clockLabel,
   diagnosticLines,
   groupResults,
+  policyLines,
   renderTestResult,
   summaryLines,
   type WriteLine,
@@ -24,6 +25,7 @@ import {
   createProcessTerminalSurface,
   type InteractiveTerminalSurface,
 } from './terminal-surface'
+import type { TestRunExitStatus } from './test-run-exit-status'
 
 export type RunReporterName = 'default' | 'ndjson'
 
@@ -34,7 +36,11 @@ export interface RunReporter {
   complete?(result: TestResult): void
   fail?(error: unknown, durationMs: number): void
   refresh?(): void
-  finish(runs: readonly ScenarioRun[], durationMs: number): void
+  finish(
+    runs: readonly ScenarioRun[],
+    durationMs: number,
+    exitStatus: TestRunExitStatus,
+  ): void
 }
 
 type RunReporterOptions = {
@@ -106,7 +112,7 @@ function createBufferedRunReporter(options: RunReporterOptions): RunReporter {
     prepare,
     event() {},
     complete,
-    finish(runs, durationMs) {
+    finish(runs, durationMs, exitStatus) {
       const results = runs.map((run) => run.result)
       if (completedResults.length === 0) {
         prepare(orderedScheduleFromResults(results))
@@ -123,6 +129,7 @@ function createBufferedRunReporter(options: RunReporterOptions): RunReporter {
       })) {
         write(line)
       }
+      for (const line of policyLines(exitStatus, options.columns)) write(line)
       for (const line of summaryLines(
         specifications,
         results,

--- a/packages/cli/src/studio.test.ts
+++ b/packages/cli/src/studio.test.ts
@@ -36,7 +36,10 @@ type MonacoEditorHost = {
   }
 }
 
-async function saveExecutionTargetProfile(page: Page): Promise<void> {
+async function saveExecutionTargetProfile(
+  page: Page,
+  profileId: string,
+): Promise<void> {
   const responsePromise = page.waitForResponse(
     (response) =>
       new URL(response.url()).pathname === '/api/config' &&
@@ -50,6 +53,10 @@ async function saveExecutionTargetProfile(page: Page): Promise<void> {
   if (!response.ok()) {
     throw new Error(`Profile update failed with status ${response.status()}`)
   }
+  await page
+    .getByRole('status')
+    .filter({ hasText: `Execution target profile ${profileId} saved` })
+    .waitFor({ timeout: 10_000 })
 }
 
 describe('Studio browser seam', () => {
@@ -1106,10 +1113,10 @@ Feature: Checkout
       await page.getByRole('button', { name: 'Settings' }).click()
       await page.getByRole('button', { name: 'chrome' }).click()
       await page.getByLabel('Profile capabilities').fill('geolocation')
-      await saveExecutionTargetProfile(page)
+      await saveExecutionTargetProfile(page, 'chrome')
       await page.getByRole('button', { name: 'firefox' }).click()
       await page.getByLabel('Profile capabilities').fill('geolocation')
-      await saveExecutionTargetProfile(page)
+      await saveExecutionTargetProfile(page, 'firefox')
       await page.getByRole('button', { name: 'Specifications' }).click()
       await page.getByRole('button', { name: 'Run Specification' }).waitFor({
         timeout: 10_000,

--- a/packages/cli/src/studio.test.ts
+++ b/packages/cli/src/studio.test.ts
@@ -36,6 +36,22 @@ type MonacoEditorHost = {
   }
 }
 
+async function saveExecutionTargetProfile(page: Page): Promise<void> {
+  const responsePromise = page.waitForResponse(
+    (response) =>
+      new URL(response.url()).pathname === '/api/config' &&
+      response.request().method() === 'PUT',
+  )
+  await page
+    .getByRole('button', { name: 'Save execution target profile' })
+    .click()
+  const response = await responsePromise
+  await response.finished()
+  if (!response.ok()) {
+    throw new Error(`Profile update failed with status ${response.status()}`)
+  }
+}
+
 describe('Studio browser seam', () => {
   const fixture = new StudioBrowserFixture()
   const createStudioProject = fixture.createProject.bind(fixture)
@@ -254,6 +270,13 @@ Feature: Search
     const { child, url } = await startStudio(project)
     const page = await browser.newPage()
     try {
+      let historyRequestCount = 0
+      await page.route('**/api/history', async (route) => {
+        if (route.request().method() === 'GET' && historyRequestCount++ === 1) {
+          await Bun.sleep(100)
+        }
+        await route.continue()
+      })
       await page.goto(url)
       await page.getByRole('button', { name: 'Run Specification' }).click()
       await page
@@ -273,6 +296,7 @@ Feature: Search
       await page.getByRole('button', { name: 'History' }).click()
 
       const history = page.getByRole('table', { name: 'Test run history' })
+      await history.waitFor()
       expect(await history.getByRole('row').count()).toBe(2)
       const run = history.getByRole('row').nth(1)
       expect(await run.textContent()).toContain('Ad hoc selection')
@@ -1061,6 +1085,13 @@ Feature: Checkout
     const { child, url } = await startStudio(project)
     const page = await browser.newPage()
     try {
+      let configUpdateCount = 0
+      await page.route('**/api/config', async (route) => {
+        if (route.request().method() === 'PUT' && configUpdateCount++ === 0) {
+          await Bun.sleep(500)
+        }
+        await route.continue()
+      })
       await page.goto(url)
       await page.getByRole('heading', { name: 'Checkout' }).waitFor()
       expect(
@@ -1075,14 +1106,10 @@ Feature: Checkout
       await page.getByRole('button', { name: 'Settings' }).click()
       await page.getByRole('button', { name: 'chrome' }).click()
       await page.getByLabel('Profile capabilities').fill('geolocation')
-      await page
-        .getByRole('button', { name: 'Save execution target profile' })
-        .click()
+      await saveExecutionTargetProfile(page)
       await page.getByRole('button', { name: 'firefox' }).click()
       await page.getByLabel('Profile capabilities').fill('geolocation')
-      await page
-        .getByRole('button', { name: 'Save execution target profile' })
-        .click()
+      await saveExecutionTargetProfile(page)
       await page.getByRole('button', { name: 'Specifications' }).click()
       await page.getByRole('button', { name: 'Run Specification' }).waitFor({
         timeout: 10_000,

--- a/packages/cli/src/test-run-exit-status.ts
+++ b/packages/cli/src/test-run-exit-status.ts
@@ -1,0 +1,31 @@
+import type { TestResult } from '@pickle-spec/runner'
+import type { ProjectPolicy } from './config'
+
+type AdaptedResultsPolicy = NonNullable<ProjectPolicy['adaptedResults']>
+
+export type TestRunExitStatus = {
+  exitCode: 0 | 1 | 130
+  rejectedAdaptedResults: number
+}
+
+export function evaluateTestRunExitStatus(
+  results: readonly TestResult[],
+  adaptedResultsPolicy: AdaptedResultsPolicy = 'accept',
+): TestRunExitStatus {
+  const states = results.map((result) => result.state)
+  const rejectedAdaptedResults =
+    adaptedResultsPolicy === 'reject'
+      ? states.filter((state) => state === 'passed-with-adaptation').length
+      : 0
+
+  if (rejectedAdaptedResults > 0) {
+    return { exitCode: 1, rejectedAdaptedResults }
+  }
+  if (states.includes('cancelled')) {
+    return { exitCode: 130, rejectedAdaptedResults }
+  }
+  if (states.includes('failed') || states.includes('infrastructure-error')) {
+    return { exitCode: 1, rejectedAdaptedResults }
+  }
+  return { exitCode: 0, rejectedAdaptedResults }
+}

--- a/packages/cli/src/workspace.test.ts
+++ b/packages/cli/src/workspace.test.ts
@@ -18,6 +18,11 @@ describe('public CLI workspace seam', () => {
     specifications: 'features/**/*.feature',
     web: { baseUrl: 'https://example.com' },
   }
+  const deterministicRunConfig = {
+    schemaVersion: 1,
+    specifications: 'features/**/*.feature',
+    executionTargetProfile: { id: 'deterministic' },
+  }
   const validSpecification = {
     path: 'features/example.feature',
     source: `@pickle:id:specaaaaaaaaaaaa @pickle:state:active
@@ -54,6 +59,14 @@ Feature: Example
       cmd: [pickleCommand, 'check'],
       cwd: project,
       env: { ...Bun.env },
+    })
+  }
+
+  function runProject(project: string, env: Record<string, string> = {}) {
+    return Bun.spawnSync({
+      cmd: [pickleCommand, 'run'],
+      cwd: project,
+      env: { ...Bun.env, ...env },
     })
   }
 
@@ -699,19 +712,15 @@ Feature: Checkout
     ).text()
     const project = await createCheckProject('adaptation-policy-output', {
       config: {
-        schemaVersion: 1,
-        specifications: 'features/**/*.feature',
-        executionTargetProfile: { id: 'deterministic' },
+        ...deterministicRunConfig,
         policy: { adaptedResults: 'accept' },
       },
       specification: validSpecification,
       extensions,
     })
     const runAdapted = () =>
-      Bun.spawnSync({
-        cmd: [pickleCommand, 'run'],
-        cwd: project,
-        env: { ...Bun.env, PICKLE_TEST_OUTCOME: 'passed-with-adaptation' },
+      runProject(project, {
+        PICKLE_TEST_OUTCOME: 'passed-with-adaptation',
       })
 
     const accepted = runAdapted()
@@ -729,9 +738,7 @@ Feature: Checkout
     await Bun.write(
       join(project, 'pickle.config.jsonc'),
       JSON.stringify({
-        schemaVersion: 1,
-        specifications: 'features/**/*.feature',
-        executionTargetProfile: { id: 'deterministic' },
+        ...deterministicRunConfig,
         policy: { adaptedResults: 'reject' },
       }),
     )
@@ -766,13 +773,8 @@ Feature: Checkout
         policy: { adaptedResults: 'reject' },
       }),
     )
-    const rejectedWithCancellation = Bun.spawnSync({
-      cmd: [pickleCommand, 'run'],
-      cwd: project,
-      env: {
-        ...Bun.env,
-        PICKLE_TEST_OUTCOMES: 'passed-with-adaptation,cancelled',
-      },
+    const rejectedWithCancellation = runProject(project, {
+      PICKLE_TEST_OUTCOMES: 'passed-with-adaptation,cancelled',
     })
     const mixedOutput = rejectedWithCancellation.stdout.toString()
 
@@ -791,19 +793,15 @@ Feature: Checkout
     ).text()
     const flakyProject = await createCheckProject('flaky-result-output', {
       config: {
-        schemaVersion: 1,
-        specifications: 'features/**/*.feature',
-        executionTargetProfile: { id: 'deterministic' },
+        ...deterministicRunConfig,
         execution: { functionalRetries: 1 },
       },
       specification: validSpecification,
       extensions,
     })
 
-    const flaky = Bun.spawnSync({
-      cmd: [pickleCommand, 'run'],
-      cwd: flakyProject,
-      env: { ...Bun.env, PICKLE_TEST_OUTCOMES: 'failed,passed' },
+    const flaky = runProject(flakyProject, {
+      PICKLE_TEST_OUTCOMES: 'failed,passed',
     })
     const flakyOutput = flaky.stdout.toString()
 
@@ -817,11 +815,7 @@ Feature: Checkout
     expect(flakyOutput).toContain(' Flaky results   1')
 
     const skippedProject = await createCheckProject('skipped-result-output', {
-      config: {
-        schemaVersion: 1,
-        specifications: 'features/**/*.feature',
-        executionTargetProfile: { id: 'deterministic' },
-      },
+      config: deterministicRunConfig,
       specification: {
         path: 'features/ignored.feature',
         source: `@pickle:id:specignoredaaaaaa @pickle:state:active
@@ -833,11 +827,7 @@ Feature: Ignored
       extensions,
     })
 
-    const skipped = Bun.spawnSync({
-      cmd: [pickleCommand, 'run'],
-      cwd: skippedProject,
-      env: { ...Bun.env },
-    })
+    const skipped = runProject(skippedProject)
     const skippedOutput = skipped.stdout.toString()
 
     expect(skipped.exitCode).toBe(0)
@@ -852,20 +842,14 @@ Feature: Ignored
     const cancelledProject = await createCheckProject(
       'cancelled-result-output',
       {
-        config: {
-          schemaVersion: 1,
-          specifications: 'features/**/*.feature',
-          executionTargetProfile: { id: 'deterministic' },
-        },
+        config: deterministicRunConfig,
         specification: validSpecification,
         extensions,
       },
     )
 
-    const cancelled = Bun.spawnSync({
-      cmd: [pickleCommand, 'run'],
-      cwd: cancelledProject,
-      env: { ...Bun.env, PICKLE_TEST_OUTCOME: 'cancelled' },
+    const cancelled = runProject(cancelledProject, {
+      PICKLE_TEST_OUTCOME: 'cancelled',
     })
     const cancelledOutput = cancelled.stdout.toString()
 

--- a/packages/cli/src/workspace.test.ts
+++ b/packages/cli/src/workspace.test.ts
@@ -90,45 +90,54 @@ Feature: Purchase
     await Bun.write(
       join(workspace, 'pickle.extensions.ts'),
       `
-const state = process.env.PICKLE_TEST_OUTCOME ?? 'passed'
+const states = (
+  process.env.PICKLE_TEST_OUTCOMES ??
+  process.env.PICKLE_TEST_OUTCOME ??
+  'passed'
+).split(',')
+let attempt = 0
+
+const adapter = {
+  async openSession() {
+    const state = states[attempt++] ?? states.at(-1) ?? 'passed'
+    return {
+      async executeStep(step, signal) {
+        if (process.env.PICKLE_TEST_STEP_MARKER) {
+          await Bun.write(process.env.PICKLE_TEST_STEP_MARKER, 'started')
+        }
+        if (process.env.PICKLE_TEST_WAIT_FOR_ABORT === 'true') {
+          await new Promise((resolve, reject) => {
+            const onAbort = () => {
+              signal?.removeEventListener('abort', onAbort)
+              reject(new DOMException('Scenario cancelled', 'AbortError'))
+            }
+            signal?.addEventListener('abort', onAbort, { once: true })
+          })
+        }
+        const message = process.env.PICKLE_TEST_MESSAGE
+        const artifactPath = process.env.PICKLE_TEST_ARTIFACT
+        const artifacts = artifactPath
+          ? [{ kind: 'trace', path: artifactPath, mediaType: 'text/plain' }]
+          : undefined
+        return {
+          state,
+          resolvedActions: [{ description: \`Deterministic action: \${step.text}\` }],
+          message,
+          artifacts,
+        }
+      },
+      async close() {
+        if (process.env.PICKLE_TEST_CLOSE_MARKER) {
+          await Bun.write(process.env.PICKLE_TEST_CLOSE_MARKER, 'closed')
+        }
+      },
+    }
+  },
+}
 
 export default {
-  adapter: {
-    async openSession() {
-      return {
-        async executeStep(step, signal) {
-          if (process.env.PICKLE_TEST_STEP_MARKER) {
-            await Bun.write(process.env.PICKLE_TEST_STEP_MARKER, 'started')
-          }
-          if (process.env.PICKLE_TEST_WAIT_FOR_ABORT === 'true') {
-            await new Promise((resolve, reject) => {
-              const onAbort = () => {
-                signal?.removeEventListener('abort', onAbort)
-                reject(new DOMException('Scenario cancelled', 'AbortError'))
-              }
-              signal?.addEventListener('abort', onAbort, { once: true })
-            })
-          }
-          const message = process.env.PICKLE_TEST_MESSAGE
-          const artifactPath = process.env.PICKLE_TEST_ARTIFACT
-          const artifacts = artifactPath
-            ? [{ kind: 'trace', path: artifactPath, mediaType: 'text/plain' }]
-            : undefined
-          return {
-            state,
-            resolvedActions: [{ description: \`Deterministic action: \${step.text}\` }],
-            message,
-            artifacts,
-          }
-        },
-        async close() {
-          if (process.env.PICKLE_TEST_CLOSE_MARKER) {
-            await Bun.write(process.env.PICKLE_TEST_CLOSE_MARKER, 'closed')
-          }
-        },
-      }
-    },
-  },
+  adapter,
+  adapters: { custom: adapter },
 }
 `,
     )
@@ -682,6 +691,192 @@ Feature: Checkout
         },
       })
     }
+  })
+
+  test('default run output preserves accepted adaptations and explains policy rejection', async () => {
+    const extensions = await Bun.file(
+      join(workspace, 'pickle.extensions.ts'),
+    ).text()
+    const project = await createCheckProject('adaptation-policy-output', {
+      config: {
+        schemaVersion: 1,
+        specifications: 'features/**/*.feature',
+        executionTargetProfile: { id: 'deterministic' },
+        policy: { adaptedResults: 'accept' },
+      },
+      specification: validSpecification,
+      extensions,
+    })
+    const runAdapted = () =>
+      Bun.spawnSync({
+        cmd: [pickleCommand, 'run'],
+        cwd: project,
+        env: { ...Bun.env, PICKLE_TEST_OUTCOME: 'passed-with-adaptation' },
+      })
+
+    const accepted = runAdapted()
+
+    expect(accepted.stderr.toString()).toBe('')
+    expect(accepted.exitCode).toBe(0)
+    expect(accepted.stdout.toString()).toContain(
+      '~ features/example.feature > Validate project',
+    )
+    expect(accepted.stdout.toString()).toContain('(adapted)')
+    expect(accepted.stdout.toString()).not.toContain(
+      'Adaptation policy rejected the Test run',
+    )
+
+    await Bun.write(
+      join(project, 'pickle.config.jsonc'),
+      JSON.stringify({
+        schemaVersion: 1,
+        specifications: 'features/**/*.feature',
+        executionTargetProfile: { id: 'deterministic' },
+        policy: { adaptedResults: 'reject' },
+      }),
+    )
+    const rejected = runAdapted()
+    const rejectedOutput = rejected.stdout.toString()
+
+    expect(rejected.exitCode).toBe(1)
+    expect(rejected.stderr.toString()).toBe('')
+    expect(rejectedOutput).toContain(
+      '~ features/example.feature > Validate project',
+    )
+    expect(rejectedOutput).toContain('(adapted)')
+    expect(rejectedOutput).toContain(
+      '! Adaptation policy rejected the Test run',
+    )
+    expect(rejectedOutput).toContain(
+      '1 adapted Test result passed, but policy.adaptedResults is set to reject.',
+    )
+    expect(rejectedOutput).toContain(
+      'The Test result remains adapted and pickle run exits with code 1.',
+    )
+
+    await Bun.write(
+      join(project, 'pickle.config.jsonc'),
+      JSON.stringify({
+        schemaVersion: 1,
+        specifications: 'features/**/*.feature',
+        executionTargetProfiles: {
+          web: { adapter: 'custom' },
+          android: { adapter: 'custom' },
+        },
+        policy: { adaptedResults: 'reject' },
+      }),
+    )
+    const rejectedWithCancellation = Bun.spawnSync({
+      cmd: [pickleCommand, 'run'],
+      cwd: project,
+      env: {
+        ...Bun.env,
+        PICKLE_TEST_OUTCOMES: 'passed-with-adaptation,cancelled',
+      },
+    })
+    const mixedOutput = rejectedWithCancellation.stdout.toString()
+
+    expect(rejectedWithCancellation.exitCode).toBe(1)
+    expect(rejectedWithCancellation.stderr.toString()).toBe('')
+    expect(mixedOutput).toContain('~ [web] features/example.feature')
+    expect(mixedOutput).toContain('○ [android] features/example.feature')
+    expect(mixedOutput).toContain(
+      'The Test result remains adapted and pickle run exits with code 1.',
+    )
+  })
+
+  test('default run output reports flaky, skipped, and cancelled results truthfully', async () => {
+    const extensions = await Bun.file(
+      join(workspace, 'pickle.extensions.ts'),
+    ).text()
+    const flakyProject = await createCheckProject('flaky-result-output', {
+      config: {
+        schemaVersion: 1,
+        specifications: 'features/**/*.feature',
+        executionTargetProfile: { id: 'deterministic' },
+        execution: { functionalRetries: 1 },
+      },
+      specification: validSpecification,
+      extensions,
+    })
+
+    const flaky = Bun.spawnSync({
+      cmd: [pickleCommand, 'run'],
+      cwd: flakyProject,
+      env: { ...Bun.env, PICKLE_TEST_OUTCOMES: 'failed,passed' },
+    })
+    const flakyOutput = flaky.stdout.toString()
+
+    expect(flaky.exitCode).toBe(0)
+    expect(flaky.stderr.toString()).toBe('')
+    expect(flakyOutput).toContain(
+      '✓↻ features/example.feature > Validate project',
+    )
+    expect(flakyOutput).toContain('(passed; flaky, 2 attempts)')
+    expect(flakyOutput).toContain(' Test results    1 passed (1)')
+    expect(flakyOutput).toContain(' Flaky results   1')
+
+    const skippedProject = await createCheckProject('skipped-result-output', {
+      config: {
+        schemaVersion: 1,
+        specifications: 'features/**/*.feature',
+        executionTargetProfile: { id: 'deterministic' },
+      },
+      specification: {
+        path: 'features/ignored.feature',
+        source: `@pickle:id:specignoredaaaaaa @pickle:state:active
+Feature: Ignored
+  @pickle:id:scnignoredbbbbbb @ignore
+  Scenario: Ignore this Scenario
+    Then validation succeeds`,
+      },
+      extensions,
+    })
+
+    const skipped = Bun.spawnSync({
+      cmd: [pickleCommand, 'run'],
+      cwd: skippedProject,
+      env: { ...Bun.env },
+    })
+    const skippedOutput = skipped.stdout.toString()
+
+    expect(skipped.exitCode).toBe(0)
+    expect(skipped.stderr.toString()).toBe('')
+    expect(skippedOutput).toContain(
+      '↓ features/ignored.feature > Ignore this Scenario',
+    )
+    expect(skippedOutput).toContain('(skipped: Scenario is tagged @ignore)')
+    expect(skippedOutput).not.toContain(' Failures')
+    expect(skippedOutput).not.toContain(' Infrastructure errors')
+
+    const cancelledProject = await createCheckProject(
+      'cancelled-result-output',
+      {
+        config: {
+          schemaVersion: 1,
+          specifications: 'features/**/*.feature',
+          executionTargetProfile: { id: 'deterministic' },
+        },
+        specification: validSpecification,
+        extensions,
+      },
+    )
+
+    const cancelled = Bun.spawnSync({
+      cmd: [pickleCommand, 'run'],
+      cwd: cancelledProject,
+      env: { ...Bun.env, PICKLE_TEST_OUTCOME: 'cancelled' },
+    })
+    const cancelledOutput = cancelled.stdout.toString()
+
+    expect(cancelled.exitCode).toBe(130)
+    expect(cancelled.stderr.toString()).toBe('')
+    expect(cancelledOutput).toContain(
+      '○ features/example.feature > Validate project',
+    )
+    expect(cancelledOutput).toContain('(cancelled)')
+    expect(cancelledOutput).not.toContain(' Failures')
+    expect(cancelledOutput).not.toContain(' Infrastructure errors')
   })
 
   test('default run output keeps actionable result diagnostics on stdout', async () => {

--- a/packages/studio/src/settings.tsx
+++ b/packages/studio/src/settings.tsx
@@ -95,6 +95,7 @@ export function SettingsPanel<
   const [capabilities, setCapabilities] = useState(
     (selectedProfile?.capabilities ?? []).join(', '),
   )
+  const [savedProfileId, setSavedProfileId] = useState<string>()
   const [secretName, setSecretName] = useState('')
   const [secretValue, setSecretValue] = useState('')
   const [git, setGit] = useState<GitStatus>()
@@ -205,6 +206,7 @@ export function SettingsPanel<
       props.onError('An execution target profile id is required')
       return
     }
+    setSavedProfileId(undefined)
     const profiles = Object.fromEntries(
       (props.project.profileDetails ?? []).map((profile) => [
         profile.id,
@@ -226,13 +228,13 @@ export function SettingsPanel<
     }
     props.onError(undefined)
     try {
-      props.onProject(
-        await props.api<T>('/api/config', {
-          method: 'PUT',
-          headers: { 'content-type': 'application/json' },
-          body: JSON.stringify({ executionTargetProfiles: profiles }),
-        }),
-      )
+      const project = await props.api<T>('/api/config', {
+        method: 'PUT',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ executionTargetProfiles: profiles }),
+      })
+      props.onProject(project)
+      setSavedProfileId(id)
     } catch (reason) {
       props.onError(reasonMessage(reason))
     }
@@ -449,6 +451,11 @@ export function SettingsPanel<
         <Button type="button" onClick={() => void saveProfiles()}>
           Save execution target profile
         </Button>
+        {savedProfileId ? (
+          <p role="status" className="text-sm text-muted-foreground">
+            Execution target profile {savedProfileId} saved.
+          </p>
+        ) : null}
       </section>
 
       <section className="space-y-3" aria-labelledby="credentials-heading">


### PR DESCRIPTION
## Summary

- Report CLI run outcomes consistently across live and final reporters
- Align process exit status with truthful result reporting
- Simplify workspace test setup for deterministic runs

Closes #54

## Testing

- Added and updated unit tests for run reporting, live reporting, exit status, and workspace behavior