### PR TITLE
Improve Studio result evidence inspection

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -18,7 +18,9 @@
   ],
   "scripts": {
     "typecheck": "tsc --noEmit",
-    "test": "bun test"
+    "test": "bun run test:confidentiality && bun run test:remaining",
+    "test:confidentiality": "bun test --preload ./test/test-environment.ts --max-concurrency 1 src/execution-cache-confidentiality.test.ts",
+    "test:remaining": "bun test --preload ./test/test-environment.ts --max-concurrency 1 --path-ignore-patterns '**/execution-cache-confidentiality.test.ts'"
   },
   "dependencies": {
     "@pickle-spec/mobile": "workspace:*",

--- a/packages/cli/src/studio.test.ts
+++ b/packages/cli/src/studio.test.ts
@@ -863,6 +863,70 @@ Feature: Search
       expect(
         await results.getByRole('button', { name: 'Rerun target' }).count(),
       ).toBeGreaterThan(0)
+      const failedResult = results
+        .getByRole('row')
+        .filter({ hasText: 'Pay for the order' })
+        .filter({ hasText: 'chrome' })
+        .first()
+      await failedResult.getByRole('button', { name: 'Inspect result' }).click()
+      await page
+        .getByRole('heading', {
+          name: 'Pay for the order · failed · chrome',
+        })
+        .waitFor()
+      expect(new URL(page.url()).searchParams.get('run')).toBeTruthy()
+      expect(new URL(page.url()).searchParams.get('scenario')).toBe(
+        'scnpaybbbbbbbbbb',
+      )
+      expect(
+        await page
+          .getByRole('tab', { name: 'Timeline' })
+          .getAttribute('aria-selected'),
+      ).toBe('true')
+      const evidenceTimeline = page.getByRole('list', {
+        name: 'Causal evidence timeline',
+      })
+      const timelineText = await evidenceTimeline.textContent()
+      expect(timelineText).toContain('Step')
+      expect(timelineText).toContain('Run event')
+      expect(timelineText).toContain('Diagnostic entry')
+      expect(timelineText).toContain('Test artifact')
+      expect(timelineText).toContain('Causal point')
+      await page.getByRole('tab', { name: 'Artifacts' }).click()
+      expect(
+        await page
+          .getByRole('img', {
+            name: 'screenshot from failed result for Pay for the order: Then payment is captured',
+          })
+          .count(),
+      ).toBe(1)
+      expect(
+        await page.getByRole('link', { name: 'Download screenshot' }).count(),
+      ).toBe(1)
+      expect(await page.getByText('image/png').count()).toBeGreaterThan(0)
+      const deepLink = page.url()
+      await page.reload()
+      await page
+        .getByRole('heading', {
+          name: 'Pay for the order · failed · chrome',
+        })
+        .waitFor()
+      expect(page.url()).toBe(deepLink)
+      await page.getByRole('button', { name: 'Back to run' }).click()
+      await results.waitFor()
+      const passedResult = results
+        .getByRole('row')
+        .filter({ hasText: 'Complete a purchase' })
+        .filter({ hasText: 'chrome' })
+        .first()
+      await passedResult.getByRole('button', { name: 'Inspect result' }).click()
+      expect(
+        await page
+          .getByRole('tab', { name: 'Overview' })
+          .getAttribute('aria-selected'),
+      ).toBe('true')
+      await page.getByRole('button', { name: 'Back to run' }).click()
+      await results.waitFor()
       await results
         .getByRole('button', { name: 'Rerun Scenario' })
         .first()

--- a/packages/cli/test/test-environment.ts
+++ b/packages/cli/test/test-environment.ts
@@ -1,0 +1,11 @@
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+const pickleHome = mkdtempSync(join(tmpdir(), 'pickle-cli-tests-'))
+
+process.env.PICKLE_HOME = pickleHome
+
+process.once('exit', () => {
+  rmSync(pickleHome, { recursive: true, force: true })
+})

--- a/packages/mobile/src/mobile-benchmark-cli.test.ts
+++ b/packages/mobile/src/mobile-benchmark-cli.test.ts
@@ -3,6 +3,7 @@ import { mkdtemp, rm } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { providerCredentialEnvironmentNames } from '@pickle-spec/runner/benchmarking'
+import { createControlledMobileBenchmarkDriver } from './mobile-benchmark-controlled-driver'
 
 const temporaryDirectories: string[] = []
 const cliPath = join(import.meta.dir, 'mobile-benchmark-cli.ts')
@@ -38,30 +39,12 @@ function runCli(...args: string[]) {
 
 describe('mobile benchmark executable', () => {
   test('controlled driver rejects every provider credential', async () => {
-    const controlledBenchmarkUrl = new URL(
-      './mobile-benchmark-controlled-driver.ts',
-      import.meta.url,
-    ).href
     for (const credentialName of providerCredentialEnvironmentNames) {
-      const process = Bun.spawn(
-        [
-          Bun.which('bun')!,
-          '-e',
-          `import { createControlledMobileBenchmarkDriver } from ${JSON.stringify(controlledBenchmarkUrl)}; await createControlledMobileBenchmarkDriver()`,
-        ],
-        {
-          env: { [credentialName]: 'must-not-reach-controlled-mobile' },
-          stdout: 'pipe',
-          stderr: 'pipe',
-        },
-      )
-      const [exitCode, stderr] = await Promise.all([
-        process.exited,
-        new Response(process.stderr).text(),
-      ])
-
-      expect(exitCode).not.toBe(0)
-      expect(stderr).toContain(credentialName)
+      await expect(
+        createControlledMobileBenchmarkDriver({
+          [credentialName]: 'must-not-reach-controlled-mobile',
+        }),
+      ).rejects.toThrow(credentialName)
     }
   })
 

--- a/packages/runner/src/execution-cache-lifecycle.test.ts
+++ b/packages/runner/src/execution-cache-lifecycle.test.ts
@@ -71,6 +71,8 @@ afterEach(async () => {
 
 interface LocalStoreOptions {
   waitTimeoutMs?: number
+  ttlMs?: number
+  heartbeatMs?: number
   maxBytes?: number
 }
 
@@ -83,9 +85,9 @@ async function localStore(options: LocalStoreOptions = {}) {
     cacheRoot,
     maxBytes: options.maxBytes,
     leaseTiming: {
-      ttlMs: 100,
-      heartbeatMs: 20,
-      waitTimeoutMs: options.waitTimeoutMs ?? 100,
+      ttlMs: options.ttlMs ?? 30_000,
+      heartbeatMs: options.heartbeatMs ?? 10_000,
+      waitTimeoutMs: options.waitTimeoutMs ?? 30_000,
       minPollMs: 1,
       maxPollMs: 2,
     },
@@ -449,6 +451,7 @@ describe('Execution cache lifecycle', () => {
 
   test('serializes concurrent refreshes and keeps the successful replacement', async () => {
     const cache = await localStore()
+    const { store, waiting } = observeLeaseWait(cache)
     let adaptiveExecutions = 0
     let holdRefresh = false
     let releaseRefresh: (() => void) | undefined
@@ -491,7 +494,7 @@ describe('Execution cache lifecycle', () => {
     }
     const input = cacheRunInput({
       adapter,
-      store: cache,
+      store,
       projectKey: cache.projectKey,
     })
     await runScenario(input)
@@ -508,6 +511,7 @@ describe('Execution cache lifecycle', () => {
       cachePolicy: 'refresh',
       executionCache: { ...input.executionCache, sourceRunId: 'run-3' },
     })
+    await waiting
     releaseRefresh?.()
     const [owner, waiter] = await Promise.all([ownerRun, waiterRun])
 
@@ -568,7 +572,7 @@ describe('Execution cache lifecycle', () => {
   })
 
   test('discards an Adaptive evaluation after heartbeat loses ownership', async () => {
-    const cache = await localStore()
+    const cache = await localStore({ ttlMs: 100, heartbeatMs: 20 })
     let adaptiveExecutions = 0
     const store: ExecutionCacheStore = {
       ...cache,

--- a/packages/runner/src/test-run-store.test.ts
+++ b/packages/runner/src/test-run-store.test.ts
@@ -1042,16 +1042,25 @@ test('issue 77: coordinates appends and finalization across reopened handles', a
   )
 
   const finalizing = firstReopened.materialize()
-  const lateAppendAssertions = handles.map((handle, index) =>
-    expect(
-      handle.append({
-        type: 'inference-count-updated',
-        inferenceCount: 30 + index,
-        scope: diagnosticEventScope,
-      }),
-    ).rejects.toThrow('finalized'),
+  const lateAppends = handles.map((handle, index) =>
+    handle.append({
+      type: 'inference-count-updated',
+      inferenceCount: 30 + index,
+      scope: diagnosticEventScope,
+    }),
   )
-  await Promise.all([finalizing, ...lateAppendAssertions])
+  const [finalization, ...appendOutcomes] = await Promise.allSettled([
+    finalizing,
+    ...lateAppends,
+  ])
+
+  expect(finalization?.status).toBe('fulfilled')
+  for (const outcome of appendOutcomes) {
+    expect(outcome.status).toBe('rejected')
+    if (outcome.status !== 'rejected') continue
+    if (!(outcome.reason instanceof Error)) throw outcome.reason
+    expect(outcome.reason.message).toContain('finalized')
+  }
   expect(
     (await secondReopened.events()).map((event) => event.sequence),
   ).toEqual(Array.from({ length: 31 }, (_, index) => index + 1))

--- a/packages/runner/src/test-run-store.test.ts
+++ b/packages/runner/src/test-run-store.test.ts
@@ -1042,18 +1042,16 @@ test('issue 77: coordinates appends and finalization across reopened handles', a
   )
 
   const finalizing = firstReopened.materialize()
-  const lateAppends = handles.map((handle, index) =>
-    handle.append({
-      type: 'inference-count-updated',
-      inferenceCount: 30 + index,
-      scope: diagnosticEventScope,
-    }),
+  const lateAppendAssertions = handles.map((handle, index) =>
+    expect(
+      handle.append({
+        type: 'inference-count-updated',
+        inferenceCount: 30 + index,
+        scope: diagnosticEventScope,
+      }),
+    ).rejects.toThrow('finalized'),
   )
-  await finalizing
-
-  for (const lateAppend of lateAppends) {
-    await expect(lateAppend).rejects.toThrow('finalized')
-  }
+  await Promise.all([finalizing, ...lateAppendAssertions])
   expect(
     (await secondReopened.events()).map((event) => event.sequence),
   ).toEqual(Array.from({ length: 31 }, (_, index) => index + 1))

--- a/packages/studio/src/components/ui/tabs.tsx
+++ b/packages/studio/src/components/ui/tabs.tsx
@@ -1,0 +1,79 @@
+import { Tabs as TabsPrimitive } from '@base-ui/react/tabs'
+import { cva, type VariantProps } from 'class-variance-authority'
+
+import { cn } from '../../lib/utils'
+
+function Tabs({
+  className,
+  orientation = 'horizontal',
+  ...props
+}: TabsPrimitive.Root.Props) {
+  return (
+    <TabsPrimitive.Root
+      data-slot="tabs"
+      data-orientation={orientation}
+      className={cn(
+        'group/tabs flex gap-3 data-[orientation=horizontal]:flex-col data-[orientation=vertical]:flex-row',
+        className,
+      )}
+      {...props}
+    />
+  )
+}
+
+const tabsListVariants = cva(
+  'group/tabs-list inline-flex w-fit items-center justify-center rounded-lg p-[3px] text-muted-foreground group-data-[orientation=horizontal]/tabs:h-8 group-data-[orientation=vertical]/tabs:h-fit group-data-[orientation=vertical]/tabs:flex-col data-[variant=line]:rounded-none',
+  {
+    variants: {
+      variant: {
+        default: 'bg-muted',
+        line: 'gap-1 bg-transparent',
+      },
+    },
+    defaultVariants: {
+      variant: 'default',
+    },
+  },
+)
+
+function TabsList({
+  className,
+  variant = 'default',
+  ...props
+}: TabsPrimitive.List.Props & VariantProps<typeof tabsListVariants>) {
+  return (
+    <TabsPrimitive.List
+      data-slot="tabs-list"
+      data-variant={variant}
+      className={cn(tabsListVariants({ variant }), className)}
+      {...props}
+    />
+  )
+}
+
+function TabsTrigger({ className, ...props }: TabsPrimitive.Tab.Props) {
+  return (
+    <TabsPrimitive.Tab
+      data-slot="tabs-trigger"
+      className={cn(
+        "relative inline-flex h-[calc(100%-1px)] flex-1 items-center justify-center gap-1.5 rounded-md border border-transparent px-1.5 py-0.5 text-xs font-medium whitespace-nowrap text-foreground/60 transition-all group-data-[orientation=vertical]/tabs:w-full group-data-[orientation=vertical]/tabs:justify-start group-data-[orientation=vertical]/tabs:py-[calc(--spacing(1.25))] hover:text-foreground focus-visible:border-current/35 focus-visible:outline-none disabled:pointer-events-none disabled:opacity-50 has-data-[icon=inline-end]:pr-1 has-data-[icon=inline-start]:pl-1 aria-disabled:pointer-events-none aria-disabled:opacity-50 dark:text-muted-foreground dark:hover:text-foreground [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-3.5",
+        'group-data-[variant=line]/tabs-list:bg-transparent group-data-[variant=line]/tabs-list:data-active:bg-accent group-data-[variant=line]/tabs-list:data-active:text-accent-foreground',
+        'data-active:bg-background data-active:text-foreground dark:data-active:border-input dark:data-active:bg-input/30 dark:data-active:text-foreground',
+        className,
+      )}
+      {...props}
+    />
+  )
+}
+
+function TabsContent({ className, ...props }: TabsPrimitive.Panel.Props) {
+  return (
+    <TabsPrimitive.Panel
+      data-slot="tabs-content"
+      className={cn('flex-1 text-xs/relaxed outline-none', className)}
+      {...props}
+    />
+  )
+}
+
+export { Tabs, TabsContent, TabsList, TabsTrigger }

--- a/packages/studio/src/frontend.tsx
+++ b/packages/studio/src/frontend.tsx
@@ -21,6 +21,14 @@ import {
 import { HistoryPanel } from './history'
 import { cn } from './lib/utils'
 import {
+  historyLocationHref,
+  isResultInspection,
+  parseHistoryLocation,
+  type ResultInspectorTab,
+} from './result-inspection'
+import { ResultInspector } from './result-inspector'
+import { reasonMessage, resultBadgeVariant } from './result-presentation'
+import {
   attentionCells,
   type ClientEvent,
   cellKey,
@@ -56,6 +64,7 @@ if (token) {
     `${address.pathname}${address.search}${address.hash}`,
   )
 }
+const initialHistoryLocation = parseHistoryLocation(location.search)
 const areas = ['Specifications', 'Settings'] as const
 const specificationRowHeight = 32
 
@@ -73,10 +82,9 @@ async function api<T>(path: string, init?: RequestInit): Promise<T> {
 type StatusBadgeState = TestResultState | 'idle' | 'running'
 
 function badgeVariant(state: StatusBadgeState) {
-  if (state === 'failed' || state === 'infrastructure-error') return 'failed'
-  if (state === 'passed') return 'passed'
   if (state === 'running') return 'running'
-  return 'default'
+  if (state === 'idle') return 'default'
+  return resultBadgeVariant(state)
 }
 
 function statusText(state: StatusBadgeState) {
@@ -103,20 +111,17 @@ function matrixCellVariant(state: MatrixCell['state']) {
   return 'outline'
 }
 
-function reasonMessage(reason: unknown) {
-  return reason instanceof Error ? reason.message : String(reason)
-}
-
 function StudioApp() {
   const [project, setProject] = useState<StudioProject>()
   const [error, setError] = useState<string>()
   const [runId, setRunId] = useState<string>()
   const [selectedId, setSelectedId] = useState<string>()
+  const [historyLocation, setHistoryLocation] = useState(initialHistoryLocation)
   const [currentArea, setCurrentArea] =
     useState<(typeof areas)[number]>('Specifications')
   const [specificationSection, setSpecificationSection] = useState<
     'scenarios' | 'history'
-  >('scenarios')
+  >(initialHistoryLocation ? 'history' : 'scenarios')
   const [view, setView] = useState<RunView>(emptyRunView)
   const [authoring, setAuthoring] = useState(false)
   const [attentionOrder, setAttentionOrder] = useState<string[]>()
@@ -135,6 +140,19 @@ function StudioApp() {
     return () => {
       cancelled = true
     }
+  }, [])
+
+  useEffect(() => {
+    function restoreLocation() {
+      const next = parseHistoryLocation(location.search)
+      setHistoryLocation(next)
+      if (next) {
+        setCurrentArea('Specifications')
+        setSpecificationSection('history')
+      }
+    }
+    addEventListener('popstate', restoreLocation)
+    return () => removeEventListener('popstate', restoreLocation)
   }, [])
 
   useEffect(() => {
@@ -168,6 +186,9 @@ function StudioApp() {
   }, [attention, attentionOrder])
   const aggregate = statusLabel(view)
   const selected =
+    project?.specifications.find(
+      (item) => item.uri === historyLocation?.specificationUri,
+    ) ??
     project?.specifications.find((item) => item.id === selectedId) ??
     project?.specifications[0]
   const canRunAll = Boolean(project?.readiness?.ready ?? true)
@@ -178,6 +199,19 @@ function StudioApp() {
     const value = await api<StudioProject>('/api/project')
     setProject(value)
     return value
+  }
+
+  function navigateHistory(next: typeof historyLocation) {
+    history.pushState(
+      null,
+      '',
+      next ? historyLocationHref(next) : location.pathname,
+    )
+    setHistoryLocation(next)
+  }
+
+  function leaveHistory() {
+    if (historyLocation) navigateHistory(undefined)
   }
 
   async function startRun(request: StudioRunRequest) {
@@ -270,7 +304,10 @@ function StudioApp() {
               key={area}
               variant={area === currentArea ? 'secondary' : 'ghost'}
               aria-current={area === currentArea ? 'page' : undefined}
-              onClick={() => setCurrentArea(area)}
+              onClick={() => {
+                setCurrentArea(area)
+                if (area === 'Settings') leaveHistory()
+              }}
             >
               {area}
             </Button>
@@ -300,6 +337,7 @@ function StudioApp() {
               running={running}
               canRun={canRunAll}
               onSelect={(id) => {
+                leaveHistory()
                 setSelectedId(id)
                 setSpecificationSection('scenarios')
               }}
@@ -370,7 +408,10 @@ function StudioApp() {
                               ? 'page'
                               : undefined
                           }
-                          onClick={() => setSpecificationSection('scenarios')}
+                          onClick={() => {
+                            leaveHistory()
+                            setSpecificationSection('scenarios')
+                          }}
                         >
                           Scenarios
                         </Button>
@@ -461,12 +502,39 @@ function StudioApp() {
                     </div>
                   </div>
                 </header>
-                {authoring ? null : specificationSection === 'history' ? (
+                {authoring ? null : isResultInspection(historyLocation) &&
+                  historyLocation.specificationUri === selected.uri ? (
+                  <ResultInspector
+                    api={api}
+                    location={historyLocation}
+                    onBack={() =>
+                      navigateHistory({
+                        specificationUri: selected.uri,
+                        runId: historyLocation.runId,
+                      })
+                    }
+                    onTabChange={(tab: ResultInspectorTab) =>
+                      navigateHistory({ ...historyLocation, tab })
+                    }
+                  />
+                ) : specificationSection === 'history' ? (
                   <HistoryPanel
                     key={selected.uri}
                     api={api}
+                    initialRunId={
+                      historyLocation?.specificationUri === selected.uri
+                        ? historyLocation.runId
+                        : undefined
+                    }
                     runPhase={view.phase}
                     specification={selected}
+                    onReviewRun={(reviewedRunId) =>
+                      navigateHistory({
+                        specificationUri: selected.uri,
+                        runId: reviewedRunId,
+                      })
+                    }
+                    onInspectResult={navigateHistory}
                     onRerun={startRun}
                   />
                 ) : (

--- a/packages/studio/src/history.tsx
+++ b/packages/studio/src/history.tsx
@@ -18,6 +18,8 @@ import {
   TableHeader,
   TableRow,
 } from './components/ui/table'
+import type { HistoryLocation } from './result-inspection'
+import { reasonMessage, resultBadgeVariant } from './result-presentation'
 import type {
   StudioHistory,
   StudioRunRequest,
@@ -31,7 +33,10 @@ const resultRowHeight = 56
 
 interface HistoryPanelProps {
   api: StudioApi
+  initialRunId?: string
   runPhase: 'idle' | 'running' | 'finished'
+  onInspectResult: (location: HistoryLocation) => void
+  onReviewRun: (runId: string) => void
   onRerun: (request: StudioRunRequest) => Promise<void>
   specification: { name: string; uri: string }
 }
@@ -66,16 +71,6 @@ function bytesLabel(bytes: number): string {
   return `${(bytes / 1_024 ** 3).toFixed(1)} GB`
 }
 
-function stateVariant(state: TestRunSummary['state']) {
-  if (state === 'failed' || state === 'infrastructure-error') return 'failed'
-  if (state === 'passed') return 'passed'
-  return 'default'
-}
-
-function reasonMessage(reason: unknown): string {
-  return reason instanceof Error ? reason.message : String(reason)
-}
-
 function sortedRuns(history: StudioHistory | undefined): TestRunSummary[] {
   return [...(history?.runs ?? [])].sort(
     (left, right) =>
@@ -92,6 +87,7 @@ export function HistoryPanel(props: HistoryPanelProps) {
   const [comparison, setComparison] = useState<TestRunComparison>()
   const [reviewed, setReviewed] = useState<TestRunManifest>()
   const reviewedSectionRef = useRef<HTMLElement>(null)
+  const autoReviewedRunId = useRef<string | undefined>(undefined)
   const [includeAllArtifacts, setIncludeAllArtifacts] = useState(false)
   const runs = useMemo(
     () =>
@@ -105,12 +101,22 @@ export function HistoryPanel(props: HistoryPanelProps) {
     itemSize: historyRowHeight,
   })
   const visibleRuns = runs.slice(runWindow.start, runWindow.end)
-  const reviewedResults = reviewed?.results ?? []
+  const reviewedAttempts = useMemo(
+    () =>
+      (reviewed?.results ?? [])
+        .filter(
+          (result) => result.specification.uri === props.specification.uri,
+        )
+        .flatMap((result) =>
+          result.attempts.map((attempt) => ({ result, attempt })),
+        ),
+    [props.specification.uri, reviewed?.results],
+  )
   const resultWindow = useVirtualWindow<HTMLDivElement>({
-    count: reviewedResults.length,
+    count: reviewedAttempts.length,
     itemSize: resultRowHeight,
   })
-  const visibleResults = reviewedResults.slice(
+  const visibleAttempts = reviewedAttempts.slice(
     resultWindow.start,
     resultWindow.end,
   )
@@ -118,6 +124,27 @@ export function HistoryPanel(props: HistoryPanelProps) {
   const loadHistory = useCallback(async () => {
     setHistory(await props.api<StudioHistory>('/api/history'))
   }, [props.api])
+
+  const loadReviewedRun = useCallback(
+    async (runId: string) => {
+      setError(undefined)
+      try {
+        const snapshot = await props.api<StudioRunSnapshot>(
+          `/api/runs/${encodeURIComponent(runId)}`,
+        )
+        setReviewed(snapshot.manifest)
+        return true
+      } catch (reason) {
+        setError(reasonMessage(reason))
+        return false
+      }
+    },
+    [props.api],
+  )
+
+  async function reviewRun(runId: string) {
+    if (await loadReviewedRun(runId)) props.onReviewRun(runId)
+  }
 
   const shouldLoadHistory =
     props.runPhase !== 'running' || history === undefined
@@ -137,6 +164,18 @@ export function HistoryPanel(props: HistoryPanelProps) {
     if (reviewed) reviewedSectionRef.current?.focus()
   }, [reviewed])
 
+  useEffect(() => {
+    if (
+      !props.initialRunId ||
+      props.initialRunId === autoReviewedRunId.current ||
+      reviewed?.id === props.initialRunId
+    ) {
+      return
+    }
+    autoReviewedRunId.current = props.initialRunId
+    void loadReviewedRun(props.initialRunId)
+  }, [loadReviewedRun, props.initialRunId, reviewed?.id])
+
   async function compareSelected() {
     if (selectedRunIds.length !== 2) return
     setError(undefined)
@@ -151,18 +190,6 @@ export function HistoryPanel(props: HistoryPanelProps) {
           }),
         }),
       )
-    } catch (reason) {
-      setError(reasonMessage(reason))
-    }
-  }
-
-  async function reviewRun(runId: string) {
-    setError(undefined)
-    try {
-      const snapshot = await props.api<StudioRunSnapshot>(
-        `/api/runs/${encodeURIComponent(runId)}`,
-      )
-      setReviewed(snapshot.manifest)
     } catch (reason) {
       setError(reasonMessage(reason))
     }
@@ -321,7 +348,7 @@ export function HistoryPanel(props: HistoryPanelProps) {
                   <TableCell>{run.applicationRevision ?? 'Not set'}</TableCell>
                   <TableCell>{durationLabel(run.durationMs)}</TableCell>
                   <TableCell>
-                    <Badge variant={stateVariant(run.state)}>
+                    <Badge variant={resultBadgeVariant(run.state)}>
                       <ResultMark state={run.state} />
                       {run.state}
                     </Badge>
@@ -447,31 +474,27 @@ export function HistoryPanel(props: HistoryPanelProps) {
                   <TableHead>Scenario</TableHead>
                   <TableHead>Target</TableHead>
                   <TableHead>State</TableHead>
+                  <TableHead>Attempt</TableHead>
                   <TableHead>Execution mode</TableHead>
                   <TableHead>Cache outcome</TableHead>
                   <TableHead>Uncacheable reason</TableHead>
                   <TableHead>Inferences</TableHead>
                   <TableHead>Duration</TableHead>
-                  <TableHead>Rerun</TableHead>
+                  <TableHead>Actions</TableHead>
                 </TableRow>
               </TableHeader>
               <TableBody>
-                <VirtualTableSpacer height={resultWindow.before} colSpan={9} />
-                {visibleResults.map((result) => {
-                  const attempt = result.attempts.at(-1)
-                  if (!attempt) {
-                    throw new Error(
-                      'A Test result requires at least one Scenario attempt',
-                    )
-                  }
+                <VirtualTableSpacer height={resultWindow.before} colSpan={10} />
+                {visibleAttempts.map(({ result, attempt }) => {
                   return (
                     <TableRow
-                      key={`${result.scenario.id ?? result.scenario.name}:${result.executionTargetProfile.id}`}
+                      key={`${result.scenario.id ?? result.scenario.name}:${result.scenario.examplesRowId ?? ''}:${result.executionTargetProfile.id}:${attempt.attempt}`}
                       style={{ height: resultRowHeight }}
                     >
                       <TableCell>{result.scenario.name}</TableCell>
                       <TableCell>{result.executionTargetProfile.id}</TableCell>
-                      <TableCell>{result.state}</TableCell>
+                      <TableCell>{attempt.state}</TableCell>
+                      <TableCell>{attempt.attempt}</TableCell>
                       <TableCell>
                         {attempt.executionMode ?? 'Not recorded'}
                       </TableCell>
@@ -484,9 +507,27 @@ export function HistoryPanel(props: HistoryPanelProps) {
                       <TableCell>
                         {inferenceCountLabel(attempt.inferenceCount)}
                       </TableCell>
-                      <TableCell>{durationLabel(result.durationMs)}</TableCell>
+                      <TableCell>{durationLabel(attempt.durationMs)}</TableCell>
                       <TableCell>
                         <div className="flex gap-2">
+                          <Button
+                            type="button"
+                            size="sm"
+                            variant="outline"
+                            onClick={() =>
+                              props.onInspectResult({
+                                specificationUri: result.specification.uri,
+                                runId: reviewed.id,
+                                scenarioId:
+                                  result.scenario.id ?? result.scenario.name,
+                                examplesRowId: result.scenario.examplesRowId,
+                                profileId: result.executionTargetProfile.id,
+                                attempt: attempt.attempt,
+                              })
+                            }
+                          >
+                            Inspect result
+                          </Button>
                           <Button
                             type="button"
                             size="sm"
@@ -522,7 +563,7 @@ export function HistoryPanel(props: HistoryPanelProps) {
                     </TableRow>
                   )
                 })}
-                <VirtualTableSpacer height={resultWindow.after} colSpan={9} />
+                <VirtualTableSpacer height={resultWindow.after} colSpan={10} />
               </TableBody>
             </Table>
           </section>

--- a/packages/studio/src/result-evidence-panels.tsx
+++ b/packages/studio/src/result-evidence-panels.tsx
@@ -1,0 +1,239 @@
+import type { EvidenceAvailability, TestResultState } from '@pickle-spec/runner'
+import { ButtonLink } from './components/ui/button'
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from './components/ui/card'
+import {
+  type ArtifactEvidence,
+  artifactUrl,
+  type DiagnosticEvidence,
+  type InspectedResult,
+} from './result-evidence'
+
+type MetadataProps = {
+  label: string
+  value: string
+  mono?: boolean
+}
+
+type ResultArtifactsProps = {
+  artifacts: readonly ArtifactEvidence[]
+  scenarioName: string
+  resultState: TestResultState
+}
+
+type ResultDiagnosticsProps = {
+  diagnostics: readonly DiagnosticEvidence[]
+  availability: readonly EvidenceAvailability[]
+}
+
+function Metadata(props: MetadataProps) {
+  return (
+    <div className="space-y-1">
+      <dt className="text-muted-foreground">{props.label}</dt>
+      <dd className={props.mono ? 'break-all font-mono' : undefined}>
+        {props.value}
+      </dd>
+    </div>
+  )
+}
+
+function EvidenceAvailabilityCard(props: {
+  availability: readonly EvidenceAvailability[]
+}) {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Evidence availability</CardTitle>
+        <CardDescription>
+          What the test run retained for investigation.
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        <dl className="space-y-3">
+          {props.availability.map((item) => (
+            <div
+              key={item.kind}
+              className="flex items-start justify-between gap-3"
+            >
+              <dt>{item.kind}</dt>
+              <dd className="text-right text-muted-foreground">
+                {item.state}
+                {item.message ? (
+                  <span className="block">{item.message}</span>
+                ) : null}
+              </dd>
+            </div>
+          ))}
+        </dl>
+      </CardContent>
+    </Card>
+  )
+}
+
+export function ResultOverview(props: InspectedResult) {
+  const { result, attempt } = props
+  return (
+    <div className="grid gap-3 lg:grid-cols-[minmax(0,2fr)_minmax(16rem,1fr)]">
+      <Card>
+        <CardHeader>
+          <CardTitle>Scenario attempt</CardTitle>
+          <CardDescription>
+            Canonical result evidence persisted with this test run.
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <dl className="grid gap-x-6 gap-y-4 sm:grid-cols-2">
+            <Metadata
+              label="Started"
+              value={new Date(attempt.startedAt).toLocaleString()}
+            />
+            <Metadata
+              label="Finished"
+              value={new Date(attempt.finishedAt).toLocaleString()}
+            />
+            <Metadata label="Duration" value={`${attempt.durationMs} ms`} />
+            <Metadata label="Attempt" value={String(attempt.attempt)} />
+            <Metadata
+              label="Execution mode"
+              value={attempt.executionMode ?? 'Not recorded'}
+            />
+            <Metadata
+              label="Cache outcome"
+              value={attempt.cacheOutcome ?? 'Not recorded'}
+            />
+            <Metadata
+              label="Inferences"
+              value={String(attempt.inferenceCount ?? 'Not recorded')}
+            />
+            <Metadata
+              label="Scenario identifier"
+              value={result.scenario.id ?? 'Derived from name'}
+              mono
+            />
+          </dl>
+        </CardContent>
+      </Card>
+      <EvidenceAvailabilityCard availability={attempt.evidenceAvailability} />
+    </div>
+  )
+}
+
+function EmptyEvidence(props: { message: string }) {
+  return (
+    <div className="rounded-lg border border-dashed border-border px-4 py-8 text-center text-muted-foreground">
+      {props.message}
+    </div>
+  )
+}
+
+export function ResultArtifacts(props: ResultArtifactsProps) {
+  if (props.artifacts.length === 0) {
+    return (
+      <EmptyEvidence message="No Test artifacts were retained for this Scenario attempt." />
+    )
+  }
+  return (
+    <div className="space-y-3">
+      {props.artifacts.map((evidence) => {
+        const { artifact } = evidence
+        const artifactHref = artifactUrl(artifact.path)
+        const isImage = artifact.mediaType?.startsWith('image/')
+        return (
+          <Card key={`${artifact.path}:${evidence.stepIndex}`}>
+            <CardHeader>
+              <CardTitle>{artifact.kind}</CardTitle>
+              <CardDescription>{evidence.stepText}</CardDescription>
+            </CardHeader>
+            <CardContent className="grid gap-4 lg:grid-cols-[minmax(0,2fr)_minmax(16rem,1fr)]">
+              {isImage ? (
+                <ButtonLink
+                  variant="ghost"
+                  href={artifactHref}
+                  className="h-auto w-full justify-start overflow-hidden border-border bg-muted/20 p-0 hover:bg-muted/30"
+                >
+                  <img
+                    alt={`${artifact.kind} from ${props.resultState} result for ${props.scenarioName}: ${evidence.stepText}`}
+                    src={artifactHref}
+                    className="max-h-[32rem] w-full object-contain"
+                  />
+                </ButtonLink>
+              ) : (
+                <div className="flex min-h-32 items-center justify-center rounded-md border border-dashed border-border text-muted-foreground">
+                  Preview is unavailable for{' '}
+                  {artifact.mediaType ?? artifact.kind}.
+                </div>
+              )}
+              <div className="space-y-4">
+                <dl className="space-y-3">
+                  <Metadata label="Kind" value={artifact.kind} />
+                  <Metadata
+                    label="Media type"
+                    value={artifact.mediaType ?? 'Not recorded'}
+                  />
+                  <Metadata
+                    label="Captured"
+                    value={new Date(evidence.capturedAt).toLocaleString()}
+                  />
+                  <Metadata
+                    label="Step index"
+                    value={String(evidence.stepIndex)}
+                  />
+                  <Metadata label="Persisted path" value={artifact.path} mono />
+                </dl>
+                <ButtonLink variant="outline" href={artifactHref} download>
+                  Download {artifact.kind}
+                </ButtonLink>
+              </div>
+            </CardContent>
+          </Card>
+        )
+      })}
+    </div>
+  )
+}
+
+export function ResultDiagnostics(props: ResultDiagnosticsProps) {
+  const diagnosticsAvailability = props.availability.find(
+    (item) => item.kind === 'diagnostics',
+  )
+  const availabilityDescription = diagnosticsAvailability?.message
+    ? `${diagnosticsAvailability.state} · ${diagnosticsAvailability.message}`
+    : (diagnosticsAvailability?.state ?? 'Not recorded')
+  return (
+    <div className="space-y-3">
+      <Card>
+        <CardHeader>
+          <CardTitle>Diagnostics availability</CardTitle>
+          <CardDescription>{availabilityDescription}</CardDescription>
+        </CardHeader>
+      </Card>
+      {props.diagnostics.length === 0 ? (
+        <EmptyEvidence message="No Diagnostic entries were retained for this Scenario attempt." />
+      ) : (
+        <ol className="space-y-3" aria-label="Diagnostic entries">
+          {props.diagnostics.map((diagnostic) => (
+            <li key={diagnostic.id}>
+              <Card>
+                <CardHeader>
+                  <CardTitle>{diagnostic.source}</CardTitle>
+                  <CardDescription>
+                    {new Date(diagnostic.occurredAt).toLocaleString()}
+                    {diagnostic.stepText ? ` · ${diagnostic.stepText}` : ''}
+                  </CardDescription>
+                </CardHeader>
+                <CardContent>
+                  <p className="text-destructive">{diagnostic.message}</p>
+                </CardContent>
+              </Card>
+            </li>
+          ))}
+        </ol>
+      )}
+    </div>
+  )
+}

--- a/packages/studio/src/result-evidence-timeline.tsx
+++ b/packages/studio/src/result-evidence-timeline.tsx
@@ -1,0 +1,100 @@
+import type { TestResultState } from '@pickle-spec/runner'
+import { useEffect, useRef } from 'react'
+import { Badge } from './components/ui/badge'
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from './components/ui/card'
+import { relativeTimeLabel, type TimelineEntry } from './result-evidence'
+
+type ResultEvidenceTimelineProps = {
+  entries: readonly TimelineEntry[]
+  startedAt: string
+  state: TestResultState
+}
+
+export function ResultEvidenceTimeline(props: ResultEvidenceTimelineProps) {
+  const causalRef = useRef<HTMLLIElement>(null)
+  const causalEntry = props.entries.find((entry) => entry.causal)
+  useEffect(() => {
+    causalRef.current?.scrollIntoView({ block: 'center', inline: 'nearest' })
+  }, [])
+  const causalPointUnavailable =
+    !causalEntry &&
+    (props.state === 'failed' || props.state === 'infrastructure-error')
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Causal evidence timeline</CardTitle>
+        <CardDescription>
+          Steps, Run events, Diagnostic entries, and Test artifacts share one
+          clock.
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        {causalPointUnavailable ? (
+          <p role="status" className="mb-3 text-muted-foreground">
+            Causal point unavailable. The retained evidence does not identify a
+            failing step or Diagnostic entry.
+          </p>
+        ) : null}
+        <ol
+          aria-label="Causal evidence timeline"
+          className="relative space-y-0 before:absolute before:top-2 before:bottom-2 before:left-[5.75rem] before:w-px before:bg-border sm:before:left-[7.75rem]"
+        >
+          {props.entries.map((entry) => (
+            <li
+              key={entry.id}
+              ref={entry.causal ? causalRef : undefined}
+              aria-current={entry.causal ? 'true' : undefined}
+              className="relative grid grid-cols-[5rem_minmax(0,1fr)] gap-4 py-2 sm:grid-cols-[7rem_minmax(0,1fr)]"
+            >
+              <time className="pr-3 text-right font-mono text-[0.625rem] text-muted-foreground tabular-nums">
+                {relativeTimeLabel(entry.occurredAt, props.startedAt)}
+              </time>
+              <span
+                aria-hidden="true"
+                className={`absolute top-[0.875rem] left-[5.5rem] size-2 rounded-full border sm:left-[7.5rem] ${
+                  entry.causal
+                    ? 'border-foreground/35 bg-foreground'
+                    : 'border-border bg-card'
+                }`}
+              />
+              <div
+                className={`min-w-0 rounded-md border px-3 py-2 ${
+                  entry.causal
+                    ? 'border-foreground/25 bg-muted/30'
+                    : 'border-border bg-muted/20'
+                }`}
+              >
+                <div className="flex flex-wrap items-center gap-2">
+                  <Badge>{entry.kind}</Badge>
+                  {entry.causal ? (
+                    <span className="font-mono text-[0.625rem] text-foreground">
+                      Causal point
+                    </span>
+                  ) : null}
+                </div>
+                <p className="mt-1 font-medium">{entry.title}</p>
+                {entry.detail ? (
+                  <p
+                    className={`mt-1 break-words ${
+                      entry.causal
+                        ? 'text-destructive'
+                        : 'text-muted-foreground'
+                    }`}
+                  >
+                    {entry.detail}
+                  </p>
+                ) : null}
+              </div>
+            </li>
+          ))}
+        </ol>
+      </CardContent>
+    </Card>
+  )
+}

--- a/packages/studio/src/result-evidence.test.ts
+++ b/packages/studio/src/result-evidence.test.ts
@@ -1,0 +1,155 @@
+import { expect, test } from 'bun:test'
+import type {
+  RunEvent,
+  ScenarioAttempt,
+  TestResult,
+  TestResultState,
+} from '@pickle-spec/runner'
+import {
+  defaultResultInspectorTab,
+  findInspectedResult,
+  timelineFor,
+} from './result-evidence'
+import { historyLocationHref, parseHistoryLocation } from './result-inspection'
+import type { StudioRunSnapshot } from './server'
+
+const evidenceAvailability: ScenarioAttempt['evidenceAvailability'] = [
+  { kind: 'screenshot', state: 'not-requested' },
+  { kind: 'trace', state: 'not-requested' },
+  { kind: 'recording', state: 'not-requested' },
+  { kind: 'device-log', state: 'not-requested' },
+  { kind: 'diagnostics', state: 'not-supported' },
+]
+
+function attempt(
+  attemptNumber: number,
+  state: TestResultState = 'passed',
+): ScenarioAttempt {
+  return {
+    attempt: attemptNumber,
+    startedAt: '2026-08-22T12:00:00.000Z',
+    finishedAt: '2026-08-22T12:00:01.000Z',
+    durationMs: 1_000,
+    state,
+    steps: [],
+    evidenceAvailability,
+  }
+}
+
+function result(
+  specificationUri: string,
+  examplesRowId: string,
+  attempts: ScenarioAttempt[],
+): TestResult {
+  return {
+    schemaVersion: 2,
+    specification: { name: specificationUri, uri: specificationUri },
+    scenario: {
+      id: 'scenario-outline',
+      name: 'Pay for each order',
+      examplesRowId,
+    },
+    executionTargetProfile: { id: 'chrome' },
+    state: attempts.at(-1)?.state ?? 'cancelled',
+    startedAt: attempts[0]?.startedAt ?? '2026-08-22T12:00:00.000Z',
+    finishedAt: attempts.at(-1)?.finishedAt ?? '2026-08-22T12:00:01.000Z',
+    durationMs: attempts.reduce((total, item) => total + item.durationMs, 0),
+    attempts,
+  }
+}
+
+function snapshot(
+  results: TestResult[],
+  events: RunEvent[] = [],
+): StudioRunSnapshot {
+  return {
+    id: 'run-78',
+    events,
+    manifest: {
+      schemaVersion: 2,
+      id: 'run-78',
+      startedAt: '2026-08-22T12:00:00.000Z',
+      finishedAt: '2026-08-22T12:00:02.000Z',
+      state: 'failed',
+      results,
+    },
+  }
+}
+
+function scenarioStarted(examplesRowId: string, sequence: number): RunEvent {
+  return {
+    schemaVersion: 2,
+    sequence,
+    occurredAt: `2026-08-22T12:00:00.00${sequence}Z`,
+    type: 'scenario-started',
+    scenario: {
+      id: 'scenario-outline',
+      name: 'Pay for each order',
+      examplesRowId,
+    },
+    executionTargetProfile: { id: 'chrome' },
+    scope: {
+      scenarioId: 'scenario-outline',
+      examplesRowId,
+      executionTargetProfileId: 'chrome',
+      attempt: 1,
+    },
+  }
+}
+
+test('selects one persisted attempt by Specification and Examples-row identity', () => {
+  const expectedAttempt = attempt(1, 'failed')
+  const run = snapshot([
+    result('features/first.feature', 'row-1', [attempt(1)]),
+    result('features/second.feature', 'row-2', [expectedAttempt, attempt(2)]),
+  ])
+
+  expect(
+    findInspectedResult(run, {
+      specificationUri: 'features/second.feature',
+      runId: run.id,
+      scenarioId: 'scenario-outline',
+      examplesRowId: 'row-2',
+      profileId: 'chrome',
+      attempt: 1,
+    })?.attempt,
+  ).toBe(expectedAttempt)
+})
+
+test('keeps Run events scoped to the selected Examples row', () => {
+  const selectedAttempt = attempt(1, 'failed')
+  const entries = timelineFor(
+    [scenarioStarted('row-1', 1), scenarioStarted('row-2', 2)],
+    selectedAttempt,
+    {
+      specificationUri: 'features/checkout.feature',
+      runId: 'run-78',
+      scenarioId: 'scenario-outline',
+      examplesRowId: 'row-2',
+      profileId: 'chrome',
+      attempt: 1,
+    },
+  )
+
+  expect(entries.map((entry) => entry.detail)).toEqual(['Sequence 2'])
+  expect(entries.some((entry) => entry.causal)).toBe(false)
+})
+
+test('opens failed attempts in Timeline and passed attempts in Overview', () => {
+  expect(defaultResultInspectorTab('infrastructure-error')).toBe('timeline')
+  expect(defaultResultInspectorTab('passed')).toBe('overview')
+})
+
+test('round-trips durable result identity through a deep link', () => {
+  const location = {
+    specificationUri: 'features/checkout.feature',
+    runId: 'run-78',
+    scenarioId: 'scenario-outline',
+    examplesRowId: 'row-2',
+    profileId: 'chrome',
+    attempt: 2,
+    tab: 'diagnostics' as const,
+  }
+
+  expect(parseHistoryLocation(historyLocationHref(location))).toEqual(location)
+})

--- a/packages/studio/src/result-evidence.ts
+++ b/packages/studio/src/result-evidence.ts
@@ -1,0 +1,204 @@
+import type {
+  RunEvent,
+  ScenarioAttempt,
+  TestArtifact,
+  TestResult,
+  TestResultState,
+} from '@pickle-spec/runner'
+import type {
+  ResultInspectionLocation,
+  ResultInspectorTab,
+} from './result-inspection'
+import type { StudioRunSnapshot } from './server'
+
+export type InspectedResult = {
+  result: TestResult
+  attempt: ScenarioAttempt
+}
+
+export type ArtifactEvidence = {
+  artifact: TestArtifact
+  stepIndex: number
+  stepText: string
+  capturedAt: string
+}
+
+export type DiagnosticEvidence = {
+  id: string
+  occurredAt: string
+  message: string
+  source: 'Scenario attempt' | 'Step'
+  stepText?: string
+}
+
+export type TimelineEntry = {
+  id: string
+  occurredAt: string
+  kind: 'Step' | 'Run event' | 'Diagnostic entry' | 'Test artifact'
+  title: string
+  detail?: string
+  causal?: boolean
+}
+
+export function defaultResultInspectorTab(
+  state: TestResultState,
+): ResultInspectorTab {
+  return state === 'failed' || state === 'infrastructure-error'
+    ? 'timeline'
+    : 'overview'
+}
+
+export function findInspectedResult(
+  snapshot: StudioRunSnapshot,
+  location: ResultInspectionLocation,
+): InspectedResult | undefined {
+  const result = snapshot.manifest?.results.find(
+    (candidate) =>
+      candidate.specification.uri === location.specificationUri &&
+      (candidate.scenario.id ?? candidate.scenario.name) ===
+        location.scenarioId &&
+      candidate.scenario.examplesRowId === location.examplesRowId &&
+      candidate.executionTargetProfile.id === location.profileId,
+  )
+  const attempt = result?.attempts.find(
+    (candidate) => candidate.attempt === location.attempt,
+  )
+  return result && attempt ? { result, attempt } : undefined
+}
+
+export function relativeTimeLabel(
+  occurredAt: string,
+  startedAt: string,
+): string {
+  const elapsedMs = Math.max(0, Date.parse(occurredAt) - Date.parse(startedAt))
+  return `+${(elapsedMs / 1_000).toFixed(3)} s`
+}
+
+function eventTitle(event: RunEvent): string {
+  return event.type
+    .split('-')
+    .map((part) => part[0]?.toUpperCase() + part.slice(1))
+    .join(' ')
+}
+
+function scopedEvents(
+  events: readonly RunEvent[],
+  location: ResultInspectionLocation,
+): RunEvent[] {
+  return events.filter(
+    (event) =>
+      'scope' in event &&
+      event.scope.scenarioId === location.scenarioId &&
+      event.scope.examplesRowId === location.examplesRowId &&
+      event.scope.executionTargetProfileId === location.profileId &&
+      event.scope.attempt === location.attempt,
+  )
+}
+
+export function artifactsFor(attempt: ScenarioAttempt): ArtifactEvidence[] {
+  return attempt.steps.flatMap((step) =>
+    (step.artifacts ?? []).map((artifact) => ({
+      artifact,
+      stepIndex: step.index,
+      stepText: `${step.step.keyword.trim()} ${step.step.text}`,
+      capturedAt: step.finishedAt,
+    })),
+  )
+}
+
+export function diagnosticsFor(attempt: ScenarioAttempt): DiagnosticEvidence[] {
+  const diagnostics: DiagnosticEvidence[] = attempt.steps.flatMap((step) =>
+    step.message
+      ? [
+          {
+            id: `step-${step.index}`,
+            occurredAt: step.finishedAt,
+            message: step.message,
+            source: 'Step' as const,
+            stepText: `${step.step.keyword.trim()} ${step.step.text}`,
+          },
+        ]
+      : [],
+  )
+  if (
+    attempt.message &&
+    !diagnostics.some((diagnostic) => diagnostic.message === attempt.message)
+  ) {
+    diagnostics.push({
+      id: 'attempt',
+      occurredAt: attempt.finishedAt,
+      message: attempt.message,
+      source: 'Scenario attempt',
+    })
+  }
+  return diagnostics
+}
+
+export function timelineFor(
+  events: readonly RunEvent[],
+  attempt: ScenarioAttempt,
+  location: ResultInspectionLocation,
+): TimelineEntry[] {
+  const failedStep = attempt.steps.find(
+    (step) => step.state === 'failed' || step.state === 'infrastructure-error',
+  )
+  const causalStepId = failedStep ? `step-${failedStep.index}` : undefined
+  const stepEntries: TimelineEntry[] = attempt.steps.map((step) => ({
+    id: `step-${step.index}`,
+    occurredAt: step.finishedAt,
+    kind: 'Step',
+    title: `${step.step.keyword.trim()} ${step.step.text}`,
+    detail: `${step.state} · ${step.durationMs} ms`,
+    causal: causalStepId === `step-${step.index}`,
+  }))
+  const eventEntries: TimelineEntry[] = scopedEvents(events, location).map(
+    (event) => ({
+      id: `event-${event.sequence}`,
+      occurredAt: event.occurredAt,
+      kind: 'Run event',
+      title: eventTitle(event),
+      detail: `Sequence ${event.sequence}`,
+    }),
+  )
+  const diagnosticEntries: TimelineEntry[] = diagnosticsFor(attempt).map(
+    (diagnostic) => ({
+      id: `diagnostic-${diagnostic.id}`,
+      occurredAt: diagnostic.occurredAt,
+      kind: 'Diagnostic entry',
+      title: diagnostic.message,
+      detail: diagnostic.stepText ?? diagnostic.source,
+      causal: !causalStepId && diagnostic.id === 'attempt',
+    }),
+  )
+  const artifactEntries: TimelineEntry[] = artifactsFor(attempt).map(
+    (artifact, index) => ({
+      id: `artifact-${artifact.stepIndex}-${index}`,
+      occurredAt: artifact.capturedAt,
+      kind: 'Test artifact',
+      title: artifact.artifact.kind,
+      detail: artifact.stepText,
+    }),
+  )
+  const kindOrder: Record<TimelineEntry['kind'], number> = {
+    Step: 0,
+    'Run event': 1,
+    'Diagnostic entry': 2,
+    'Test artifact': 3,
+  }
+  const entries = [
+    ...stepEntries,
+    ...eventEntries,
+    ...diagnosticEntries,
+    ...artifactEntries,
+  ].sort(
+    (left, right) =>
+      Date.parse(left.occurredAt) - Date.parse(right.occurredAt) ||
+      kindOrder[left.kind] - kindOrder[right.kind] ||
+      left.id.localeCompare(right.id),
+  )
+  return entries
+}
+
+export function artifactUrl(path: string): string {
+  return `/api/artifact?path=${encodeURIComponent(path)}`
+}

--- a/packages/studio/src/result-inspection.ts
+++ b/packages/studio/src/result-inspection.ts
@@ -1,0 +1,77 @@
+export const resultInspectorTabs = [
+  'overview',
+  'timeline',
+  'artifacts',
+  'diagnostics',
+] as const
+
+export type ResultInspectorTab = (typeof resultInspectorTabs)[number]
+
+export type HistoryLocation = {
+  specificationUri: string
+  runId: string
+  scenarioId?: string
+  examplesRowId?: string
+  profileId?: string
+  attempt?: number
+  tab?: ResultInspectorTab
+}
+
+export type ResultInspectionLocation = HistoryLocation & {
+  scenarioId: string
+  profileId: string
+  attempt: number
+}
+
+export function parseHistoryLocation(
+  search: string,
+): HistoryLocation | undefined {
+  const parameters = new URLSearchParams(search)
+  const specificationUri = parameters.get('specification')
+  const runId = parameters.get('run')
+  if (!specificationUri || !runId) return undefined
+
+  const scenarioId = parameters.get('scenario') ?? undefined
+  const examplesRowId = parameters.get('examplesRow') ?? undefined
+  const profileId = parameters.get('profile') ?? undefined
+  const attemptValue = Number(parameters.get('attempt'))
+  const requestedTab = parameters.get('tab')
+  const tab = resultInspectorTabs.find((value) => value === requestedTab)
+
+  return {
+    specificationUri,
+    runId,
+    scenarioId,
+    examplesRowId,
+    profileId,
+    attempt:
+      scenarioId &&
+      profileId &&
+      Number.isInteger(attemptValue) &&
+      attemptValue > 0
+        ? attemptValue
+        : undefined,
+    tab,
+  }
+}
+
+export function historyLocationHref(location: HistoryLocation): string {
+  const parameters = new URLSearchParams({
+    specification: location.specificationUri,
+    run: location.runId,
+  })
+  if (location.scenarioId) parameters.set('scenario', location.scenarioId)
+  if (location.examplesRowId) {
+    parameters.set('examplesRow', location.examplesRowId)
+  }
+  if (location.profileId) parameters.set('profile', location.profileId)
+  if (location.attempt) parameters.set('attempt', String(location.attempt))
+  if (location.tab) parameters.set('tab', location.tab)
+  return `?${parameters}`
+}
+
+export function isResultInspection(
+  location: HistoryLocation | undefined,
+): location is ResultInspectionLocation {
+  return Boolean(location?.scenarioId && location.profileId && location.attempt)
+}

--- a/packages/studio/src/result-inspector.tsx
+++ b/packages/studio/src/result-inspector.tsx
@@ -1,0 +1,171 @@
+import { useEffect, useState } from 'react'
+import { Badge } from './components/ui/badge'
+import { Button } from './components/ui/button'
+import { LoadingState } from './components/ui/loading-state'
+import { ResultMark } from './components/ui/result-mark'
+import { Tabs, TabsContent, TabsList, TabsTrigger } from './components/ui/tabs'
+import {
+  artifactsFor,
+  defaultResultInspectorTab,
+  diagnosticsFor,
+  findInspectedResult,
+  timelineFor,
+} from './result-evidence'
+import {
+  ResultArtifacts,
+  ResultDiagnostics,
+  ResultOverview,
+} from './result-evidence-panels'
+import { ResultEvidenceTimeline } from './result-evidence-timeline'
+import type {
+  ResultInspectionLocation,
+  ResultInspectorTab,
+} from './result-inspection'
+import { reasonMessage, resultBadgeVariant } from './result-presentation'
+import type { StudioRunSnapshot } from './server'
+
+type StudioApi = <Value>(path: string, init?: RequestInit) => Promise<Value>
+
+type ResultInspectorProps = {
+  api: StudioApi
+  location: ResultInspectionLocation
+  onBack: () => void
+  onTabChange: (tab: ResultInspectorTab) => void
+}
+
+export function ResultInspector(props: ResultInspectorProps) {
+  const [snapshot, setSnapshot] = useState<StudioRunSnapshot>()
+  const [error, setError] = useState<string>()
+
+  useEffect(() => {
+    let cancelled = false
+    setSnapshot(undefined)
+    setError(undefined)
+    props
+      .api<StudioRunSnapshot>(
+        `/api/runs/${encodeURIComponent(props.location.runId)}`,
+      )
+      .then(
+        (value) => {
+          if (!cancelled) setSnapshot(value)
+        },
+        (reason: unknown) => {
+          if (!cancelled) setError(reasonMessage(reason))
+        },
+      )
+    return () => {
+      cancelled = true
+    }
+  }, [props.api, props.location.runId])
+
+  const inspected = snapshot
+    ? findInspectedResult(snapshot, props.location)
+    : undefined
+
+  if (error) {
+    return (
+      <div className="p-6">
+        <p role="alert" className="text-sm text-destructive">
+          {error}
+        </p>
+      </div>
+    )
+  }
+  if (!snapshot) {
+    return (
+      <div className="p-6">
+        <LoadingState label="Opening Test result" />
+      </div>
+    )
+  }
+  if (!inspected) {
+    return (
+      <div className="space-y-3 p-6">
+        <p role="alert" className="text-sm text-destructive">
+          This Scenario attempt is not available in test run {snapshot.id}.
+        </p>
+        <Button type="button" variant="outline" onClick={props.onBack}>
+          Back to run
+        </Button>
+      </div>
+    )
+  }
+
+  const activeTab =
+    props.location.tab ?? defaultResultInspectorTab(inspected.attempt.state)
+  const artifacts = artifactsFor(inspected.attempt)
+  const diagnostics = diagnosticsFor(inspected.attempt)
+  const timeline = timelineFor(
+    snapshot.events,
+    inspected.attempt,
+    props.location,
+  )
+  return (
+    <section
+      aria-labelledby="result-inspector-title"
+      className="min-h-0 flex-1 overflow-auto px-4 py-4 sm:px-6"
+    >
+      <header className="sticky top-0 z-10 -mx-4 mb-4 flex flex-wrap items-start justify-between gap-3 border-b border-border bg-background px-4 pb-4 sm:-mx-6 sm:px-6">
+        <div className="min-w-0 space-y-2">
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            onClick={props.onBack}
+          >
+            Back to run
+          </Button>
+          <div className="flex min-w-0 flex-wrap items-center gap-2">
+            <h3 id="result-inspector-title" className="text-lg font-medium">
+              {inspected.result.scenario.name} · {inspected.attempt.state} ·{' '}
+              {inspected.result.executionTargetProfile.id}
+            </h3>
+            <Badge variant={resultBadgeVariant(inspected.attempt.state)}>
+              <ResultMark state={inspected.attempt.state} />
+              {inspected.attempt.state}
+            </Badge>
+          </div>
+          <p className="font-mono text-xs text-muted-foreground">
+            Test run {snapshot.id} · Attempt {inspected.attempt.attempt}
+          </p>
+        </div>
+      </header>
+      <Tabs
+        value={activeTab}
+        onValueChange={(value) =>
+          props.onTabChange(value as ResultInspectorTab)
+        }
+      >
+        <TabsList variant="line" aria-label="Test result evidence">
+          <TabsTrigger value="overview">Overview</TabsTrigger>
+          <TabsTrigger value="timeline">Timeline</TabsTrigger>
+          <TabsTrigger value="artifacts">Artifacts</TabsTrigger>
+          <TabsTrigger value="diagnostics">Diagnostics</TabsTrigger>
+        </TabsList>
+        <TabsContent value="overview">
+          <ResultOverview {...inspected} />
+        </TabsContent>
+        <TabsContent value="timeline">
+          <ResultEvidenceTimeline
+            entries={timeline}
+            startedAt={inspected.attempt.startedAt}
+            state={inspected.attempt.state}
+          />
+        </TabsContent>
+        <TabsContent value="artifacts">
+          <ResultArtifacts
+            artifacts={artifacts}
+            scenarioName={inspected.result.scenario.name}
+            resultState={inspected.attempt.state}
+          />
+        </TabsContent>
+        <TabsContent value="diagnostics">
+          <ResultDiagnostics
+            diagnostics={diagnostics}
+            availability={inspected.attempt.evidenceAvailability}
+          />
+        </TabsContent>
+      </Tabs>
+    </section>
+  )
+}

--- a/packages/studio/src/result-presentation.ts
+++ b/packages/studio/src/result-presentation.ts
@@ -1,0 +1,13 @@
+import type { TestResultState } from '@pickle-spec/runner'
+
+type ResultBadgeVariant = 'default' | 'failed' | 'passed'
+
+export function resultBadgeVariant(state: TestResultState): ResultBadgeVariant {
+  if (state === 'failed' || state === 'infrastructure-error') return 'failed'
+  if (state === 'passed') return 'passed'
+  return 'default'
+}
+
+export function reasonMessage(reason: unknown): string {
+  return reason instanceof Error ? reason.message : String(reason)
+}


### PR DESCRIPTION
## Summary

- Add result evidence panels and timeline views in Studio
- Improve result inspection and presentation flows
- Add tab support and CLI/Studio coverage for evidence inspection

Closes #78

## Testing

- Added and updated unit tests for result evidence and Studio integration
- Not run (not requested)