### PR TITLE
Handle interrupted and invalid run outcomes

### DIFF
--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -5,9 +5,6 @@ import {
   compareTestRuns,
   defaultRetention,
   formatHtml,
-  formatJson,
-  formatJunit,
-  formatNdjson,
   importRunArchive,
   openTestRunStore,
   writeRunArchive,
@@ -21,6 +18,7 @@ import {
   type WebAdapterOptions,
 } from '@pickle-spec/web'
 import cliPackage from '../package.json' with { type: 'json' }
+import { errorMessage, withRecoveryFailure } from './command-error'
 import { defaultSpecificationGlob, loadConfig } from './config'
 import {
   loadExtensions,
@@ -29,11 +27,13 @@ import {
   startProjectRun,
 } from './execute-run'
 import { checkProject, initializeProject, migrateProject } from './project'
+import { finalizeMaterializedEvidence, writeRunOutputs } from './run-outputs'
 import {
   createRunReporter,
   type RunReporterName,
   terminalReporterCapabilities,
 } from './run-reporter'
+import { createRunReportingSession } from './run-reporting-session'
 import { createStudioHistoryGateway } from './studio-history'
 import { createStudioPlanGateway } from './studio-plans'
 import {
@@ -222,10 +222,11 @@ function parseRunArguments(argv: string[]): RunArguments {
 async function run(argv: string[]): Promise<number> {
   const args = parseRunArguments(argv)
   const config = await loadConfig(args.configPath)
+  const root = process.cwd()
   const controller = new AbortController()
   const onSigint = () => controller.abort()
   const reporter = createRunReporter(args.reporter ?? 'default', {
-    projectRoot: process.cwd(),
+    projectRoot: root,
     version: cliPackage.version,
     ...terminalReporterCapabilities(
       process.stdout.isTTY,
@@ -234,29 +235,29 @@ async function run(argv: string[]): Promise<number> {
       process.env.TERM,
     ),
   })
-  const onResize = () => reporter.refresh?.()
+  const reporting = createRunReportingSession(reporter)
+  const onResize = reporting.refresh
   const startedAt = performance.now()
+  let startedRunId: string | undefined
+  let outputsWritten = false
   process.on('SIGINT', onSigint)
   if (process.stdout.isTTY) process.on('SIGWINCH', onResize)
   try {
     const started = await startProjectRun({
-      root: process.cwd(),
+      root,
       config,
       options: args,
       signal: controller.signal,
-      onEvent: reporter.event,
-      onSchedule: reporter.prepare,
-      onResult: reporter.complete,
+      onEvent: reporting.event,
+      onSchedule: reporting.prepare,
+      onResult: reporting.complete,
     })
-    reporter.start()
+    startedRunId = started.id
+    reporting.start()
     const { runs, manifest } = await started.done
-    const store = openTestRunStore({ root: process.cwd() })
-    if (args.junitPath) await Bun.write(args.junitPath, formatJunit(manifest))
-    if (args.jsonPath) await Bun.write(args.jsonPath, formatJson(manifest))
-    if (args.ndjsonPath) {
-      const persisted = await store.open(started.id)
-      await Bun.write(args.ndjsonPath, formatNdjson(await persisted.events()))
-    }
+    const store = openTestRunStore({ root })
+    await writeRunOutputs(args, root, started.id, manifest)
+    outputsWritten = true
     await store.applyRetention({
       maxAgeMs: config.retention?.days
         ? config.retention.days * dayMs
@@ -267,12 +268,73 @@ async function run(argv: string[]): Promise<number> {
     const exitStatus = evaluateTestRunExitStatus(
       runs.map(({ result }) => result),
       config.policy?.adaptedResults,
+      { interrupted: controller.signal.aborted },
     )
-    reporter.finish(runs, performance.now() - startedAt, exitStatus)
+    reporting.finish(runs, performance.now() - startedAt, exitStatus)
+    const reporterFailure = reporting.failure()
+    if (reporterFailure) throw reporterFailure.error
     return exitStatus.exitCode
   } catch (error) {
-    reporter.fail?.(error, performance.now() - startedAt)
-    throw error
+    let commandError: unknown = error
+    if (
+      controller.signal.aborted &&
+      error instanceof Error &&
+      error.name === 'AbortError'
+    ) {
+      const exitStatus = evaluateTestRunExitStatus(
+        [],
+        config.policy?.adaptedResults,
+        { interrupted: true },
+      )
+      if (startedRunId && !outputsWritten) {
+        try {
+          await finalizeMaterializedEvidence(args, root, startedRunId, {
+            includeEmptyRun: true,
+          })
+          outputsWritten = true
+        } catch (recoveryError) {
+          commandError = withRecoveryFailure(
+            commandError,
+            'Failed to finalize interrupted evidence',
+            recoveryError,
+          )
+        }
+      }
+      reporting.finish([], performance.now() - startedAt, exitStatus)
+      const reporterFailure = reporting.failure()
+      if (reporterFailure) {
+        commandError = withRecoveryFailure(
+          commandError,
+          'Failed to render interrupted summary',
+          reporterFailure.error,
+        )
+      } else if (outputsWritten) {
+        return 130
+      }
+    }
+    if (startedRunId && !outputsWritten) {
+      try {
+        await finalizeMaterializedEvidence(args, root, startedRunId)
+      } catch (recoveryError) {
+        commandError = withRecoveryFailure(
+          commandError,
+          'Failed to finalize materialized evidence',
+          recoveryError,
+        )
+      }
+    }
+    const reporterRecoveryFailure = reporting.fail(
+      commandError,
+      performance.now() - startedAt,
+    )
+    if (reporterRecoveryFailure) {
+      commandError = withRecoveryFailure(
+        commandError,
+        'Failed to restore reporter output',
+        reporterRecoveryFailure.error,
+      )
+    }
+    throw commandError
   } finally {
     process.off('SIGINT', onSigint)
     process.off('SIGWINCH', onResize)
@@ -561,6 +623,6 @@ async function main(argv: string[]): Promise<number> {
 try {
   process.exitCode = await main(Bun.argv.slice(2))
 } catch (error) {
-  console.error(error instanceof Error ? error.message : String(error))
+  console.error(`ERROR ${errorMessage(error)}`)
   process.exitCode = 2
 }

--- a/packages/cli/src/command-error.ts
+++ b/packages/cli/src/command-error.ts
@@ -1,0 +1,14 @@
+export function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error)
+}
+
+export function withRecoveryFailure(
+  primaryError: unknown,
+  recovery: string,
+  recoveryError: unknown,
+): AggregateError {
+  return new AggregateError(
+    [primaryError, recoveryError],
+    `${errorMessage(primaryError)}\n${recovery}: ${errorMessage(recoveryError)}`,
+  )
+}

--- a/packages/cli/src/execute-run.ts
+++ b/packages/cli/src/execute-run.ts
@@ -459,10 +459,13 @@ export async function startProjectRun(
           includeTarget,
         }),
       )
-      server = await startServer({
-        ...input.config.server,
-        ...(args.reuseServer ? { reuseExisting: true } : {}),
-      })
+      server = await startServer(
+        {
+          ...input.config.server,
+          ...(args.reuseServer ? { reuseExisting: true } : {}),
+        },
+        { signal: input.signal },
+      )
       const onEvent = async (event: RunEvent) => {
         const persisted = await testRun.append(event)
         if (event.type === 'scenario-finished') {

--- a/packages/cli/src/live-run-reporter.test.ts
+++ b/packages/cli/src/live-run-reporter.test.ts
@@ -347,6 +347,7 @@ test('finishes live progress with a prominent adaptation-policy rejection', () =
   reporter.start()
   reporter.finish([run], 10, {
     exitCode: 1,
+    interrupted: false,
     rejectedAdaptedResults: 1,
   })
 

--- a/packages/cli/src/live-run-reporter.ts
+++ b/packages/cli/src/live-run-reporter.ts
@@ -3,10 +3,12 @@ import type {
   ScheduledTestResult,
   TestResult,
 } from '@pickle-spec/runner'
+import { withRecoveryFailure } from './command-error'
 import {
   clockLabel,
   diagnosticLines,
   groupResults,
+  interruptionLines,
   policyLines,
   renderTestResult,
   renderTestStepResult,
@@ -262,8 +264,8 @@ export function createLiveRunReporter(
     })
     const summary = summaryLines(specifications, results, startTime, durationMs)
     summary.splice(1, 0, ...summaryNotice)
-    terminal.finish([...diagnostics, ...resultPolicyLines, ...summary])
     finished = true
+    terminal.finish([...diagnostics, ...resultPolicyLines, ...summary])
   }
 
   function finishFailure(
@@ -285,12 +287,24 @@ export function createLiveRunReporter(
     )
   }
 
+  function finishWithoutOutput(): void {
+    if (finished) return
+    setPagedRefresh(false)
+    finished = true
+    terminal.finish([])
+  }
+
   function finishTestRun(
     results: readonly TestResult[],
     durationMs: number,
     exitStatus: TestRunExitStatus,
   ): void {
-    finishOutput(results, durationMs, [], policyLines(exitStatus, columns()))
+    finishOutput(
+      results,
+      durationMs,
+      interruptionLines(exitStatus, columns()),
+      policyLines(exitStatus, columns()),
+    )
   }
 
   function complete(result: TestResult): void {
@@ -365,7 +379,24 @@ export function createLiveRunReporter(
       const results = completedResults.flatMap((result) =>
         result ? [result] : [],
       )
-      finishFailure(results, durationMs, error)
+      if (results.length === 0) {
+        finishWithoutOutput()
+        return
+      }
+      try {
+        finishFailure(results, durationMs, error)
+      } catch (renderError) {
+        try {
+          finishWithoutOutput()
+        } catch (restoreError) {
+          throw withRecoveryFailure(
+            renderError,
+            'Failed to restore terminal output',
+            restoreError,
+          )
+        }
+        throw renderError
+      }
     },
     refresh: updateDynamicRegion,
     finish(runs, durationMs, exitStatus) {

--- a/packages/cli/src/run-live.test.ts
+++ b/packages/cli/src/run-live.test.ts
@@ -428,7 +428,7 @@ test('interrupts application server startup and exits with the cancellation code
       specifications: 'features/**/*.feature',
       executionTargetProfile: { id: 'deterministic' },
       server: {
-        command: `bun -e "await Bun.write('${marker}', 'started'); setInterval(() => {}, 1000)"`,
+        command: `bun -e "await Bun.write('${marker}', 'started'); setInterval(() => {}, 1000)" & wait`,
         url: 'http://127.0.0.1:1',
         startupTimeoutMs: 10_000,
         pollIntervalMs: 5_000,

--- a/packages/cli/src/run-live.test.ts
+++ b/packages/cli/src/run-live.test.ts
@@ -10,6 +10,37 @@ type PackageManifest = {
   bin: { pickle: string }
 }
 
+type InteractiveRunOptions = {
+  cmd: string[]
+  cwd: string
+  env: Record<string, string | undefined>
+}
+
+function spawnInteractiveRun(options: InteractiveRunOptions) {
+  const output: string[] = []
+  const decoder = new TextDecoder()
+  const child = Bun.spawn({
+    ...options,
+    terminal: {
+      cols: 80,
+      rows: 24,
+      data(_terminal, data) {
+        output.push(decoder.decode(data, { stream: true }))
+      },
+    },
+  })
+  return {
+    child,
+    output,
+    async finish() {
+      const exitCode = await child.exited
+      output.push(decoder.decode())
+      child.terminal?.close()
+      return { exitCode, output: output.join('') }
+    },
+  }
+}
+
 async function waitForFile(path: string): Promise<void> {
   const deadline = Date.now() + 5_000
   while (!(await Bun.file(path).exists())) {
@@ -100,9 +131,7 @@ Feature: Streaming Specification
     Then second`,
   )
 
-  const output: string[] = []
-  const decoder = new TextDecoder()
-  const child = Bun.spawn({
+  const interactiveRun = spawnInteractiveRun({
     cmd: [pickleCommand, 'run'],
     cwd: project,
     env: {
@@ -111,14 +140,8 @@ Feature: Streaming Specification
       PICKLE_TEST_GATE_DIRECTORY: gates,
       TERM: 'xterm-256color',
     },
-    terminal: {
-      cols: 80,
-      rows: 24,
-      data(_terminal, data) {
-        output.push(decoder.decode(data, { stream: true }))
-      },
-    },
   })
+  const { child, output } = interactiveRun
 
   await Promise.race([
     Promise.all([
@@ -147,14 +170,323 @@ Feature: Streaming Specification
   expect(liveOutput).not.toContain('First result appears last [')
 
   await Bun.write(join(gates, 'first.release'), '')
-  const exitCode = await child.exited
-  output.push(decoder.decode())
-  child.terminal?.close()
-  const finalOutput = output.join('')
+  const { exitCode, output: finalOutput } = await interactiveRun.finish()
 
   expect(exitCode).toBe(0)
   expect(finalOutput).toContain('First result appears last [')
   expect(finalOutput.split(' Specifications  1')).toHaveLength(2)
   expect(finalOutput.split(' Test results    2 passed (2)')).toHaveLength(2)
   expect(finalOutput).not.toContain('\u001b[32m')
+}, 15_000)
+
+test('finishes an interrupted interactive run with partial persisted and exported evidence', async () => {
+  const project = join(workspace, 'interrupted-run')
+  const gates = join(project, 'gates')
+  const jsonPath = join(project, 'interrupted.json')
+  const ndjsonPath = join(project, 'interrupted.ndjson')
+  await mkdir(join(project, 'features'), { recursive: true })
+  await mkdir(gates, { recursive: true })
+  await Bun.write(
+    join(project, 'pickle.config.jsonc'),
+    JSON.stringify({
+      schemaVersion: 1,
+      specifications: 'features/**/*.feature',
+      executionTargetProfile: { id: 'deterministic' },
+      concurrency: 2,
+    }),
+  )
+  await Bun.write(
+    join(project, 'pickle.extensions.ts'),
+    `
+const gateDirectory = process.env.PICKLE_TEST_GATE_DIRECTORY
+
+export default {
+  adapter: {
+    async openSession() {
+      return {
+        async executeStep(step, signal) {
+          await Bun.write(\`\${gateDirectory}/\${step.text}.started\`, '')
+          while (!(await Bun.file(\`\${gateDirectory}/\${step.text}.release\`).exists())) {
+            if (signal?.aborted) throw new DOMException('Scenario cancelled', 'AbortError')
+            await Bun.sleep(5)
+          }
+          return { state: 'passed', resolvedActions: [] }
+        },
+        async close() {},
+      }
+    },
+  },
+}
+`,
+  )
+  await Bun.write(
+    join(project, 'features', 'interrupt.feature'),
+    `@pickle:id:specinterruptaaa @pickle:state:active
+Feature: Interrupt safely
+  @pickle:id:scncompletedaaaa
+  Scenario: Completed before interruption
+    Then completed
+
+  @pickle:id:scncancelledaaaa
+  Scenario: Cancelled by interruption
+    Then cancelled`,
+  )
+
+  const interactiveRun = spawnInteractiveRun({
+    cmd: [pickleCommand, 'run', '--json', jsonPath, '--ndjson', ndjsonPath],
+    cwd: project,
+    env: {
+      ...Bun.env,
+      NO_COLOR: '1',
+      PICKLE_TEST_GATE_DIRECTORY: gates,
+      TERM: 'xterm-256color',
+    },
+  })
+  const { child, output } = interactiveRun
+
+  await Promise.all([
+    waitForFile(join(gates, 'completed.started')),
+    waitForFile(join(gates, 'cancelled.started')),
+  ])
+  await Bun.write(join(gates, 'completed.release'), '')
+  await waitForOutput(output, 'Completed before interruption [')
+  child.kill('SIGINT')
+
+  const { exitCode, output: finalOutput } = await interactiveRun.finish()
+
+  expect(exitCode).toBe(130)
+  expect(finalOutput).toContain('Run interrupted')
+  expect(finalOutput).toContain('Partial summary')
+  expect(finalOutput).toContain('1 passed | 1 cancelled (2)')
+
+  const manifestPaths = [
+    ...new Bun.Glob('*/manifest.json').scanSync({
+      cwd: join(project, '.pickle', 'runs'),
+    }),
+  ]
+  expect(manifestPaths).toHaveLength(1)
+  const persistedManifest = await Bun.file(
+    join(project, '.pickle', 'runs', manifestPaths[0]!),
+  ).json()
+  const exportedManifest = await Bun.file(jsonPath).json()
+  expect(exportedManifest).toEqual(persistedManifest)
+  expect(
+    persistedManifest.results.map((result: { state: string }) => result.state),
+  ).toEqual(['passed', 'cancelled'])
+  expect(persistedManifest.finishedAt).toBeString()
+
+  const exportedEvents = (await Bun.file(ndjsonPath).text())
+    .trim()
+    .split('\n')
+    .map((line) => JSON.parse(line))
+  expect(
+    exportedEvents
+      .filter((event) => event.type === 'scenario-finished')
+      .map((event) => event.result.state),
+  ).toEqual(['passed', 'cancelled'])
+}, 15_000)
+
+test('restores an interactive terminal before reporting a zero-selection command error', async () => {
+  const project = join(workspace, 'zero-selection')
+  await mkdir(join(project, 'features'), { recursive: true })
+  await Bun.write(
+    join(project, 'pickle.config.jsonc'),
+    JSON.stringify({
+      schemaVersion: 1,
+      specifications: 'features/**/*.feature',
+      executionTargetProfile: { id: 'deterministic' },
+    }),
+  )
+  await Bun.write(
+    join(project, 'pickle.extensions.ts'),
+    `export default {
+  adapter: {
+    async openSession() { throw new Error('must not start') },
+  },
+}`,
+  )
+  await Bun.write(
+    join(project, 'features', 'selection.feature'),
+    `@pickle:id:specselectionaaa @pickle:state:active
+Feature: Selection
+  @pickle:id:scnselectionaaaa
+  Scenario: Existing Scenario
+    Then validation succeeds`,
+  )
+
+  const interactiveRun = spawnInteractiveRun({
+    cmd: [pickleCommand, 'run', '--scenario', 'Missing Scenario'],
+    cwd: project,
+    env: { ...Bun.env, NO_COLOR: '1', TERM: 'xterm-256color' },
+  })
+
+  const { exitCode, output: finalOutput } = await interactiveRun.finish()
+  const restoredTerminal = '\u001b[0m\u001b[?25h'
+
+  expect(exitCode).toBe(2)
+  expect(finalOutput).toContain(
+    'ERROR No Scenarios match the current selection',
+  )
+  expect(finalOutput).not.toContain('Run failed')
+  expect(finalOutput).not.toContain('Specifications  ')
+  expect(finalOutput).not.toContain('Test results    ')
+  expect(finalOutput.indexOf(restoredTerminal)).toBeLessThan(
+    finalOutput.indexOf('ERROR '),
+  )
+  expect(finalOutput.split(restoredTerminal)).toHaveLength(2)
+  expect(finalOutput.match(/ERROR /g)).toHaveLength(1)
+}, 15_000)
+
+test('preserves materialized evidence and restores the terminal when rendering throws', async () => {
+  const project = join(workspace, 'reporter-failure')
+  const jsonPath = join(project, 'reporter-failure.json')
+  const ndjsonPath = join(project, 'reporter-failure.ndjson')
+  await mkdir(join(project, 'features'), { recursive: true })
+  await Bun.write(
+    join(project, 'pickle.config.jsonc'),
+    JSON.stringify({
+      schemaVersion: 1,
+      specifications: 'features/**/*.feature',
+      executionTargetProfile: { id: 'deterministic' },
+      concurrency: 2,
+    }),
+  )
+  await Bun.write(
+    join(project, 'pickle.extensions.ts'),
+    `Bun.stringWidth = () => { throw new Error('Reporter rendering failed') }
+
+export default {
+  adapter: {
+    async openSession() {
+      return {
+        async executeStep() {
+          return { state: 'passed', resolvedActions: [] }
+        },
+        async close() {},
+      }
+    },
+  },
+}`,
+  )
+  await Bun.write(
+    join(project, 'features', 'reporter.feature'),
+    `@pickle:id:specreporteraaaaa @pickle:state:active
+Feature: Reporter failure
+  @pickle:id:scnreporteraaaaaa
+  Scenario: Preserve completed evidence
+    Then rendering fails after completion
+
+  @pickle:id:scnreporterbbbbbb
+  Scenario: Preserve concurrent evidence
+    Then concurrent rendering also completes`,
+  )
+
+  const interactiveRun = spawnInteractiveRun({
+    cmd: [pickleCommand, 'run', '--json', jsonPath, '--ndjson', ndjsonPath],
+    cwd: project,
+    env: { ...Bun.env, NO_COLOR: '1', TERM: 'xterm-256color' },
+  })
+
+  const { exitCode, output: finalOutput } = await interactiveRun.finish()
+  const restoredTerminal = '\u001b[0m\u001b[?25h'
+
+  expect(exitCode).toBe(2)
+  expect(finalOutput).toContain('ERROR Reporter rendering failed')
+  expect(finalOutput.indexOf(restoredTerminal)).toBeLessThan(
+    finalOutput.indexOf('ERROR '),
+  )
+  expect(finalOutput.split(restoredTerminal)).toHaveLength(2)
+  expect(finalOutput.match(/ERROR /g)).toHaveLength(1)
+  expect(finalOutput).not.toContain('Test results    ')
+
+  const exportedManifest = await Bun.file(jsonPath).json()
+  expect(
+    exportedManifest.results.map((result: { state: string }) => result.state),
+  ).toEqual(['passed', 'passed'])
+  const exportedEvents = (await Bun.file(ndjsonPath).text())
+    .trim()
+    .split('\n')
+    .map((line) => JSON.parse(line))
+  expect(
+    exportedEvents
+      .filter((event) => event.type === 'scenario-finished')
+      .map((event) => event.result.state),
+  ).toEqual(['passed', 'passed'])
+}, 15_000)
+
+test('interrupts application server startup and exits with the cancellation code', async () => {
+  const project = join(workspace, 'interrupt-server-startup')
+  const marker = join(project, 'server-started')
+  const jsonPath = join(project, 'startup-interrupted.json')
+  const junitPath = join(project, 'startup-interrupted.xml')
+  const ndjsonPath = join(project, 'startup-interrupted.ndjson')
+  await mkdir(join(project, 'features'), { recursive: true })
+  await Bun.write(
+    join(project, 'pickle.config.jsonc'),
+    JSON.stringify({
+      schemaVersion: 1,
+      specifications: 'features/**/*.feature',
+      executionTargetProfile: { id: 'deterministic' },
+      server: {
+        command: `bun -e "await Bun.write('${marker}', 'started'); setInterval(() => {}, 1000)"`,
+        url: 'http://127.0.0.1:1',
+        startupTimeoutMs: 10_000,
+        pollIntervalMs: 5_000,
+      },
+    }),
+  )
+  await Bun.write(
+    join(project, 'pickle.extensions.ts'),
+    `export default {
+  adapter: {
+    async openSession() { throw new Error('must not start') },
+  },
+}`,
+  )
+  await Bun.write(
+    join(project, 'features', 'startup.feature'),
+    `@pickle:id:specstartupaaaaa @pickle:state:active
+Feature: Startup interruption
+  @pickle:id:scnstartupaaaaaa
+  Scenario: Stop before execution
+    Then execution never starts`,
+  )
+
+  const interactiveRun = spawnInteractiveRun({
+    cmd: [
+      pickleCommand,
+      'run',
+      '--json',
+      jsonPath,
+      '--junit',
+      junitPath,
+      '--ndjson',
+      ndjsonPath,
+    ],
+    cwd: project,
+    env: { ...Bun.env, NO_COLOR: '1', TERM: 'xterm-256color' },
+  })
+  const { child } = interactiveRun
+
+  await waitForFile(marker)
+  const interruptedAt = Date.now()
+  child.kill('SIGINT')
+  const { exitCode, output: finalOutput } = await interactiveRun.finish()
+
+  expect(exitCode).toBe(130)
+  expect(Date.now() - interruptedAt).toBeLessThan(1_000)
+  expect(finalOutput).toContain('Run interrupted')
+  expect(finalOutput).toContain('Partial summary')
+  expect(finalOutput).not.toContain('ERROR Server failed to start')
+  expect(finalOutput.indexOf('\u001b[0m\u001b[?25h')).toBeGreaterThan(-1)
+
+  const exportedManifest = await Bun.file(jsonPath).json()
+  expect(exportedManifest.results).toEqual([])
+  expect(exportedManifest.finishedAt).toBeString()
+  expect(await Bun.file(junitPath).text()).toContain('tests="0"')
+  const exportedEvents = (await Bun.file(ndjsonPath).text())
+    .trim()
+    .split('\n')
+    .map((line) => JSON.parse(line))
+  expect(exportedEvents.map((event) => event.type)).toEqual(['run-started'])
 }, 15_000)

--- a/packages/cli/src/run-outputs.ts
+++ b/packages/cli/src/run-outputs.ts
@@ -1,0 +1,51 @@
+import {
+  formatJson,
+  formatJunit,
+  formatNdjson,
+  openTestRunStore,
+  type TestRunManifest,
+} from '@pickle-spec/runner'
+
+export interface RunOutputOptions {
+  junitPath?: string
+  jsonPath?: string
+  ndjsonPath?: string
+}
+
+type FinalizeEvidenceOptions = {
+  includeEmptyRun?: boolean
+}
+
+export async function writeRunOutputs(
+  options: RunOutputOptions,
+  root: string,
+  runId: string,
+  manifest: TestRunManifest,
+): Promise<void> {
+  if (options.junitPath) {
+    await Bun.write(options.junitPath, formatJunit(manifest))
+  }
+  if (options.jsonPath) await Bun.write(options.jsonPath, formatJson(manifest))
+  if (options.ndjsonPath) {
+    const persisted = await openTestRunStore({ root }).open(runId)
+    await Bun.write(options.ndjsonPath, formatNdjson(await persisted.events()))
+  }
+}
+
+export async function finalizeMaterializedEvidence(
+  options: RunOutputOptions,
+  root: string,
+  runId: string,
+  finalizeOptions: FinalizeEvidenceOptions = {},
+): Promise<void> {
+  const persisted = await openTestRunStore({ root }).open(runId)
+  const events = await persisted.events()
+  if (
+    !finalizeOptions.includeEmptyRun &&
+    !events.some((event) => event.type === 'scenario-finished')
+  ) {
+    return
+  }
+  const manifest = await persisted.materialize()
+  await writeRunOutputs(options, root, runId, manifest)
+}

--- a/packages/cli/src/run-report.ts
+++ b/packages/cli/src/run-report.ts
@@ -534,6 +534,22 @@ export function policyLines(
   ]
 }
 
+export function interruptionLines(
+  exitStatus: TestRunExitStatus,
+  columns?: number,
+): string[] {
+  if (!exitStatus.interrupted) return []
+  return [
+    ...wrappedLines(' ! ', 'Run interrupted', '   ', columns),
+    ...wrappedLines(
+      '   ',
+      'Partial summary: every Test result materialized before interruption is included.',
+      '   ',
+      columns,
+    ),
+  ]
+}
+
 function testResultSummary(results: readonly TestResult[]): string {
   const entries = Object.entries(
     resultPresentations,

--- a/packages/cli/src/run-reporter.test.ts
+++ b/packages/cli/src/run-reporter.test.ts
@@ -475,6 +475,40 @@ test('counts Test result states as mutually exclusive summary outcomes', () => {
   )
 })
 
+test('labels an interrupted non-interactive report as a partial summary', () => {
+  const lines: string[] = []
+  const reporter = createRunReporter('default', {
+    write: (line) => lines.push(line),
+    projectRoot: '/workspace/project',
+    version: '1.0.2',
+    color: false,
+    columns: 120,
+    now: () => new Date(2026, 7, 20, 14, 32, 7),
+  })
+  const run = passedRun({
+    specificationUri: 'features/checkout.feature',
+    specificationName: 'Checkout',
+    scenarioId: 'scenario-cancelled',
+    scenarioName: 'Interrupted checkout',
+    profileId: 'web',
+    durationMs: 10,
+  })
+  run.result.state = 'cancelled'
+
+  reporter.start()
+  reporter.finish([run], 10, {
+    exitCode: 130,
+    interrupted: true,
+    rejectedAdaptedResults: 0,
+  })
+
+  expect(lines).toContain(' ! Run interrupted')
+  expect(lines).toContain(
+    '   Partial summary: every Test result materialized before interruption is included.',
+  )
+  expect(lines).toContain(' Test results    1 cancelled (1)')
+})
+
 test('enables color only for a TTY when NO_COLOR is absent', () => {
   expect(terminalReporterCapabilities(true, 100, undefined)).toEqual({
     color: true,

--- a/packages/cli/src/run-reporter.ts
+++ b/packages/cli/src/run-reporter.ts
@@ -9,6 +9,7 @@ import {
   clockLabel,
   diagnosticLines,
   groupResults,
+  interruptionLines,
   policyLines,
   renderTestResult,
   summaryLines,
@@ -130,6 +131,9 @@ function createBufferedRunReporter(options: RunReporterOptions): RunReporter {
         write(line)
       }
       for (const line of policyLines(exitStatus, options.columns)) write(line)
+      for (const line of interruptionLines(exitStatus, options.columns)) {
+        write(line)
+      }
       for (const line of summaryLines(
         specifications,
         results,

--- a/packages/cli/src/run-reporting-session.ts
+++ b/packages/cli/src/run-reporting-session.ts
@@ -1,0 +1,61 @@
+import type {
+  RunEvent,
+  ScenarioRun,
+  ScheduledTestResult,
+  TestResult,
+} from '@pickle-spec/runner'
+import type { RunReporter } from './run-reporter'
+import type { TestRunExitStatus } from './test-run-exit-status'
+
+export type ReporterFailure = {
+  error: unknown
+}
+
+export interface RunReportingSession {
+  start(): void
+  prepare(schedule: readonly ScheduledTestResult[]): void
+  event(event: RunEvent): void
+  complete(result: TestResult): void
+  refresh(): void
+  finish(
+    runs: readonly ScenarioRun[],
+    durationMs: number,
+    exitStatus: TestRunExitStatus,
+  ): void
+  failure(): ReporterFailure | undefined
+  fail(error: unknown, durationMs: number): ReporterFailure | undefined
+}
+
+export function createRunReportingSession(
+  reporter: RunReporter,
+): RunReportingSession {
+  let reporterFailure: ReporterFailure | undefined
+
+  function capture(operation: () => void): void {
+    if (reporterFailure) return
+    try {
+      operation()
+    } catch (error) {
+      reporterFailure = { error }
+    }
+  }
+
+  return {
+    start: () => capture(reporter.start),
+    prepare: (schedule) => capture(() => reporter.prepare?.(schedule)),
+    event: (event) => capture(() => reporter.event(event)),
+    complete: (result) => capture(() => reporter.complete?.(result)),
+    refresh: () => capture(() => reporter.refresh?.()),
+    finish: (runs, durationMs, exitStatus) =>
+      capture(() => reporter.finish(runs, durationMs, exitStatus)),
+    failure: () => reporterFailure,
+    fail(error, durationMs) {
+      try {
+        reporter.fail?.(error, durationMs)
+        return undefined
+      } catch (reporterRecoveryError) {
+        return { error: reporterRecoveryError }
+      }
+    },
+  }
+}

--- a/packages/cli/src/server.ts
+++ b/packages/cli/src/server.ts
@@ -13,6 +13,11 @@ export interface ServerRuntime {
   spawn: typeof Bun.spawn
 }
 
+export interface StartServerOptions {
+  runtime?: ServerRuntime
+  signal?: AbortSignal
+}
+
 const runtime: ServerRuntime = { fetch, sleep: Bun.sleep, spawn: Bun.spawn }
 
 function commandForShell(command: string): string[] {
@@ -33,11 +38,14 @@ async function isHealthy(
   url: string,
   deadline: number,
   serverRuntime: ServerRuntime,
+  signal?: AbortSignal,
 ): Promise<boolean> {
   const remaining = deadline - Date.now()
   if (remaining <= 0) return false
   const controller = new AbortController()
+  const onAbort = () => controller.abort()
   const timeout = setTimeout(() => controller.abort(), remaining)
+  signal?.addEventListener('abort', onAbort, { once: true })
   try {
     const response = await serverRuntime.fetch(
       config.readinessPath ? new URL(config.readinessPath, url) : url,
@@ -50,25 +58,64 @@ async function isHealthy(
     return false
   } finally {
     clearTimeout(timeout)
+    signal?.removeEventListener('abort', onAbort)
   }
+}
+
+function cancellationError(): DOMException {
+  return new DOMException('Server startup cancelled', 'AbortError')
+}
+
+function throwIfCancelled(signal?: AbortSignal): void {
+  if (signal?.aborted) throw cancellationError()
+}
+
+async function waitForPoll(
+  durationMs: number,
+  serverRuntime: ServerRuntime,
+  signal?: AbortSignal,
+): Promise<void> {
+  if (!signal) {
+    await serverRuntime.sleep(durationMs)
+    return
+  }
+  throwIfCancelled(signal)
+  await new Promise<void>((resolve, reject) => {
+    const onAbort = () => {
+      clearTimeout(timeout)
+      signal.removeEventListener('abort', onAbort)
+      reject(cancellationError())
+    }
+    const timeout = setTimeout(() => {
+      signal.removeEventListener('abort', onAbort)
+      resolve()
+    }, durationMs)
+    signal.addEventListener('abort', onAbort, { once: true })
+    if (signal.aborted) onAbort()
+  })
 }
 
 export async function startServer(
   config: ServerConfig,
-  serverRuntime: ServerRuntime = runtime,
+  options: StartServerOptions = {},
 ): Promise<ManagedServer | undefined> {
+  const serverRuntime = options.runtime ?? runtime
+  const signal = options.signal
   if (!config.command) return undefined
+  throwIfCancelled(signal)
   const url = serverUrl(config)
   const timeoutMs = config.startupTimeoutMs ?? 30_000
   const deadline = Date.now() + timeoutMs
 
   if (
     config.reuseExisting &&
-    (await isHealthy(config, url, deadline, serverRuntime))
+    (await isHealthy(config, url, deadline, serverRuntime, signal))
   ) {
+    throwIfCancelled(signal)
     return { mode: 'reused', url, stop() {} }
   }
 
+  throwIfCancelled(signal)
   const child: Subprocess = serverRuntime.spawn(
     commandForShell(config.command),
     {
@@ -77,17 +124,27 @@ export async function startServer(
       stderr: 'pipe',
     },
   )
-  while (Date.now() < deadline) {
-    if (await isHealthy(config, url, deadline, serverRuntime)) {
-      return { mode: 'spawned', url, stop: () => child.kill() }
+  try {
+    while (Date.now() < deadline) {
+      throwIfCancelled(signal)
+      if (await isHealthy(config, url, deadline, serverRuntime, signal)) {
+        throwIfCancelled(signal)
+        return { mode: 'spawned', url, stop: () => child.kill() }
+      }
+      throwIfCancelled(signal)
+      const remaining = deadline - Date.now()
+      if (remaining <= 0) break
+      await waitForPoll(
+        Math.min(config.pollIntervalMs ?? 500, remaining),
+        serverRuntime,
+        signal,
+      )
     }
-    await serverRuntime.sleep(
-      Math.min(config.pollIntervalMs ?? 500, deadline - Date.now()),
+    throw new Error(
+      `Server failed to start within ${timeoutMs}ms. Command: "${config.command}", URL: "${url}"`,
     )
+  } catch (error) {
+    child.kill()
+    throw error
   }
-
-  child.kill()
-  throw new Error(
-    `Server failed to start within ${timeoutMs}ms. Command: "${config.command}", URL: "${url}"`,
-  )
 }

--- a/packages/cli/src/server.ts
+++ b/packages/cli/src/server.ts
@@ -20,6 +20,18 @@ export interface StartServerOptions {
 
 const runtime: ServerRuntime = { fetch, sleep: Bun.sleep, spawn: Bun.spawn }
 
+function stopServerProcess(child: Subprocess): void {
+  if (process.platform === 'win32') {
+    child.kill()
+    return
+  }
+  try {
+    process.kill(-child.pid, 'SIGTERM')
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== 'ESRCH') throw error
+  }
+}
+
 function commandForShell(command: string): string[] {
   return process.platform === 'win32'
     ? ['cmd.exe', '/d', '/s', '/c', command]
@@ -120,8 +132,9 @@ export async function startServer(
     commandForShell(config.command),
     {
       cwd: process.cwd(),
+      detached: process.platform !== 'win32',
       stdout: 'ignore',
-      stderr: 'pipe',
+      stderr: 'ignore',
     },
   )
   try {
@@ -129,7 +142,7 @@ export async function startServer(
       throwIfCancelled(signal)
       if (await isHealthy(config, url, deadline, serverRuntime, signal)) {
         throwIfCancelled(signal)
-        return { mode: 'spawned', url, stop: () => child.kill() }
+        return { mode: 'spawned', url, stop: () => stopServerProcess(child) }
       }
       throwIfCancelled(signal)
       const remaining = deadline - Date.now()
@@ -144,7 +157,7 @@ export async function startServer(
       `Server failed to start within ${timeoutMs}ms. Command: "${config.command}", URL: "${url}"`,
     )
   } catch (error) {
-    child.kill()
+    stopServerProcess(child)
     throw error
   }
 }

--- a/packages/cli/src/terminal-surface.test.ts
+++ b/packages/cli/src/terminal-surface.test.ts
@@ -100,15 +100,37 @@ test('moves unrelated process output above the live region without erasing it', 
   surface.finish(['summary'])
 
   expect(output).toEqual([
+    '\u001b[?25l',
     'live progress',
     '\r\u001b[2K',
     'adapter log\n',
     'live progress',
     '\r\u001b[2K',
     'summary\n',
+    '\u001b[0m\u001b[?25h',
   ])
   expect(stream.write('after finish\n')).toBe(true)
   expect(output.at(-1)).toBe('after finish\n')
   expect(stream.write).toBe(originalWrite)
   expect(errorStream.write).toBe(originalErrorWrite)
+})
+
+test('restores process streams and terminal state when final rendering throws', () => {
+  const output: string[] = []
+  const stream = {
+    columns: 80,
+    write(chunk: string) {
+      output.push(chunk)
+      if (chunk === 'summary\n') throw new Error('terminal write failed')
+      return true
+    },
+  }
+  const originalWrite = stream.write
+  const surface = createProcessTerminalSurface(stream)
+
+  surface.activate?.()
+
+  expect(() => surface.finish(['summary'])).toThrow('terminal write failed')
+  expect(stream.write).toBe(originalWrite)
+  expect(output.at(-1)).toBe('\u001b[0m\u001b[?25h')
 })

--- a/packages/cli/src/terminal-surface.ts
+++ b/packages/cli/src/terminal-surface.ts
@@ -30,7 +30,9 @@ type CapturedTerminalStream = {
 }
 
 const clearLine = '\r\u001b[2K'
+const hideCursor = '\u001b[?25l'
 const moveUp = '\u001b[1A'
+const restoreTerminal = '\u001b[0m\u001b[?25h'
 const reservedTerminalRows = 2
 
 export function availableTerminalRows(rows: number | undefined): number {
@@ -176,6 +178,7 @@ export function createProcessTerminalSurface(
     activate() {
       if (active) return
       active = true
+      outputStream.write(hideCursor)
       for (const captured of capturedStreams) {
         captured.stream.write = interceptedWrite(captured)
       }
@@ -188,10 +191,14 @@ export function createProcessTerminalSurface(
       surface.commit(lines)
     },
     finish(lines) {
-      finishExternalLine()
-      dynamicLines = []
-      surface.finish(lines)
-      restoreWrite()
+      try {
+        finishExternalLine()
+        dynamicLines = []
+        surface.finish(lines)
+      } finally {
+        restoreWrite()
+        outputStream.write(restoreTerminal)
+      }
     },
     update(lines) {
       dynamicLines = [...lines]

--- a/packages/cli/src/test-run-exit-status.ts
+++ b/packages/cli/src/test-run-exit-status.ts
@@ -5,12 +5,18 @@ type AdaptedResultsPolicy = NonNullable<ProjectPolicy['adaptedResults']>
 
 export type TestRunExitStatus = {
   exitCode: 0 | 1 | 130
+  interrupted: boolean
   rejectedAdaptedResults: number
+}
+
+type TestRunExitOptions = {
+  interrupted?: boolean
 }
 
 export function evaluateTestRunExitStatus(
   results: readonly TestResult[],
   adaptedResultsPolicy: AdaptedResultsPolicy = 'accept',
+  options: TestRunExitOptions = {},
 ): TestRunExitStatus {
   const states = results.map((result) => result.state)
   const rejectedAdaptedResults =
@@ -18,14 +24,17 @@ export function evaluateTestRunExitStatus(
       ? states.filter((state) => state === 'passed-with-adaptation').length
       : 0
 
+  if (options.interrupted) {
+    return { exitCode: 130, interrupted: true, rejectedAdaptedResults }
+  }
   if (rejectedAdaptedResults > 0) {
-    return { exitCode: 1, rejectedAdaptedResults }
+    return { exitCode: 1, interrupted: false, rejectedAdaptedResults }
   }
   if (states.includes('cancelled')) {
-    return { exitCode: 130, rejectedAdaptedResults }
+    return { exitCode: 130, interrupted: false, rejectedAdaptedResults }
   }
   if (states.includes('failed') || states.includes('infrastructure-error')) {
-    return { exitCode: 1, rejectedAdaptedResults }
+    return { exitCode: 1, interrupted: false, rejectedAdaptedResults }
   }
-  return { exitCode: 0, rejectedAdaptedResults }
+  return { exitCode: 0, interrupted: false, rejectedAdaptedResults }
 }

--- a/packages/cli/src/workspace.test.ts
+++ b/packages/cli/src/workspace.test.ts
@@ -479,9 +479,101 @@ export default {}
     })
 
     expect(run.exitCode).toBe(2)
+    expect(run.stderr.toString()).toStartWith('ERROR ')
     expect(run.stderr.toString()).toContain('Parser errors')
+    expect(run.stderr.toString()).not.toContain('\n    at ')
+    expect(run.stdout.toString()).not.toContain('Test results    ')
     expect(await Bun.file(marker).exists()).toBe(false)
     expect(await Bun.file(extensionMarker).exists()).toBe(false)
+  })
+
+  test('run reports invalid configuration as a concise command error', async () => {
+    const project = await createCheckProject('run-invalid-configuration', {
+      config: { schemaVersion: 99 },
+      specification: validSpecification,
+    })
+
+    const run = runProject(project)
+    const stderr = run.stderr.toString()
+
+    expect(run.exitCode).toBe(2)
+    expect(stderr).toStartWith('ERROR Invalid configuration')
+    expect(stderr).toContain('Unsupported configuration schemaVersion: 99')
+    expect(stderr).not.toContain('\n    at ')
+    expect(run.stdout.toString()).toBe('')
+  })
+
+  test('run reports missing Specifications without a Test result summary', async () => {
+    const project = await createCheckProject('run-missing-specifications', {
+      config: {
+        ...deterministicRunConfig,
+        specifications: 'features/**/*.feature',
+      },
+      extensions: await Bun.file(
+        join(workspace, 'pickle.extensions.ts'),
+      ).text(),
+    })
+
+    const run = runProject(project)
+    const stderr = run.stderr.toString()
+    const stdout = run.stdout.toString()
+
+    expect(run.exitCode).toBe(2)
+    expect(stderr).toStartWith('ERROR No specifications found matching:')
+    expect(stderr).not.toContain('\n    at ')
+    expect(stdout).not.toContain('Specifications  ')
+    expect(stdout).not.toContain('Test results    ')
+  })
+
+  test('run treats an empty Scenario selection as a command error', async () => {
+    const project = await createCheckProject('run-empty-selection', {
+      config: deterministicRunConfig,
+      specification: validSpecification,
+      extensions: await Bun.file(
+        join(workspace, 'pickle.extensions.ts'),
+      ).text(),
+    })
+
+    const run = Bun.spawnSync({
+      cmd: [pickleCommand, 'run', '--scenario', 'Missing Scenario'],
+      cwd: project,
+      env: { ...Bun.env },
+    })
+    const stderr = run.stderr.toString()
+    const stdout = run.stdout.toString()
+
+    expect(run.exitCode).toBe(2)
+    expect(stderr).toBe('ERROR No Scenarios match the current selection\n')
+    expect(stdout).not.toContain('Specifications  ')
+    expect(stdout).not.toContain('Test results    ')
+  })
+
+  test('run reports an application server startup failure as a command error', async () => {
+    const project = await createCheckProject('run-server-start-failure', {
+      config: {
+        ...deterministicRunConfig,
+        server: {
+          command: 'exit 9',
+          url: 'http://127.0.0.1:1',
+          startupTimeoutMs: 20,
+          pollIntervalMs: 5,
+        },
+      },
+      specification: validSpecification,
+      extensions: await Bun.file(
+        join(workspace, 'pickle.extensions.ts'),
+      ).text(),
+    })
+
+    const run = runProject(project)
+    const stderr = run.stderr.toString()
+    const stdout = run.stdout.toString()
+
+    expect(run.exitCode).toBe(2)
+    expect(stderr).toStartWith('ERROR Server failed to start within 20ms')
+    expect(stderr).not.toContain('\n    at ')
+    expect(stdout).not.toContain('Specifications  ')
+    expect(stdout).not.toContain('Test results    ')
   })
 
   test('check rejects an empty Specification path set', async () => {
@@ -836,6 +928,9 @@ Feature: Ignored
       '↓ features/ignored.feature > Ignore this Scenario',
     )
     expect(skippedOutput).toContain('(skipped: Scenario is tagged @ignore)')
+    expect(skippedOutput).toContain(' Specifications  1')
+    expect(skippedOutput).toContain(' Scenarios       1')
+    expect(skippedOutput).toContain(' Test results    1 skipped (1)')
     expect(skippedOutput).not.toContain(' Failures')
     expect(skippedOutput).not.toContain(' Infrastructure errors')
 
@@ -1354,9 +1449,14 @@ export default {
     })
 
     expect(run.exitCode).toBe(2)
+    expect(run.stderr.toString()).toStartWith(
+      'ERROR Execution target profile "web"',
+    )
     expect(run.stderr.toString()).toContain(
       'Execution target profile "web" lacks required capabilities for Scenario "Show stores near the customer": geolocation',
     )
+    expect(run.stderr.toString()).not.toContain('\n    at ')
+    expect(run.stdout.toString()).not.toContain('Test results    ')
     expect(await Bun.file(marker).exists()).toBe(false)
   })
 


### PR DESCRIPTION
## Summary

- Handle interrupted and invalid runs consistently across CLI execution and reporting
- Update terminal, live, and run reporters with the correct exit status and error handling
- Add coverage for live runs, reporter behavior, terminal output, and workspace handling

Closes #55

## Testing

Not run (not requested)