### PR TITLE
Implement issues 81–87 across CLI, runner, mobile, and Studio

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,18 @@ pickle run "features/**/*.feature" --state draft
 pickle run "features/**/*.feature" --shard 1/3
 pickle run "features/**/*.feature" --concurrency 5 --retries 1
 pickle run "features/**/*.feature" --screenshot on-step
+pickle run --application-output stdout --application-output stderr
+pickle run --evidence always
 ```
+
+Evidence persistence defaults to `on-failure`. Configure
+`evidence.persistence` for every run, override it with
+`executionTargetProfiles.<id>.evidence.persistence`, or use `--evidence` for
+one run. The supported policies are `off`, `on-failure`, and `always`; results
+and run events are persisted under every policy. Managed application stdout and
+stderr are independent diagnostic streams. Enable them under `server.output`,
+per profile under `applicationOutput`, or for one run with repeatable
+`--application-output` flags.
 
 The default reporter is for people. It groups every Test result by Specification
 URI, Specification, and Scenario, then reports the selected counts and timing:
@@ -209,6 +220,11 @@ web/mobile benchmark, budgets, and rerun protocol.
 
 Every `pickle run` writes an immutable test run under `~/.pickle/projects/<project-name>-<project-key>/runs/`. Pickle Spec does not create runtime folders inside the project.
 
+Test runs have no deletion policy by default. Studio shows total local storage,
+warns at 5 GB, and lets you pin complete runs before applying an explicitly
+configured age or size limit. Active and pinned runs are never retention
+candidates.
+
 To create a selective rerun from an earlier test run, use:
 
 ```bash
@@ -223,7 +239,7 @@ A rerun creates a new test run and records `sourceRunId`. It never changes the s
 To move a test run between machines, export and import a run archive:
 
 ```bash
-pickle export <run-id> --archive run.archive.json
+pickle export <run-id> --output archive=run.archive.json
 pickle import run.archive.json
 ```
 
@@ -240,11 +256,25 @@ Comparison matches results by Scenario identifier and execution target profile i
 To create a self-contained HTML export, use:
 
 ```bash
-pickle export <run-id> --html report.html
-pickle export <run-id> --html report.html --all-artifacts
+pickle export <run-id> --output html=report.html
+pickle export <run-id> --output html=report.html --all-artifacts
 ```
 
 HTML export includes failure artifacts by default. Successful Adaptive fallback uses the normal artifact policy rather than a special category. The manifest includes execution mode, Cache outcome, and inference count. `--all-artifacts` embeds every available test artifact and prints a size warning when the export exceeds 10 MB.
+
+Both `pickle run` and `pickle export` accept repeatable `--output format=path`
+requests for `json`, `ndjson`, `junit`, `html`, `archive`, and `allure`.
+Each destination is published independently after the complete output is staged.
+Existing destinations are preserved unless `--force` is explicit. For example:
+
+```bash
+pickle run --output junit=results.xml --output allure=allure-results
+pickle export <run-id> --output json=run.json --output html=report.html
+```
+
+Allure output is a raw `allure-results` directory that can be consumed by
+Allure 2 or Allure 3. Pickle Spec does not bundle an Allure report renderer,
+history manager, categories configuration, or runtime dependency.
 
 ## Add a custom adapter
 

--- a/apps/example/package.json
+++ b/apps/example/package.json
@@ -8,7 +8,7 @@
     "run:regression": "pickle run --suite regression",
     "migrate": "pickle migrate",
     "smoke": "pickle run --suite smoke --profile web",
-    "export": "pickle export 83c9a5e9-0384-466e-ae38-bc623214b9c3 --html report.html",
+    "export": "pickle export 83c9a5e9-0384-466e-ae38-bc623214b9c3 --output html=report.html",
     "studio": "pickle studio"
   },
   "dependencies": {

--- a/packages/cli/src/application-diagnostics.test.ts
+++ b/packages/cli/src/application-diagnostics.test.ts
@@ -1,0 +1,329 @@
+import { expect, test } from 'bun:test'
+import type { RunEvent } from '@pickle-spec/runner'
+import { createApplicationDiagnosticBuffer } from './application-diagnostics'
+
+const scenario = { id: 'checkout', name: 'Checkout succeeds' }
+const executionTargetProfile = { id: 'desktop', adapter: 'web' }
+const scope = {
+  scenarioId: 'checkout',
+  executionTargetProfileId: 'desktop',
+  attempt: 1,
+}
+
+type RunEventData<Event extends RunEvent> = Event extends RunEvent
+  ? Omit<Event, 'schemaVersion' | 'sequence' | 'occurredAt'>
+  : never
+
+function event(input: RunEventData<RunEvent>) {
+  return {
+    schemaVersion: 2,
+    sequence: 1,
+    occurredAt: '2026-08-23T12:00:00.000Z',
+    ...input,
+  } as RunEvent
+}
+
+test('correlates managed output to an active step without changing its state', () => {
+  const diagnostics = createApplicationDiagnosticBuffer({
+    profiles: { stdout: ['desktop'], stderr: [] },
+    availability: { stdout: 'available', stderr: 'not-requested' },
+  })
+  diagnostics.project(
+    event({
+      type: 'scenario-started',
+      scenario,
+      executionTargetProfile,
+      scope,
+    }),
+  )
+  diagnostics.project(
+    event({
+      type: 'step-started',
+      scenario,
+      executionTargetProfile,
+      scope: { ...scope, stepIndex: 0 },
+      step: { keyword: 'When', text: 'I pay', type: 'action' },
+    }),
+  )
+  diagnostics.record({
+    occurredAt: '2026-08-23T12:00:00.100Z',
+    stream: 'stdout',
+    line: 'payment accepted',
+  })
+
+  const projected = diagnostics.project(
+    event({
+      type: 'step-finished',
+      scenario,
+      executionTargetProfile,
+      scope: { ...scope, stepIndex: 0 },
+      result: {
+        index: 0,
+        startedAt: '2026-08-23T12:00:00.000Z',
+        finishedAt: '2026-08-23T12:00:00.200Z',
+        durationMs: 200,
+        step: { keyword: 'When', text: 'I pay', type: 'action' },
+        state: 'passed',
+        resolvedActions: [],
+      },
+    }),
+  )
+
+  expect(projected.type).toBe('step-finished')
+  if (projected.type !== 'step-finished') throw new Error('unexpected event')
+  expect(projected.result.state).toBe('passed')
+  expect(projected.result.diagnostics).toEqual([
+    {
+      occurredAt: '2026-08-23T12:00:00.100Z',
+      level: 'info',
+      origin: 'application',
+      stream: 'stdout',
+      message: 'payment accepted',
+      scenarioId: 'checkout',
+      scenarioName: 'Checkout succeeds',
+      stepIndex: 0,
+      stepText: 'When I pay',
+      executionTargetProfileId: 'desktop',
+    },
+  ])
+
+  const finished = diagnostics.project(
+    event({
+      type: 'scenario-finished',
+      specification: { name: 'Checkout', uri: 'checkout.feature' },
+      scenario,
+      executionTargetProfile,
+      scope,
+      attempt: {
+        attempt: 1,
+        startedAt: '2026-08-23T12:00:00.000Z',
+        finishedAt: '2026-08-23T12:00:01.000Z',
+        durationMs: 1_000,
+        state: 'failed',
+        steps: [{ ...projected.result, diagnostics: undefined }],
+        evidenceAvailability: [
+          { kind: 'screenshot', state: 'not-requested' },
+          { kind: 'trace', state: 'not-requested' },
+          { kind: 'recording', state: 'not-supported' },
+          { kind: 'device-log', state: 'not-supported' },
+          { kind: 'diagnostics', state: 'not-requested' },
+        ],
+      },
+    }),
+  )
+
+  if (finished.type !== 'scenario-finished') throw new Error('unexpected event')
+  expect(finished.attempt.steps[0]?.diagnostics).toEqual(
+    projected.result.diagnostics,
+  )
+  expect(
+    finished.attempt.evidenceAvailability.find(
+      (item) => item.kind === 'diagnostics',
+    ),
+  ).toEqual({ kind: 'diagnostics', state: 'available' })
+})
+
+test('attaches startup output to the first matching Scenario attempt', () => {
+  const diagnostics = createApplicationDiagnosticBuffer({
+    profiles: { stdout: [], stderr: ['desktop'] },
+    availability: { stdout: 'not-requested', stderr: 'available' },
+  })
+  diagnostics.record({
+    occurredAt: '2026-08-23T11:59:59.000Z',
+    stream: 'stderr',
+    line: 'warming database pool',
+  })
+  diagnostics.project(
+    event({
+      type: 'scenario-started',
+      scenario,
+      executionTargetProfile,
+      scope,
+    }),
+  )
+
+  const projected = diagnostics.project(
+    event({
+      type: 'scenario-finished',
+      specification: { name: 'Checkout', uri: 'checkout.feature' },
+      scenario,
+      executionTargetProfile,
+      scope,
+      attempt: {
+        attempt: 1,
+        startedAt: '2026-08-23T12:00:00.000Z',
+        finishedAt: '2026-08-23T12:00:01.000Z',
+        durationMs: 1_000,
+        state: 'passed',
+        steps: [],
+        evidenceAvailability: [
+          { kind: 'screenshot', state: 'not-requested' },
+          { kind: 'trace', state: 'not-requested' },
+          { kind: 'recording', state: 'not-supported' },
+          { kind: 'device-log', state: 'not-supported' },
+          { kind: 'diagnostics', state: 'not-requested' },
+        ],
+      },
+    }),
+  )
+
+  if (projected.type !== 'scenario-finished')
+    throw new Error('unexpected event')
+  expect(projected.attempt.diagnostics?.[0]).toMatchObject({
+    origin: 'application',
+    stream: 'stderr',
+    executionTargetProfileId: 'desktop',
+  })
+  expect(projected.attempt.diagnostics?.[0]?.scenarioId).toBeUndefined()
+  expect(
+    projected.attempt.evidenceAvailability.find(
+      (item) => item.kind === 'diagnostics',
+    ),
+  ).toEqual({ kind: 'diagnostics', state: 'available' })
+  expect(projected.attempt.applicationOutputAvailability).toEqual([
+    { stream: 'stdout', state: 'not-requested' },
+    { stream: 'stderr', state: 'available' },
+  ])
+})
+
+test('does not duplicate shared process output across concurrent Scenarios', () => {
+  const live: unknown[] = []
+  const diagnostics = createApplicationDiagnosticBuffer({
+    profiles: { stdout: ['desktop'], stderr: [] },
+    availability: { stdout: 'available', stderr: 'not-requested' },
+    onDiagnostic: (entry) => live.push(entry),
+  })
+  const otherScenario = { id: 'refund', name: 'Refund succeeds' }
+  const otherScope = { ...scope, scenarioId: 'refund' }
+  diagnostics.project(
+    event({
+      type: 'scenario-started',
+      scenario,
+      executionTargetProfile,
+      scope,
+    }),
+  )
+  diagnostics.project(
+    event({
+      type: 'scenario-started',
+      scenario: otherScenario,
+      executionTargetProfile,
+      scope: otherScope,
+    }),
+  )
+  diagnostics.record({
+    occurredAt: '2026-08-23T12:00:00.100Z',
+    stream: 'stdout',
+    line: 'shared server line',
+  })
+
+  const first = diagnostics.project(
+    event({
+      type: 'scenario-finished',
+      specification: { name: 'Checkout', uri: 'checkout.feature' },
+      scenario,
+      executionTargetProfile,
+      scope,
+      attempt: {
+        attempt: 1,
+        startedAt: '2026-08-23T12:00:00.000Z',
+        finishedAt: '2026-08-23T12:00:01.000Z',
+        durationMs: 1_000,
+        state: 'failed',
+        steps: [],
+        evidenceAvailability: [
+          { kind: 'screenshot', state: 'not-requested' },
+          { kind: 'trace', state: 'not-requested' },
+          { kind: 'recording', state: 'not-requested' },
+          { kind: 'device-log', state: 'not-requested' },
+          { kind: 'diagnostics', state: 'not-requested' },
+        ],
+      },
+    }),
+  )
+  const second = diagnostics.project(
+    event({
+      type: 'scenario-finished',
+      specification: { name: 'Checkout', uri: 'checkout.feature' },
+      scenario: otherScenario,
+      executionTargetProfile,
+      scope: otherScope,
+      attempt: {
+        attempt: 1,
+        startedAt: '2026-08-23T12:00:00.000Z',
+        finishedAt: '2026-08-23T12:00:01.000Z',
+        durationMs: 1_000,
+        state: 'passed',
+        steps: [],
+        evidenceAvailability: [
+          { kind: 'screenshot', state: 'not-requested' },
+          { kind: 'trace', state: 'not-requested' },
+          { kind: 'recording', state: 'not-requested' },
+          { kind: 'device-log', state: 'not-requested' },
+          { kind: 'diagnostics', state: 'not-requested' },
+        ],
+      },
+    }),
+  )
+  if (first.type !== 'scenario-finished' || second.type !== 'scenario-finished')
+    throw new Error('unexpected event')
+
+  expect(first.attempt.diagnostics).toEqual([
+    expect.objectContaining({ message: 'shared server line' }),
+  ])
+  expect(first.attempt.diagnostics?.[0]?.scenarioId).toBeUndefined()
+  expect(second.attempt.diagnostics).toBeUndefined()
+  expect(live).toEqual([expect.objectContaining({ profileId: 'desktop' })])
+  expect('scope' in (live[0] as object)).toBe(false)
+})
+
+test('reports reused managed output as not-supported when no diagnostics exist', () => {
+  const diagnostics = createApplicationDiagnosticBuffer({
+    profiles: { stdout: ['desktop'], stderr: [] },
+    availability: { stdout: 'not-supported', stderr: 'not-requested' },
+  })
+  diagnostics.project(
+    event({
+      type: 'scenario-started',
+      scenario,
+      executionTargetProfile,
+      scope,
+    }),
+  )
+  const projected = diagnostics.project(
+    event({
+      type: 'scenario-finished',
+      specification: { name: 'Checkout', uri: 'checkout.feature' },
+      scenario,
+      executionTargetProfile,
+      scope,
+      attempt: {
+        attempt: 1,
+        startedAt: '2026-08-23T12:00:00.000Z',
+        finishedAt: '2026-08-23T12:00:01.000Z',
+        durationMs: 1_000,
+        state: 'passed',
+        steps: [],
+        evidenceAvailability: [
+          { kind: 'screenshot', state: 'not-requested' },
+          { kind: 'trace', state: 'not-requested' },
+          { kind: 'recording', state: 'not-supported' },
+          { kind: 'device-log', state: 'not-supported' },
+          { kind: 'diagnostics', state: 'not-requested' },
+        ],
+      },
+    }),
+  )
+
+  if (projected.type !== 'scenario-finished')
+    throw new Error('unexpected event')
+  expect(
+    projected.attempt.evidenceAvailability.find(
+      (item) => item.kind === 'diagnostics',
+    ),
+  ).toEqual({
+    kind: 'diagnostics',
+    state: 'not-supported',
+    message: 'Managed application stdout is unavailable for a reused server.',
+  })
+})

--- a/packages/cli/src/application-diagnostics.ts
+++ b/packages/cli/src/application-diagnostics.ts
@@ -1,0 +1,314 @@
+import type {
+  DiagnosticEntry,
+  EvidenceAvailability,
+  RunEvent,
+  ScenarioIdentity,
+} from '@pickle-spec/runner'
+import type {
+  ApplicationOutputAvailability,
+  ApplicationOutputLine,
+  ApplicationOutputStream,
+} from './server'
+
+export interface ApplicationDiagnosticBufferOptions {
+  profiles: Record<ApplicationOutputStream, readonly string[]>
+  availability: ApplicationOutputAvailability
+  onDiagnostic?: (event: LiveApplicationDiagnostic) => void
+}
+
+export interface LiveApplicationDiagnostic {
+  profileId: string
+  scope?: RunEventScope
+  diagnostic: DiagnosticEntry
+}
+
+interface ActiveScenario {
+  scenario: ScenarioIdentity
+  scope: RunEventScope
+  step?: { index: number; text: string }
+  diagnostics: DiagnosticEntry[]
+  stepDiagnostics: Map<number, DiagnosticEntry[]>
+}
+
+type RunEventScope = Extract<RunEvent, { type: 'scenario-started' }>['scope']
+
+export interface ApplicationDiagnosticBuffer {
+  record(line: ApplicationOutputLine): void
+  project(event: RunEvent): RunEvent
+}
+
+function scopeKey(scope: RunEventScope): string {
+  return [
+    scope.scenarioId,
+    scope.examplesRowId ?? '',
+    scope.executionTargetProfileId,
+    scope.attempt,
+  ].join('\u0000')
+}
+
+function requestedProfiles(
+  options: ApplicationDiagnosticBufferOptions,
+  stream: ApplicationOutputStream,
+): ReadonlySet<string> {
+  return new Set(options.profiles[stream])
+}
+
+function availabilityFor(
+  current: readonly EvidenceAvailability[],
+  options: ApplicationDiagnosticBufferOptions,
+  profileId: string,
+  hasDiagnostics: boolean,
+): EvidenceAvailability[] {
+  const requested = (['stdout', 'stderr'] as const).filter((stream) =>
+    options.profiles[stream].includes(profileId),
+  )
+  if (requested.length === 0) return [...current]
+  const diagnostic = current.find((item) => item.kind === 'diagnostics')
+  if (hasDiagnostics || diagnostic?.state === 'available') {
+    return replaceDiagnosticsAvailability(current, {
+      kind: 'diagnostics',
+      state: 'available',
+    })
+  }
+  const unsupported = requested.filter(
+    (stream) => options.availability[stream] === 'not-supported',
+  )
+  if (unsupported.length > 0) {
+    return replaceDiagnosticsAvailability(current, {
+      kind: 'diagnostics',
+      state: 'not-supported',
+      message: `Managed application ${unsupported.join(' and ')} ${unsupported.length === 1 ? 'is' : 'are'} unavailable for a reused server.`,
+    })
+  }
+  return replaceDiagnosticsAvailability(current, {
+    kind: 'diagnostics',
+    state: 'missing',
+    message: `Managed application ${requested.join(' and ')} capture produced no lines.`,
+  })
+}
+
+function applicationOutputAvailabilityFor(
+  options: ApplicationDiagnosticBufferOptions,
+  profileId: string,
+  diagnostics: readonly DiagnosticEntry[],
+) {
+  return (['stdout', 'stderr'] as const).map((stream) => {
+    if (!options.profiles[stream].includes(profileId)) {
+      return { stream, state: 'not-requested' as const }
+    }
+    if (diagnostics.some((entry) => entry.stream === stream)) {
+      return { stream, state: 'available' as const }
+    }
+    if (options.availability[stream] === 'not-supported') {
+      return {
+        stream,
+        state: 'not-supported' as const,
+        message: `Managed application ${stream} is unavailable for a reused server.`,
+      }
+    }
+    return {
+      stream,
+      state: 'missing' as const,
+      message: `Managed application ${stream} capture produced no lines.`,
+    }
+  })
+}
+
+function replaceDiagnosticsAvailability(
+  current: readonly EvidenceAvailability[],
+  replacement: EvidenceAvailability,
+): EvidenceAvailability[] {
+  return current.map((item) =>
+    item.kind === 'diagnostics' ? replacement : item,
+  )
+}
+
+export function createApplicationDiagnosticBuffer(
+  options: ApplicationDiagnosticBufferOptions,
+): ApplicationDiagnosticBuffer {
+  const stdoutProfiles = requestedProfiles(options, 'stdout')
+  const stderrProfiles = requestedProfiles(options, 'stderr')
+  const active = new Map<string, ActiveScenario>()
+  const pending = new Map<string, ApplicationOutputLine[]>()
+
+  function diagnosticFor(
+    scenario: ActiveScenario,
+    line: ApplicationOutputLine,
+    scoped: boolean,
+  ): DiagnosticEntry {
+    return {
+      occurredAt: line.occurredAt,
+      level: line.stream === 'stderr' ? 'warning' : 'info',
+      origin: 'application',
+      stream: line.stream,
+      message: line.line,
+      ...(scoped
+        ? {
+            scenarioId: scenario.scope.scenarioId,
+            scenarioName: scenario.scenario.name,
+            stepIndex: scenario.step?.index,
+            stepText: scenario.step?.text,
+          }
+        : {}),
+      executionTargetProfileId: scenario.scope.executionTargetProfileId,
+    }
+  }
+
+  function appendDiagnostic(
+    scenario: ActiveScenario,
+    line: ApplicationOutputLine,
+    scoped = true,
+  ): DiagnosticEntry {
+    const diagnostic = diagnosticFor(scenario, line, scoped)
+    scenario.diagnostics.push(diagnostic)
+    return diagnostic
+  }
+
+  function record(line: ApplicationOutputLine): void {
+    const profiles = line.stream === 'stdout' ? stdoutProfiles : stderrProfiles
+    for (const profileId of profiles) {
+      const scenarios = [...active.values()].filter(
+        (scenario) => scenario.scope.executionTargetProfileId === profileId,
+      )
+      if (scenarios.length === 0) {
+        pending.set(profileId, [...(pending.get(profileId) ?? []), line])
+        options.onDiagnostic?.({
+          profileId,
+          diagnostic: {
+            occurredAt: line.occurredAt,
+            level: line.stream === 'stderr' ? 'warning' : 'info',
+            origin: 'application',
+            stream: line.stream,
+            message: line.line,
+            executionTargetProfileId: profileId,
+          },
+        })
+        continue
+      }
+      if (scenarios.length === 1) {
+        const scenario = scenarios[0]!
+        const diagnostic = appendDiagnostic(scenario, line)
+        options.onDiagnostic?.({
+          profileId,
+          scope: scenario.scope,
+          diagnostic,
+        })
+        continue
+      }
+      pending.set(profileId, [...(pending.get(profileId) ?? []), line])
+      options.onDiagnostic?.({
+        profileId,
+        diagnostic: {
+          occurredAt: line.occurredAt,
+          level: line.stream === 'stderr' ? 'warning' : 'info',
+          origin: 'application',
+          stream: line.stream,
+          message: line.line,
+          executionTargetProfileId: profileId,
+        },
+      })
+    }
+  }
+
+  function project(event: RunEvent): RunEvent {
+    if (event.type === 'scenario-started') {
+      const scenario: ActiveScenario = {
+        scenario: event.scenario,
+        scope: event.scope,
+        diagnostics: [],
+        stepDiagnostics: new Map(),
+      }
+      active.set(scopeKey(event.scope), scenario)
+      return event
+    }
+
+    const scenario = 'scope' in event ? active.get(scopeKey(event.scope)) : null
+    if (event.type === 'step-started' && scenario) {
+      scenario.step = {
+        index: event.scope.stepIndex ?? 0,
+        text: `${event.step.keyword.trim()} ${event.step.text}`,
+      }
+      return event
+    }
+    if (event.type === 'step-finished' && scenario) {
+      const stepIndex = event.scope.stepIndex ?? event.result.index
+      const diagnostics = scenario.diagnostics.filter(
+        (entry) => entry.stepIndex === stepIndex,
+      )
+      scenario.diagnostics = scenario.diagnostics.filter(
+        (entry) => entry.stepIndex !== stepIndex,
+      )
+      if (diagnostics.length > 0) {
+        scenario.stepDiagnostics.set(stepIndex, diagnostics)
+      }
+      scenario.step = undefined
+      if (diagnostics.length === 0) return event
+      return {
+        ...event,
+        result: {
+          ...event.result,
+          diagnostics: [...(event.result.diagnostics ?? []), ...diagnostics],
+        },
+      }
+    }
+    if (event.type === 'scenario-finished' && scenario) {
+      const profileId = event.scope.executionTargetProfileId
+      const otherActiveScenarios = [...active.values()].filter(
+        (candidate) =>
+          candidate !== scenario &&
+          candidate.scope.executionTargetProfileId === profileId,
+      )
+      const ownsSharedOutput =
+        event.attempt.state === 'failed' ||
+        event.attempt.state === 'infrastructure-error' ||
+        otherActiveScenarios.length === 0
+      if (ownsSharedOutput) {
+        for (const line of pending.get(profileId) ?? []) {
+          appendDiagnostic(scenario, line, false)
+        }
+        pending.delete(profileId)
+      }
+      active.delete(scopeKey(event.scope))
+      const steps = event.attempt.steps.map((step) => {
+        const diagnostics = scenario.stepDiagnostics.get(step.index) ?? []
+        if (diagnostics.length === 0) return step
+        return {
+          ...step,
+          diagnostics: [...(step.diagnostics ?? []), ...diagnostics],
+        }
+      })
+      const diagnostics = [
+        ...(event.attempt.diagnostics ?? []),
+        ...scenario.diagnostics,
+      ]
+      const stepsHaveDiagnostics = steps.some(
+        (step) => (step.diagnostics?.length ?? 0) > 0,
+      )
+      return {
+        ...event,
+        attempt: {
+          ...event.attempt,
+          steps,
+          diagnostics: diagnostics.length > 0 ? diagnostics : undefined,
+          evidenceAvailability: availabilityFor(
+            event.attempt.evidenceAvailability,
+            options,
+            event.scope.executionTargetProfileId,
+            diagnostics.length > 0 || stepsHaveDiagnostics,
+          ),
+          applicationOutputAvailability: applicationOutputAvailabilityFor(
+            options,
+            event.scope.executionTargetProfileId,
+            [
+              ...diagnostics,
+              ...steps.flatMap((step) => step.diagnostics ?? []),
+            ],
+          ),
+        },
+      }
+    }
+    return event
+  }
+
+  return { record, project }
+}

--- a/packages/cli/src/application-output.test.ts
+++ b/packages/cli/src/application-output.test.ts
@@ -1,0 +1,58 @@
+import { expect, test } from 'bun:test'
+import type { ExecutionTargetProfile } from '@pickle-spec/runner'
+import { resolveApplicationOutput } from './application-output'
+import type { PickleConfig } from './config'
+
+const profiles: ExecutionTargetProfile[] = [
+  { id: 'desktop', adapter: 'web' },
+  { id: 'phone', adapter: 'mobile' },
+]
+
+const config: PickleConfig = {
+  schemaVersion: 1,
+  server: { output: { stderr: true } },
+  executionTargetProfiles: {
+    desktop: {
+      adapter: 'web',
+      applicationOutput: { stdout: true, stderr: false },
+    },
+    phone: { adapter: 'mobile' },
+  },
+}
+
+test('resolves managed output per selected profile with the run-wide fallback', () => {
+  expect(resolveApplicationOutput(config, profiles)).toEqual({
+    capture: { stdout: true, stderr: true },
+    profiles: {
+      stdout: ['desktop'],
+      stderr: ['phone'],
+    },
+  })
+})
+
+test('an individual run can enable or disable each stream independently', () => {
+  expect(
+    resolveApplicationOutput(config, profiles, {
+      stdout: false,
+      stderr: true,
+    }),
+  ).toEqual({
+    capture: { stdout: false, stderr: true },
+    profiles: {
+      stdout: [],
+      stderr: ['desktop', 'phone'],
+    },
+  })
+})
+
+test('uses run-wide output for a legacy single profile', () => {
+  expect(
+    resolveApplicationOutput(
+      { schemaVersion: 1, server: { output: { stdout: true } } },
+      [{ id: 'web', adapter: 'web' }],
+    ),
+  ).toEqual({
+    capture: { stdout: true, stderr: false },
+    profiles: { stdout: ['web'], stderr: [] },
+  })
+})

--- a/packages/cli/src/application-output.ts
+++ b/packages/cli/src/application-output.ts
@@ -1,0 +1,45 @@
+import type { ExecutionTargetProfile } from '@pickle-spec/runner'
+import type { PickleConfig } from './config'
+import type { ApplicationOutputStream } from './server'
+
+export type ApplicationOutputOptions = Partial<
+  Record<ApplicationOutputStream, boolean>
+>
+
+export interface ResolvedApplicationOutput {
+  capture: Record<ApplicationOutputStream, boolean>
+  profiles: Record<ApplicationOutputStream, string[]>
+}
+
+const outputStreams = ['stdout', 'stderr'] as const
+
+export function resolveApplicationOutput(
+  config: PickleConfig,
+  selectedProfiles: readonly ExecutionTargetProfile[],
+  runOptions: ApplicationOutputOptions = {},
+): ResolvedApplicationOutput {
+  const profiles = {
+    stdout: [] as string[],
+    stderr: [] as string[],
+  }
+
+  for (const profile of selectedProfiles) {
+    const configured = config.executionTargetProfiles?.[profile.id]
+    for (const stream of outputStreams) {
+      const enabled =
+        runOptions[stream] ??
+        configured?.applicationOutput?.[stream] ??
+        config.server?.output?.[stream] ??
+        false
+      if (enabled) profiles[stream].push(profile.id)
+    }
+  }
+
+  return {
+    capture: {
+      stdout: profiles.stdout.length > 0,
+      stderr: profiles.stderr.length > 0,
+    },
+    profiles,
+  }
+}

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -1,13 +1,13 @@
 #!/usr/bin/env bun
 
 import { resolve } from 'node:path'
+import type { EvidencePersistencePolicy } from '@pickle-spec/runner'
 import {
   compareTestRuns,
-  defaultRetention,
-  formatHtml,
   importRunArchive,
   openTestRunStore,
-  writeRunArchive,
+  publishTestRunExports,
+  type TestRunExportRequest,
 } from '@pickle-spec/runner'
 import type { SelectionOptions, SpecificationState } from '@pickle-spec/spec'
 import type { StudioAuthoringModel } from '@pickle-spec/studio'
@@ -18,6 +18,7 @@ import {
   type WebAdapterOptions,
 } from '@pickle-spec/web'
 import cliPackage from '../package.json' with { type: 'json' }
+import type { ApplicationOutputOptions } from './application-output'
 import { runCacheCommand } from './cache'
 import { errorMessage, withRecoveryFailure } from './command-error'
 import { defaultSpecificationGlob, loadConfig } from './config'
@@ -27,8 +28,14 @@ import {
   loadProjectSpecifications,
   startProjectRun,
 } from './execute-run'
+import { parseTestRunOutput } from './output-arguments'
 import { checkProject, initializeProject, migrateProject } from './project'
-import { finalizeMaterializedEvidence, writeRunOutputs } from './run-outputs'
+import {
+  finalizeMaterializedEvidence,
+  reportTestRunExportOutcomes,
+  testRunExportFailed,
+  writeRunOutputs,
+} from './run-outputs'
 import {
   createRunReporter,
   type RunReporterName,
@@ -67,15 +74,17 @@ interface RunArguments {
   headed?: boolean
   screenshotMode?: NonNullable<WebAdapterOptions['screenshots']>['mode']
   applicationRevision?: string
-  junitPath?: string
-  jsonPath?: string
-  ndjsonPath?: string
+  outputs?: TestRunExportRequest[]
+  force?: boolean
+  allArtifacts?: boolean
   rerunId?: string
   failures?: boolean
   fast?: boolean
   refreshCache?: boolean
   cacheOnly?: boolean
   reporter?: RunReporterName
+  applicationOutput?: ApplicationOutputOptions
+  evidencePersistence?: EvidencePersistencePolicy
 }
 
 interface StudioArguments {
@@ -188,14 +197,40 @@ function parseRunArguments(argv: string[]): RunArguments {
       case '--application-revision':
         args.applicationRevision = valueAfter(argv, index++)
         break
-      case '--junit':
-        args.junitPath = valueAfter(argv, index++)
+      case '--application-output': {
+        const stream = valueAfter(argv, index++)
+        if (stream !== 'stdout' && stream !== 'stderr') {
+          throw new Error('--application-output requires stdout or stderr')
+        }
+        args.applicationOutput = {
+          ...args.applicationOutput,
+          [stream]: true,
+        }
         break
-      case '--json':
-        args.jsonPath = valueAfter(argv, index++)
+      }
+      case '--evidence': {
+        const persistence = valueAfter(argv, index++)
+        if (
+          persistence !== 'off' &&
+          persistence !== 'on-failure' &&
+          persistence !== 'always'
+        ) {
+          throw new Error('--evidence requires off, on-failure, or always')
+        }
+        args.evidencePersistence = persistence
         break
-      case '--ndjson':
-        args.ndjsonPath = valueAfter(argv, index++)
+      }
+      case '--output':
+        args.outputs = [
+          ...(args.outputs ?? []),
+          parseTestRunOutput(valueAfter(argv, index++)),
+        ]
+        break
+      case '--force':
+        args.force = true
+        break
+      case '--all-artifacts':
+        args.allArtifacts = true
         break
       case '--rerun':
         args.rerunId = valueAfter(argv, index++)
@@ -268,14 +303,20 @@ async function run(argv: string[]): Promise<number> {
     reporting.start()
     const { runs } = await started.done
     const store = openTestRunStore({ root })
-    await writeRunOutputs(args, root, started.id)
+    const outputOutcomes = await writeRunOutputs(args, root, started.id)
     outputsWritten = true
-    await store.applyRetention({
+    reportTestRunExportOutcomes(outputOutcomes, console.error)
+    const retention = await store.applyRetention({
       maxAgeMs: config.retention?.days
         ? config.retention.days * dayMs
         : undefined,
       maxBytes: config.retention?.maxBytes,
     })
+    if (config.retention?.days || config.retention?.maxBytes) {
+      console.error(
+        `RETENTION removed ${retention.removed.length} Test runs (${retention.beforeBytes} → ${retention.afterBytes} bytes)${retention.removed.length > 0 ? `: ${retention.removed.join(', ')}` : ''}`,
+      )
+    }
 
     const exitStatus = evaluateTestRunExitStatus(
       runs.map(({ result }) => result),
@@ -284,7 +325,7 @@ async function run(argv: string[]): Promise<number> {
     reporting.finish(runs, performance.now() - startedAt, exitStatus)
     const reporterFailure = reporting.failure()
     if (reporterFailure) throw reporterFailure.error
-    return exitStatus.exitCode
+    return testRunExportFailed(outputOutcomes) ? 2 : exitStatus.exitCode
   } catch (error) {
     let commandError: unknown = error
     if (
@@ -295,9 +336,13 @@ async function run(argv: string[]): Promise<number> {
       const exitStatus = evaluateTestRunExitStatus([], { interrupted: true })
       if (startedRunId && !outputsWritten) {
         try {
-          await finalizeMaterializedEvidence(args, root, startedRunId, {
-            includeEmptyRun: true,
-          })
+          const outcomes = await finalizeMaterializedEvidence(
+            args,
+            root,
+            startedRunId,
+            { includeEmptyRun: true },
+          )
+          reportTestRunExportOutcomes(outcomes, console.error)
           outputsWritten = true
         } catch (recoveryError) {
           commandError = withRecoveryFailure(
@@ -321,7 +366,12 @@ async function run(argv: string[]): Promise<number> {
     }
     if (startedRunId && !outputsWritten) {
       try {
-        await finalizeMaterializedEvidence(args, root, startedRunId)
+        const outcomes = await finalizeMaterializedEvidence(
+          args,
+          root,
+          startedRunId,
+        )
+        reportTestRunExportOutcomes(outcomes, console.error)
       } catch (recoveryError) {
         commandError = withRecoveryFailure(
           commandError,
@@ -412,48 +462,50 @@ async function importArchive(argv: string[]): Promise<number> {
 async function exportRun(argv: string[]): Promise<number> {
   if (argv[0] !== 'export' || !argv[1]) {
     throw new Error(
-      'Usage: pickle export <id> (--archive <path> | --html <path>) [--all-artifacts]',
+      'Usage: pickle export <id> --output format=path [--output format=path] [--force] [--all-artifacts]',
     )
   }
   const runId = argv[1]
-  let archivePath: string | undefined
-  let htmlPath: string | undefined
+  const outputs: TestRunExportRequest[] = []
   let allArtifacts = false
+  let force = false
   for (let index = 2; index < argv.length; index++) {
     const flag = argv[index]!
-    if (flag === '--archive') archivePath = valueAfter(argv, index++)
-    else if (flag === '--html') htmlPath = valueAfter(argv, index++)
+    if (flag === '--output') {
+      const output = parseTestRunOutput(valueAfter(argv, index++))
+      outputs.push({ ...output, path: resolve(output.path) })
+    } else if (flag === '--force') force = true
     else if (flag === '--all-artifacts') allArtifacts = true
     else throw new Error(`Unknown option: ${flag}`)
   }
-  if (!archivePath && !htmlPath) {
-    throw new Error('pickle export requires --archive or --html')
+  if (outputs.length === 0) {
+    throw new Error('pickle export requires at least one --output format=path')
   }
-  if (archivePath && htmlPath) {
-    throw new Error('pickle export accepts either --archive or --html')
-  }
-  if (archivePath) {
-    await writeRunArchive({
-      root: process.cwd(),
-      runId,
-      outputPath: resolve(archivePath),
-    })
-    return 0
-  }
-
-  const { manifest } = await loadPersistedRun(process.cwd(), runId)
-  const html = await formatHtml(manifest, {
-    artifacts: allArtifacts ? 'all' : 'failures',
+  const outcomes = await publishTestRunExports({
+    root: process.cwd(),
+    runId,
+    outputs,
+    force,
+    htmlArtifacts: allArtifacts ? 'all' : 'failures',
   })
-  const htmlBytes = Buffer.byteLength(html, 'utf8')
+  reportTestRunExportOutcomes(outcomes, console.log)
+
   const warningThreshold = 10 * 1024 * 1024
-  if (allArtifacts && htmlBytes > warningThreshold) {
-    console.error(
-      `Warning: HTML export includes every available test artifact and is larger than 10 MB (${htmlBytes} bytes).`,
-    )
+  if (allArtifacts) {
+    for (const output of outputs) {
+      const file = Bun.file(output.path)
+      if (
+        output.format === 'html' &&
+        (await file.exists()) &&
+        file.size > warningThreshold
+      ) {
+        console.error(
+          `Warning: HTML export includes every available test artifact and is larger than 10 MB (${file.size} bytes).`,
+        )
+      }
+    }
   }
-  await Bun.write(resolve(htmlPath!), html)
-  return 0
+  return testRunExportFailed(outcomes) ? 2 : 0
 }
 
 function parseStudioArguments(argv: string[]): StudioArguments {
@@ -566,8 +618,8 @@ async function studio(argv: string[]): Promise<number> {
       return {
         maxAgeMs: current.retention?.days
           ? current.retention.days * dayMs
-          : defaultRetention.maxAgeMs,
-        maxBytes: current.retention?.maxBytes ?? defaultRetention.maxBytes,
+          : undefined,
+        maxBytes: current.retention?.maxBytes,
       }
     }),
     gateway: {
@@ -603,6 +655,9 @@ async function studio(argv: string[]): Promise<number> {
           },
           signal: runController.signal,
           onEvent,
+          onApplicationDiagnostic(event) {
+            onEvent({ type: 'diagnostic-recorded', ...event })
+          },
         })
         activeRuns.set(started.id, runController)
         void started.done

--- a/packages/cli/src/config-application-output.test.ts
+++ b/packages/cli/src/config-application-output.test.ts
@@ -1,0 +1,68 @@
+import { afterEach, expect, test } from 'bun:test'
+import { mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { loadConfig } from './config'
+
+const directories: string[] = []
+
+afterEach(async () => {
+  await Promise.all(
+    directories
+      .splice(0)
+      .map((directory) => rm(directory, { recursive: true, force: true })),
+  )
+})
+
+async function loadApplicationOutputConfig(config: Record<string, unknown>) {
+  const root = await mkdtemp(join(tmpdir(), 'pickle-application-output-'))
+  directories.push(root)
+  await Bun.write(
+    join(root, 'pickle.config.jsonc'),
+    JSON.stringify({ schemaVersion: 1, ...config }),
+  )
+  return loadConfig(undefined, root)
+}
+
+test('configures managed application output independently for a profile', async () => {
+  const config = await loadApplicationOutputConfig({
+    executionTargetProfiles: {
+      browser: {
+        adapter: 'web',
+        applicationOutput: { stdout: true, stderr: false },
+      },
+    },
+  })
+
+  expect(config.executionTargetProfiles?.browser?.applicationOutput).toEqual({
+    stdout: true,
+    stderr: false,
+  })
+})
+
+test('configures managed application output for every run', async () => {
+  const config = await loadApplicationOutputConfig({
+    server: {
+      command: 'bun app.ts',
+      port: 3000,
+      output: { stderr: true },
+    },
+  })
+
+  expect(config.server?.output).toEqual({ stderr: true })
+})
+
+test('rejects non-boolean managed application output settings', async () => {
+  expect(
+    loadApplicationOutputConfig({
+      executionTargetProfiles: {
+        browser: {
+          adapter: 'web',
+          applicationOutput: { stdout: 'yes' },
+        },
+      },
+    }),
+  ).rejects.toThrow(
+    'executionTargetProfiles.applicationOutput.stdout must be a boolean',
+  )
+})

--- a/packages/cli/src/config-evidence.test.ts
+++ b/packages/cli/src/config-evidence.test.ts
@@ -1,0 +1,59 @@
+import { afterEach, expect, test } from 'bun:test'
+import { mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { loadConfig } from './config'
+
+const directories: string[] = []
+
+afterEach(async () => {
+  await Promise.all(
+    directories
+      .splice(0)
+      .map((directory) => rm(directory, { recursive: true, force: true })),
+  )
+})
+
+async function loadEvidenceConfig(config: Record<string, unknown>) {
+  const root = await mkdtemp(join(tmpdir(), 'pickle-evidence-config-'))
+  directories.push(root)
+  await Bun.write(
+    join(root, 'pickle.config.jsonc'),
+    JSON.stringify({ schemaVersion: 1, ...config }),
+  )
+  return loadConfig(undefined, root)
+}
+
+test('configures run-wide and profile-specific evidence persistence', async () => {
+  const config = await loadEvidenceConfig({
+    evidence: { persistence: 'on-failure' },
+    executionTargetProfiles: {
+      browser: {
+        adapter: 'web',
+        evidence: { persistence: 'always' },
+      },
+      mobile: {
+        adapter: 'mobile',
+        evidence: { persistence: 'off' },
+        mobile: {
+          executionTarget: 'android-emulator',
+          application: { id: 'dev.pickle.example', binaryPath: 'app.apk' },
+        },
+      },
+    },
+  })
+
+  expect(config.evidence?.persistence).toBe('on-failure')
+  expect(config.executionTargetProfiles?.browser?.evidence?.persistence).toBe(
+    'always',
+  )
+  expect(config.executionTargetProfiles?.mobile?.evidence?.persistence).toBe(
+    'off',
+  )
+})
+
+test('rejects unsupported evidence persistence values', async () => {
+  expect(
+    loadEvidenceConfig({ evidence: { persistence: 'sometimes' } }),
+  ).rejects.toThrow('evidence.persistence must be off, on-failure, or always')
+})

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -2,6 +2,7 @@ import { join, resolve } from 'node:path'
 import type { MobileAdapterOptions } from '@pickle-spec/mobile'
 import {
   type ArtifactCapturePolicy,
+  type EvidencePersistencePolicy,
   type ExecutionSettings,
   type ExecutionTargetProfile,
   executionSettingsSchema,
@@ -29,11 +30,20 @@ export interface ServerConfig {
   pollIntervalMs?: number
   readinessPath?: string
   reuseExisting?: boolean
+  output?: {
+    stdout?: boolean
+    stderr?: boolean
+  }
 }
 
 export interface ProjectExecutionTargetProfile {
   adapter: string
   capabilities?: readonly string[]
+  applicationOutput?: {
+    stdout?: boolean
+    stderr?: boolean
+  }
+  evidence?: ProjectEvidence
   web?: WebAdapterOptions
   mobile?: MobileAdapterOptions
 }
@@ -49,6 +59,10 @@ export interface ProjectCache {
 
 export interface ProjectArtifacts {
   capture?: ArtifactCapturePolicy
+}
+
+export interface ProjectEvidence {
+  persistence?: EvidencePersistencePolicy
 }
 
 export interface ProjectSecretRef {
@@ -70,6 +84,7 @@ export interface PickleConfig {
   server?: ServerConfig
   retention?: ProjectRetention
   cache?: ProjectCache
+  evidence?: ProjectEvidence
   artifacts?: ProjectArtifacts
   links?: Record<string, string>
   secrets?: Record<string, ProjectSecretRef>
@@ -209,6 +224,28 @@ const projectProfileSchema = strictObject('executionTargetProfiles', {
     )
     .min(1, { error: 'capabilities must contain at least one capability' })
     .optional(),
+  applicationOutput: strictObject('executionTargetProfiles.applicationOutput', {
+    stdout: z
+      .boolean({
+        error:
+          'executionTargetProfiles.applicationOutput.stdout must be a boolean',
+      })
+      .optional(),
+    stderr: z
+      .boolean({
+        error:
+          'executionTargetProfiles.applicationOutput.stderr must be a boolean',
+      })
+      .optional(),
+  }).optional(),
+  evidence: strictObject('executionTargetProfiles.evidence', {
+    persistence: z
+      .enum(['off', 'on-failure', 'always'], {
+        error:
+          'executionTargetProfiles.evidence.persistence must be off, on-failure, or always',
+      })
+      .optional(),
+  }).optional(),
   web: webAdapterOptionsSchema.optional(),
   mobile: strictObject('executionTargetProfiles.mobile', {
     executionTarget: z.enum(['android-emulator', 'ios-simulator']).optional(),
@@ -340,6 +377,14 @@ const pickleConfigSchema = strictObject('configuration', {
     reuseExisting: z
       .boolean({ error: 'server.reuseExisting must be a boolean' })
       .optional(),
+    output: strictObject('server.output', {
+      stdout: z
+        .boolean({ error: 'server.output.stdout must be a boolean' })
+        .optional(),
+      stderr: z
+        .boolean({ error: 'server.output.stderr must be a boolean' })
+        .optional(),
+    }).optional(),
   })
     .superRefine((server, context) => {
       if (server.command && !server.url && !server.port) {
@@ -372,6 +417,13 @@ const pickleConfigSchema = strictObject('configuration', {
   }).optional(),
   cache: strictObject('cache', {
     maxBytes: optionalPositiveInteger('cache.maxBytes'),
+  }).optional(),
+  evidence: strictObject('evidence', {
+    persistence: z
+      .enum(['off', 'on-failure', 'always'], {
+        error: 'evidence.persistence must be off, on-failure, or always',
+      })
+      .optional(),
   }).optional(),
   artifacts: strictObject('artifacts', {
     capture: z

--- a/packages/cli/src/execute-run.ts
+++ b/packages/cli/src/execute-run.ts
@@ -1,6 +1,7 @@
 import { relative, resolve } from 'node:path'
 import { pathToFileURL } from 'node:url'
 import type {
+  EvidencePersistencePolicy,
   ExecutionTargetAdapter,
   ExecutionTargetProfile,
   RunEvent,
@@ -30,6 +31,15 @@ import {
   validateSpecificationMetadata,
 } from '@pickle-spec/spec'
 import { createWebAdapter, type WebAdapterOptions } from '@pickle-spec/web'
+import {
+  type ApplicationDiagnosticBuffer,
+  createApplicationDiagnosticBuffer,
+  type LiveApplicationDiagnostic,
+} from './application-diagnostics'
+import {
+  type ApplicationOutputOptions,
+  resolveApplicationOutput,
+} from './application-output'
 import { resolveApplicationRevision } from './application-revision'
 import {
   defaultExtensionsFile,
@@ -38,7 +48,11 @@ import {
   runConfigurationFrom,
 } from './config'
 import type { Extensions } from './extensions'
-import { startServer } from './server'
+import {
+  type ApplicationOutputAvailability,
+  type ApplicationOutputLine,
+  startServer,
+} from './server'
 import { configuredMobileAdapter } from './studio-mobile-targets'
 
 export interface ProjectRunOptions {
@@ -62,6 +76,8 @@ export interface ProjectRunOptions {
   fast?: boolean
   refreshCache?: boolean
   cacheOnly?: boolean
+  applicationOutput?: ApplicationOutputOptions
+  evidencePersistence?: EvidencePersistencePolicy
 }
 
 export interface StartedProjectRun {
@@ -78,6 +94,7 @@ type StartProjectRunInput = {
   options?: ProjectRunOptions
   signal?: AbortSignal
   onEvent?: (event: RunEvent) => void | Promise<void>
+  onApplicationDiagnostic?: (event: LiveApplicationDiagnostic) => void
   onSchedule?: (
     schedule: readonly ScheduledTestResult[],
   ) => void | Promise<void>
@@ -317,12 +334,24 @@ export async function startProjectRun(
   )
   const store = openTestRunStore({
     root,
-    artifactCapture: input.config.artifacts?.capture,
+    evidencePersistence:
+      input.config.evidence?.persistence ?? input.config.artifacts?.capture,
+    evidencePersistenceByProfile: Object.fromEntries(
+      Object.entries(input.config.executionTargetProfiles ?? {}).flatMap(
+        ([profileId, profile]) =>
+          profile.evidence?.persistence
+            ? [[profileId, profile.evidence.persistence]]
+            : [],
+      ),
+    ),
   })
   const testRun = await store.create({
     ...(args.rerunId ? { sourceRunId: args.rerunId } : {}),
     ...(args.suite ? { suite: args.suite } : {}),
     ...(applicationRevision ? { applicationRevision } : {}),
+    ...(args.evidencePersistence
+      ? { evidencePersistence: args.evidencePersistence }
+      : {}),
   })
 
   const done = new Promise<{
@@ -465,16 +494,48 @@ export async function startProjectRun(
           includeTarget,
         }),
       )
+      const applicationOutput = resolveApplicationOutput(
+        input.config,
+        resolvedConfiguration.targets.map(
+          ({ executionTargetProfile }) => executionTargetProfile,
+        ),
+        args.applicationOutput,
+      )
+      const pendingApplicationOutput: ApplicationOutputLine[] = []
+      let applicationDiagnostics: ApplicationDiagnosticBuffer | undefined
       server = await startServer(
         {
           ...input.config.server,
+          output: applicationOutput.capture,
           ...(args.reuseServer ? { reuseExisting: true } : {}),
         },
-        { signal: input.signal },
+        {
+          signal: input.signal,
+          onOutput(line) {
+            if (applicationDiagnostics) applicationDiagnostics.record(line)
+            else pendingApplicationOutput.push(line)
+          },
+        },
       )
+      const unavailableOutput: ApplicationOutputAvailability = {
+        stdout: applicationOutput.capture.stdout
+          ? 'not-supported'
+          : 'not-requested',
+        stderr: applicationOutput.capture.stderr
+          ? 'not-supported'
+          : 'not-requested',
+      }
+      applicationDiagnostics = createApplicationDiagnosticBuffer({
+        profiles: applicationOutput.profiles,
+        availability: server?.outputAvailability ?? unavailableOutput,
+        onDiagnostic: input.onApplicationDiagnostic,
+      })
+      for (const line of pendingApplicationOutput)
+        applicationDiagnostics.record(line)
       const onEvent = async (event: RunEvent) => {
-        const persisted = await testRun.append(event)
-        if (event.type === 'scenario-finished') {
+        const projected = applicationDiagnostics.project(event)
+        const persisted = await testRun.append(projected)
+        if (projected.type === 'scenario-finished') {
           await testRun.materialize({ finished: false })
         }
         await input.onEvent?.(persisted)
@@ -531,7 +592,13 @@ export async function startProjectRun(
       const manifest = await testRun.materialize()
       return { runs, manifest }
     } finally {
-      server?.stop()
+      if (server) {
+        server.stop()
+        await Promise.race([
+          server.outputComplete.catch(() => undefined),
+          Bun.sleep(1_000),
+        ])
+      }
       if (resolvedConfiguration) {
         await disposeAdapters(resolvedConfiguration.targets)
       }

--- a/packages/cli/src/output-arguments.test.ts
+++ b/packages/cli/src/output-arguments.test.ts
@@ -1,0 +1,18 @@
+import { expect, test } from 'bun:test'
+import { parseTestRunOutput } from './output-arguments'
+
+test('parses a supported Test run output and preserves equals signs in its path', () => {
+  expect(parseTestRunOutput('json=reports/run=ci.json')).toEqual({
+    format: 'json',
+    path: 'reports/run=ci.json',
+  })
+})
+
+test('rejects unsupported or incomplete Test run output requests', () => {
+  expect(() => parseTestRunOutput('tap=results.tap')).toThrow(
+    'Unsupported output format "tap"',
+  )
+  expect(() => parseTestRunOutput('json=')).toThrow(
+    '--output requires format=path',
+  )
+})

--- a/packages/cli/src/output-arguments.ts
+++ b/packages/cli/src/output-arguments.ts
@@ -1,0 +1,21 @@
+import {
+  type TestRunExportRequest,
+  testRunExportFormats,
+} from '@pickle-spec/runner'
+
+export function parseTestRunOutput(value: string): TestRunExportRequest {
+  const separator = value.indexOf('=')
+  if (separator <= 0 || separator === value.length - 1) {
+    throw new Error('--output requires format=path')
+  }
+  const format = value.slice(0, separator)
+  if (
+    !testRunExportFormats.includes(format as TestRunExportRequest['format'])
+  ) {
+    throw new Error(`Unsupported output format "${format}"`)
+  }
+  return {
+    format: format as TestRunExportRequest['format'],
+    path: value.slice(separator + 1),
+  }
+}

--- a/packages/cli/src/run-live.test.ts
+++ b/packages/cli/src/run-live.test.ts
@@ -234,7 +234,14 @@ Feature: Interrupt safely
   )
 
   const interactiveRun = spawnInteractiveRun({
-    cmd: [pickleCommand, 'run', '--json', jsonPath, '--ndjson', ndjsonPath],
+    cmd: [
+      pickleCommand,
+      'run',
+      '--output',
+      `json=${jsonPath}`,
+      '--output',
+      `ndjson=${ndjsonPath}`,
+    ],
     cwd: project,
     env: {
       ...Bun.env,
@@ -383,7 +390,14 @@ Feature: Reporter failure
   )
 
   const interactiveRun = spawnInteractiveRun({
-    cmd: [pickleCommand, 'run', '--json', jsonPath, '--ndjson', ndjsonPath],
+    cmd: [
+      pickleCommand,
+      'run',
+      '--output',
+      `json=${jsonPath}`,
+      '--output',
+      `ndjson=${ndjsonPath}`,
+    ],
     cwd: project,
     env: { ...Bun.env, NO_COLOR: '1', TERM: 'xterm-256color' },
   })
@@ -457,12 +471,12 @@ Feature: Startup interruption
     cmd: [
       pickleCommand,
       'run',
-      '--json',
-      jsonPath,
-      '--junit',
-      junitPath,
-      '--ndjson',
-      ndjsonPath,
+      '--output',
+      `json=${jsonPath}`,
+      '--output',
+      `junit=${junitPath}`,
+      '--output',
+      `ndjson=${ndjsonPath}`,
     ],
     cwd: project,
     env: { ...Bun.env, NO_COLOR: '1', TERM: 'xterm-256color' },

--- a/packages/cli/src/run-outputs.ts
+++ b/packages/cli/src/run-outputs.ts
@@ -1,52 +1,32 @@
 import {
-  formatJson,
-  formatJunit,
-  formatNdjson,
   openTestRunStore,
-  type RunEvent,
-  type TestRunManifest,
+  publishTestRunExports,
+  type TestRunExportOutcome,
+  type TestRunExportRequest,
 } from '@pickle-spec/runner'
-import { loadPersistedRun } from './execute-run'
 
 export interface RunOutputOptions {
-  junitPath?: string
-  jsonPath?: string
-  ndjsonPath?: string
+  outputs?: readonly TestRunExportRequest[]
+  force?: boolean
+  allArtifacts?: boolean
 }
 
 type FinalizeEvidenceOptions = {
   includeEmptyRun?: boolean
 }
 
-interface MaterializedRunEvidence {
-  manifest: TestRunManifest
-  events: RunEvent[]
-}
-
-async function writeMaterializedRunOutputs(
-  options: RunOutputOptions,
-  evidence: MaterializedRunEvidence,
-): Promise<void> {
-  if (options.junitPath) {
-    await Bun.write(options.junitPath, formatJunit(evidence.manifest))
-  }
-  if (options.jsonPath) {
-    await Bun.write(options.jsonPath, formatJson(evidence.manifest))
-  }
-  if (options.ndjsonPath) {
-    await Bun.write(options.ndjsonPath, formatNdjson(evidence.events))
-  }
-}
-
 export async function writeRunOutputs(
   options: RunOutputOptions,
   root: string,
   runId: string,
-): Promise<void> {
-  await writeMaterializedRunOutputs(
-    options,
-    await loadPersistedRun(root, runId),
-  )
+): Promise<TestRunExportOutcome[]> {
+  return publishTestRunExports({
+    root,
+    runId,
+    outputs: options.outputs ?? [],
+    force: options.force,
+    htmlArtifacts: options.allArtifacts ? 'all' : 'failures',
+  })
 }
 
 export async function finalizeMaterializedEvidence(
@@ -54,15 +34,36 @@ export async function finalizeMaterializedEvidence(
   root: string,
   runId: string,
   finalizeOptions: FinalizeEvidenceOptions = {},
-): Promise<void> {
+): Promise<TestRunExportOutcome[]> {
   const persisted = await openTestRunStore({ root }).open(runId)
   const events = await persisted.events()
   if (
     !finalizeOptions.includeEmptyRun &&
     !events.some((event) => event.type === 'scenario-finished')
   ) {
-    return
+    return []
   }
-  const manifest = await persisted.materialize()
-  await writeMaterializedRunOutputs(options, { manifest, events })
+  await persisted.materialize()
+  return writeRunOutputs(options, root, runId)
+}
+
+export function reportTestRunExportOutcomes(
+  outcomes: readonly TestRunExportOutcome[],
+  write: (line: string) => void,
+): void {
+  for (const outcome of outcomes) {
+    if (outcome.status === 'succeeded') {
+      write(`OUTPUT succeeded ${outcome.format}=${outcome.path}`)
+    } else {
+      write(
+        `OUTPUT failed ${outcome.format}=${outcome.path}: ${outcome.message}`,
+      )
+    }
+  }
+}
+
+export function testRunExportFailed(
+  outcomes: readonly TestRunExportOutcome[],
+): boolean {
+  return outcomes.some(({ status }) => status === 'failed')
 }

--- a/packages/cli/src/server.test.ts
+++ b/packages/cli/src/server.test.ts
@@ -1,0 +1,140 @@
+import { describe, expect, test } from 'bun:test'
+import type { Subprocess } from 'bun'
+import {
+  type ApplicationOutputLine,
+  type ServerRuntime,
+  startServer,
+} from './server'
+
+function stream(...chunks: string[]): ReadableStream<Uint8Array> {
+  const encoder = new TextEncoder()
+  return new ReadableStream({
+    start(controller) {
+      for (const chunk of chunks) controller.enqueue(encoder.encode(chunk))
+      controller.close()
+    },
+  })
+}
+
+function runtimeWithOutput(input: {
+  stdout: ReadableStream<Uint8Array>
+  stderr: ReadableStream<Uint8Array>
+  spawnOptions: unknown[]
+}): ServerRuntime {
+  return {
+    fetch: async () => new Response(null, { status: 200 }),
+    sleep: async () => {},
+    spawn(command, options) {
+      input.spawnOptions.push({ command, options })
+      return {
+        pid: 123,
+        stdout: input.stdout,
+        stderr: input.stderr,
+        kill() {},
+      } as Subprocess
+    },
+  }
+}
+
+describe('managed application output', () => {
+  test('captures opted-in stdout lines across chunk boundaries without capturing stderr', async () => {
+    const lines: ApplicationOutputLine[] = []
+    const spawnOptions: unknown[] = []
+    const managed = await startServer(
+      {
+        command: 'bun app.ts',
+        url: 'http://localhost:3000',
+        output: { stdout: true },
+      },
+      {
+        runtime: runtimeWithOutput({
+          stdout: stream('first', ' line\nsecond line\npartial'),
+          stderr: stream('private error\n'),
+          spawnOptions,
+        }),
+        now: () => new Date('2026-08-23T12:00:00.000Z'),
+        onOutput(line) {
+          lines.push(line)
+        },
+      },
+    )
+
+    await managed?.outputComplete
+
+    expect(lines).toEqual([
+      {
+        occurredAt: '2026-08-23T12:00:00.000Z',
+        stream: 'stdout',
+        line: 'first line',
+      },
+      {
+        occurredAt: '2026-08-23T12:00:00.000Z',
+        stream: 'stdout',
+        line: 'second line',
+      },
+      {
+        occurredAt: '2026-08-23T12:00:00.000Z',
+        stream: 'stdout',
+        line: 'partial',
+      },
+    ])
+    expect(spawnOptions).toEqual([
+      expect.objectContaining({
+        options: expect.objectContaining({ stdout: 'pipe', stderr: 'ignore' }),
+      }),
+    ])
+  })
+
+  test('captures stderr independently', async () => {
+    const lines: ApplicationOutputLine[] = []
+    const managed = await startServer(
+      {
+        command: 'bun app.ts',
+        url: 'http://localhost:3000',
+        output: { stderr: true },
+      },
+      {
+        runtime: runtimeWithOutput({
+          stdout: stream('ignored\n'),
+          stderr: stream('warning\n'),
+          spawnOptions: [],
+        }),
+        onOutput(line) {
+          lines.push(line)
+        },
+      },
+    )
+
+    await managed?.outputComplete
+
+    expect(lines.map(({ stream, line }) => ({ stream, line }))).toEqual([
+      { stream: 'stderr', line: 'warning' },
+    ])
+  })
+
+  test('reports opted-in output as unsupported when the application is reused', async () => {
+    const managed = await startServer(
+      {
+        command: 'bun app.ts',
+        url: 'http://localhost:3000',
+        reuseExisting: true,
+        output: { stdout: true, stderr: true },
+      },
+      {
+        runtime: {
+          fetch: async () => new Response(null, { status: 200 }),
+          sleep: async () => {},
+          spawn() {
+            throw new Error('must not spawn')
+          },
+        },
+      },
+    )
+
+    expect(managed?.mode).toBe('reused')
+    expect(managed?.outputAvailability).toEqual({
+      stdout: 'not-supported',
+      stderr: 'not-supported',
+    })
+  })
+})

--- a/packages/cli/src/server.ts
+++ b/packages/cli/src/server.ts
@@ -4,23 +4,103 @@ import type { ServerConfig } from './config'
 export interface ManagedServer {
   mode: 'spawned' | 'reused'
   url: string
+  outputAvailability: ApplicationOutputAvailability
+  outputComplete: Promise<void>
   stop(): void
 }
 
+export type ApplicationOutputStream = 'stdout' | 'stderr'
+
+export interface ApplicationOutputLine {
+  occurredAt: string
+  stream: ApplicationOutputStream
+  line: string
+}
+
+export type ApplicationOutputAvailabilityState =
+  | 'available'
+  | 'not-requested'
+  | 'not-supported'
+
+export type ApplicationOutputAvailability = Record<
+  ApplicationOutputStream,
+  ApplicationOutputAvailabilityState
+>
+
+type ManagedApplicationProcess = Pick<
+  Subprocess,
+  'pid' | 'stdout' | 'stderr' | 'kill'
+>
+
+interface ServerSpawnOptions {
+  cwd: string
+  detached: boolean
+  stdout: 'ignore' | 'pipe'
+  stderr: 'ignore' | 'pipe'
+}
+
 export interface ServerRuntime {
-  fetch: typeof fetch
-  sleep: typeof Bun.sleep
-  spawn: typeof Bun.spawn
+  fetch(input: string | URL | Request, init?: RequestInit): Promise<Response>
+  sleep(durationMs: number): Promise<void>
+  spawn(
+    command: string[],
+    options: ServerSpawnOptions,
+  ): ManagedApplicationProcess
 }
 
 export interface StartServerOptions {
   runtime?: ServerRuntime
   signal?: AbortSignal
+  now?: () => Date
+  onOutput?: (line: ApplicationOutputLine) => void | Promise<void>
 }
 
-const runtime: ServerRuntime = { fetch, sleep: Bun.sleep, spawn: Bun.spawn }
+const runtime: ServerRuntime = {
+  fetch,
+  sleep: Bun.sleep,
+  spawn: (command, options) => Bun.spawn(command, options),
+}
 
-function stopServerProcess(child: Subprocess): void {
+function outputAvailability(
+  config: ServerConfig,
+  supported: boolean,
+): ApplicationOutputAvailability {
+  const state = (stream: ApplicationOutputStream) => {
+    if (!config.output?.[stream]) return 'not-requested' as const
+    return supported ? ('available' as const) : ('not-supported' as const)
+  }
+  return { stdout: state('stdout'), stderr: state('stderr') }
+}
+
+async function observeOutput(
+  source: ReadableStream<Uint8Array>,
+  stream: ApplicationOutputStream,
+  now: () => Date,
+  onOutput?: StartServerOptions['onOutput'],
+): Promise<void> {
+  const decoder = new TextDecoder()
+  const reader = source.getReader()
+  let pending = ''
+  const emit = async (line: string) => {
+    await onOutput?.({ occurredAt: now().toISOString(), stream, line })
+  }
+  try {
+    while (true) {
+      const { value, done } = await reader.read()
+      if (done) break
+      pending += decoder.decode(value, { stream: true })
+      const lines = pending.split('\n')
+      pending = lines.pop() ?? ''
+      for (const line of lines) await emit(line.replace(/\r$/, ''))
+    }
+    pending += decoder.decode()
+    if (pending.length > 0) await emit(pending.replace(/\r$/, ''))
+  } finally {
+    reader.releaseLock()
+  }
+}
+
+function stopServerProcess(child: ManagedApplicationProcess): void {
   if (process.platform === 'win32') {
     child.kill()
     return
@@ -113,6 +193,7 @@ export async function startServer(
 ): Promise<ManagedServer | undefined> {
   const serverRuntime = options.runtime ?? runtime
   const signal = options.signal
+  const now = options.now ?? (() => new Date())
   if (!config.command) return undefined
   throwIfCancelled(signal)
   const url = serverUrl(config)
@@ -124,25 +205,46 @@ export async function startServer(
     (await isHealthy(config, url, deadline, serverRuntime, signal))
   ) {
     throwIfCancelled(signal)
-    return { mode: 'reused', url, stop() {} }
+    return {
+      mode: 'reused',
+      url,
+      outputAvailability: outputAvailability(config, false),
+      outputComplete: Promise.resolve(),
+      stop() {},
+    }
   }
 
   throwIfCancelled(signal)
-  const child: Subprocess = serverRuntime.spawn(
-    commandForShell(config.command),
-    {
-      cwd: process.cwd(),
-      detached: process.platform !== 'win32',
-      stdout: 'ignore',
-      stderr: 'ignore',
-    },
-  )
+  const child = serverRuntime.spawn(commandForShell(config.command), {
+    cwd: process.cwd(),
+    detached: process.platform !== 'win32',
+    stdout: config.output?.stdout ? 'pipe' : 'ignore',
+    stderr: config.output?.stderr ? 'pipe' : 'ignore',
+  })
+  const outputTasks: Promise<void>[] = []
+  if (config.output?.stdout && child.stdout instanceof ReadableStream) {
+    outputTasks.push(
+      observeOutput(child.stdout, 'stdout', now, options.onOutput),
+    )
+  }
+  if (config.output?.stderr && child.stderr instanceof ReadableStream) {
+    outputTasks.push(
+      observeOutput(child.stderr, 'stderr', now, options.onOutput),
+    )
+  }
+  const outputComplete = Promise.all(outputTasks).then(() => undefined)
   try {
     while (Date.now() < deadline) {
       throwIfCancelled(signal)
       if (await isHealthy(config, url, deadline, serverRuntime, signal)) {
         throwIfCancelled(signal)
-        return { mode: 'spawned', url, stop: () => stopServerProcess(child) }
+        return {
+          mode: 'spawned',
+          url,
+          outputAvailability: outputAvailability(config, true),
+          outputComplete,
+          stop: () => stopServerProcess(child),
+        }
       }
       throwIfCancelled(signal)
       const remaining = deadline - Date.now()

--- a/packages/cli/src/studio-history.test.ts
+++ b/packages/cli/src/studio-history.test.ts
@@ -1,0 +1,86 @@
+import { afterEach, expect, test } from 'bun:test'
+import { mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import {
+  openTestRunStore,
+  resolveLocalProjectStorage,
+} from '@pickle-spec/runner'
+import { createStudioHistoryGateway } from './studio-history'
+
+const directories: string[] = []
+const originalPickleHome = process.env.PICKLE_HOME
+
+afterEach(async () => {
+  if (originalPickleHome === undefined) delete process.env.PICKLE_HOME
+  else process.env.PICKLE_HOME = originalPickleHome
+  await Promise.all(
+    directories
+      .splice(0)
+      .map((directory) => rm(directory, { recursive: true, force: true })),
+  )
+})
+
+async function fixture(finished = true) {
+  const root = await mkdtemp(join(tmpdir(), 'pickle-studio-history-root-'))
+  const pickleHome = await mkdtemp(
+    join(tmpdir(), 'pickle-studio-history-home-'),
+  )
+  directories.push(root, pickleHome)
+  process.env.PICKLE_HOME = pickleHome
+  const store = openTestRunStore({ root, createId: () => 'run-1' })
+  const run = await store.create()
+  await run.materialize({ finished })
+  return { root }
+}
+
+test('lists storage and explicit retention without deleting by default', async () => {
+  const { root } = await fixture()
+  const gateway = createStudioHistoryGateway(root, async () => ({}))
+
+  const history = await gateway.list()
+  const result = await gateway.deleteEligible()
+
+  expect(history.runs.map((run) => run.id)).toEqual(['run-1'])
+  expect(history.retention).toEqual({})
+  expect(history.storage.totalBytes).toBeGreaterThan(0)
+  expect(result.removed).toEqual([])
+})
+
+test('pins and unpins a test run without mutating the immutable manifest', async () => {
+  const { root } = await fixture()
+  const gateway = createStudioHistoryGateway(root, async () => ({
+    maxAgeMs: 1,
+  }))
+  const manifestPath = join(
+    resolveLocalProjectStorage(root).runsDirectory,
+    'run-1',
+    'manifest.json',
+  )
+  const before = await Bun.file(manifestPath).bytes()
+
+  await gateway.pin('run-1')
+  expect((await gateway.list()).storage.pinnedRunIds).toEqual(['run-1'])
+  expect((await gateway.deleteEligible()).removed).toEqual([])
+  await gateway.unpin('run-1')
+  expect((await gateway.list()).storage.pinnedRunIds).toEqual([])
+  expect(await Bun.file(manifestPath).bytes()).toEqual(before)
+})
+
+test('exports Studio Allure results as a valid empty ZIP archive', async () => {
+  const { root } = await fixture()
+  const gateway = createStudioHistoryGateway(root, async () => ({}))
+
+  const bytes = await gateway.exportAllure('run-1')
+
+  expect([...bytes.slice(0, 4)]).toEqual([0x50, 0x4b, 0x05, 0x06])
+})
+
+test('rejects Studio Allure export until the Test run is finalized', async () => {
+  const { root } = await fixture(false)
+  const gateway = createStudioHistoryGateway(root, async () => ({}))
+
+  await expect(gateway.exportAllure('run-1')).rejects.toThrow(
+    'must be finalized before export',
+  )
+})

--- a/packages/cli/src/studio-history.ts
+++ b/packages/cli/src/studio-history.ts
@@ -4,9 +4,11 @@ import { join } from 'node:path'
 import type { RetentionPolicy } from '@pickle-spec/runner'
 import {
   compareTestRuns,
+  createAllureResultsZip,
   formatHtml,
   importRunArchive,
   openTestRunStore,
+  resolveLocalProjectStorage,
   writeRunArchive,
 } from '@pickle-spec/runner'
 import type { StudioHistoryGateway } from '@pickle-spec/studio'
@@ -14,13 +16,18 @@ import { loadPersistedRun } from './execute-run'
 
 export function createStudioHistoryGateway(
   root: string,
-  retention: () => Promise<Required<RetentionPolicy>>,
+  retention: () => Promise<RetentionPolicy>,
 ): StudioHistoryGateway {
   const store = openTestRunStore({ root })
 
   return {
     async list() {
-      return { runs: await store.list(), retention: await retention() }
+      const [runs, policy, storage] = await Promise.all([
+        store.list(),
+        retention(),
+        store.inspectStorage(),
+      ])
+      return { runs, retention: policy, storage }
     },
     async compare(baselineRunId, candidateRunId) {
       const [baseline, candidate] = await Promise.all([
@@ -45,8 +52,27 @@ export function createStudioHistoryGateway(
       const { manifest } = await loadPersistedRun(root, runId)
       return formatHtml(manifest, { artifacts })
     },
+    async exportAllure(runId) {
+      const { manifest } = await loadPersistedRun(root, runId)
+      if (!manifest.finishedAt) {
+        throw new Error(`Test run "${runId}" must be finalized before export`)
+      }
+      return createAllureResultsZip(manifest, {
+        artifactsDirectory: join(
+          resolveLocalProjectStorage(root).runsDirectory,
+          runId,
+          'artifacts',
+        ),
+      })
+    },
     async deleteEligible() {
       return store.applyRetention(await retention())
+    },
+    pin(runId) {
+      return store.pin(runId)
+    },
+    unpin(runId) {
+      return store.unpin(runId)
     },
   }
 }

--- a/packages/cli/src/studio.test.ts
+++ b/packages/cli/src/studio.test.ts
@@ -975,6 +975,22 @@ Feature: Search
       expect(
         await page.getByRole('link', { name: 'Export HTML' }).count(),
       ).toBe(1)
+      const allureHref = await page
+        .getByRole('link', { name: 'Export Allure results' })
+        .getAttribute('href')
+      const allureResponse = await page.evaluate(async (href) => {
+        const response = await fetch(href!)
+        return {
+          contentType: response.headers.get('content-type'),
+          signature: [
+            ...new Uint8Array(await response.arrayBuffer()).slice(0, 4),
+          ],
+        }
+      }, allureHref)
+      expect(allureResponse).toEqual({
+        contentType: 'application/zip',
+        signature: [0x50, 0x4b, 0x03, 0x04],
+      })
       const defaultHtmlHref = await page
         .getByRole('link', { name: 'Export HTML' })
         .getAttribute('href')
@@ -1019,6 +1035,9 @@ Feature: Search
           ),
         ).text(),
       ).toBe(importBytes)
+
+      await history.getByRole('button', { name: 'Pin' }).first().click()
+      await history.getByRole('button', { name: 'Unpin' }).waitFor()
 
       await page
         .getByRole('button', { name: 'Delete eligible history' })

--- a/packages/cli/src/workspace.test.ts
+++ b/packages/cli/src/workspace.test.ts
@@ -334,7 +334,13 @@ Feature: Release acceptance
 
     const archivePath = join(project, 'release-run.archive.json')
     const archive = Bun.spawnSync({
-      cmd: [pickleCommand, 'export', runId, '--archive', archivePath],
+      cmd: [
+        pickleCommand,
+        'export',
+        runId,
+        '--output',
+        `archive=${archivePath}`,
+      ],
       cwd: project,
       env: { ...Bun.env },
     })
@@ -373,7 +379,7 @@ Feature: Release acceptance
 
     const htmlPath = join(project, 'release-run.html')
     const html = Bun.spawnSync({
-      cmd: [pickleCommand, 'export', runId, '--html', htmlPath],
+      cmd: [pickleCommand, 'export', runId, '--output', `html=${htmlPath}`],
       cwd: project,
       env: { ...Bun.env },
     })
@@ -1327,10 +1333,10 @@ export default {
       cmd: [
         pickleCommand,
         'run',
-        '--json',
-        jsonPath,
-        '--ndjson',
-        ndjsonPath,
+        '--output',
+        `json=${jsonPath}`,
+        '--output',
+        `ndjson=${ndjsonPath}`,
         '--reporter',
         'ndjson',
       ],
@@ -1345,7 +1351,8 @@ export default {
       new Response(child.stderr).text(),
     ])
 
-    expect(stderr).toBe('')
+    expect(stderr).toContain(`OUTPUT succeeded json=${jsonPath}`)
+    expect(stderr).toContain(`OUTPUT succeeded ndjson=${ndjsonPath}`)
     expect(exitCode).toBe(1)
     expect(stdout).toContain('Payment was declined')
 
@@ -2057,12 +2064,12 @@ Feature: Purchase
       cmd: [
         pickleCommand,
         'run',
-        '--junit',
-        junitPath,
-        '--json',
-        jsonPath,
-        '--ndjson',
-        ndjsonPath,
+        '--output',
+        `junit=${junitPath}`,
+        '--output',
+        `json=${jsonPath}`,
+        '--output',
+        `ndjson=${ndjsonPath}`,
         '--reporter',
         'ndjson',
       ],
@@ -2077,9 +2084,12 @@ Feature: Purchase
       new Response(process.stderr).text(),
     ])
 
-    expect(stderr).toBe('')
+    expect(stderr).toContain(`OUTPUT succeeded junit=${junitPath}`)
+    expect(stderr).toContain(`OUTPUT succeeded json=${jsonPath}`)
+    expect(stderr).toContain(`OUTPUT succeeded ndjson=${ndjsonPath}`)
     expect(exitCode).toBe(0)
     expect(stdout).toContain('"kind":"run-event"')
+    expect(stdout).not.toContain('OUTPUT succeeded')
 
     const manifests = [
       ...new Bun.Glob('*/manifest.json').scanSync({
@@ -2371,14 +2381,77 @@ export default {
       ][0]!,
     )
     const archivePath = join(project, 'run.archive.json')
+    const allurePath = join(project, 'allure-results')
     const exported = Bun.spawnSync({
-      cmd: [pickleCommand, 'export', sourceId, '--archive', archivePath],
+      cmd: [
+        pickleCommand,
+        'export',
+        sourceId,
+        '--output',
+        `archive=${archivePath}`,
+        '--output',
+        `allure=${allurePath}`,
+      ],
       cwd: project,
       env: { ...Bun.env },
     })
     expect(exported.exitCode).toBe(0)
     expect(await Bun.file(archivePath).exists()).toBe(true)
+    const allureResultPaths = [
+      ...new Bun.Glob('*-result.json').scanSync({ cwd: allurePath }),
+    ]
+    expect(allureResultPaths).toHaveLength(1)
+    expect(
+      await Bun.file(join(allurePath, allureResultPaths[0]!)).json(),
+    ).toMatchObject({
+      testCaseId: 'scnpurchasebbbbbb',
+      status: 'failed',
+      labels: expect.arrayContaining([
+        { name: 'executionTargetProfile', value: 'deterministic' },
+      ]),
+    })
+    expect([
+      ...new Bun.Glob('*-attachment.png').scanSync({ cwd: allurePath }),
+    ]).toHaveLength(1)
     const originalArchive = await Bun.file(archivePath).text()
+
+    const siblingHtmlPath = join(project, 'sibling.html')
+    const partial = Bun.spawnSync({
+      cmd: [
+        pickleCommand,
+        'export',
+        sourceId,
+        '--output',
+        `archive=${archivePath}`,
+        '--output',
+        `html=${siblingHtmlPath}`,
+      ],
+      cwd: project,
+      env: { ...Bun.env },
+    })
+    expect(partial.exitCode).toBe(2)
+    expect(partial.stdout.toString()).toContain(
+      `OUTPUT failed archive=${archivePath}`,
+    )
+    expect(partial.stdout.toString()).toContain(
+      `OUTPUT succeeded html=${siblingHtmlPath}`,
+    )
+    expect(await Bun.file(archivePath).text()).toBe(originalArchive)
+    expect(await Bun.file(siblingHtmlPath).exists()).toBe(true)
+
+    const forced = Bun.spawnSync({
+      cmd: [
+        pickleCommand,
+        'export',
+        sourceId,
+        '--output',
+        `archive=${archivePath}`,
+        '--force',
+      ],
+      cwd: project,
+      env: { ...Bun.env },
+    })
+    expect(forced.exitCode).toBe(0)
 
     const target = await createCheckProject('import-target', {
       config: {
@@ -2424,7 +2497,7 @@ export default {
 
     const htmlPath = join(project, 'report.html')
     const html = Bun.spawnSync({
-      cmd: [pickleCommand, 'export', sourceId, '--html', htmlPath],
+      cmd: [pickleCommand, 'export', sourceId, '--output', `html=${htmlPath}`],
       cwd: project,
       env: { ...Bun.env },
     })

--- a/packages/cli/test/studio-browser-fixture.ts
+++ b/packages/cli/test/studio-browser-fixture.ts
@@ -44,7 +44,13 @@ export class StudioBrowserFixture {
     const project = join(this.workspace, name)
     const screenshot = join(project, 'failure.png')
     await mkdir(join(project, 'features'), { recursive: true })
-    await Bun.write(screenshot, Buffer.from([137, 80, 78, 71, 13, 10, 26, 10]))
+    await Bun.write(
+      screenshot,
+      Buffer.from(
+        'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII=',
+        'base64',
+      ),
+    )
     await Bun.write(
       join(project, 'pickle.config.jsonc'),
       JSON.stringify({

--- a/packages/cli/test/studio-hardening-suite.ts
+++ b/packages/cli/test/studio-hardening-suite.ts
@@ -334,6 +334,12 @@ Feature: Fixture ${suffix}
   test('Studio virtualizes large run and reviewed-result collections', async () => {
     const project = await createStudioProject('large-run-history')
     await createLargeHistory(project)
+    const configPath = join(project, 'pickle.config.jsonc')
+    const config = await Bun.file(configPath).json()
+    await Bun.write(
+      configPath,
+      JSON.stringify({ ...config, retention: { days: 1 } }),
+    )
     const { child, url } = await startStudio(project)
     const page = await browser.newPage()
     try {

--- a/packages/mobile/src/agent-device-evidence.ts
+++ b/packages/mobile/src/agent-device-evidence.ts
@@ -1,5 +1,5 @@
-import { mkdir, readFile, writeFile } from 'node:fs/promises'
-import { join } from 'node:path'
+import { mkdir, readFile, stat, writeFile } from 'node:fs/promises'
+import { basename, join, resolve } from 'node:path'
 import { z } from 'zod'
 import type { AgentDeviceClientPort } from './agent-device-client'
 import type {
@@ -9,6 +9,10 @@ import type {
 } from './worker-protocol'
 
 type MobileArtifact = NonNullable<WorkerStepExecution['artifacts']>[number]
+export type MobileEvidenceAvailability = NonNullable<
+  WorkerStepExecution['evidenceAvailability']
+>[number]
+type NodeError = Error & { code?: string }
 
 export interface AgentDeviceEvidenceSession {
   artifactDirectory?: string
@@ -19,12 +23,36 @@ export interface AgentDeviceEvidenceSession {
 }
 
 export interface ActiveScenarioEvidence {
+  availability: MobileEvidenceAvailability[]
   directory?: string
   recordingPath?: string
   tracePath?: string
 }
 
+export interface FinishedScenarioEvidence {
+  artifacts: MobileArtifact[]
+  availability: MobileEvidenceAvailability[]
+}
+
 const screenshotResultSchema = z.object({ path: z.string().min(1) })
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error)
+}
+
+function unavailableEvidence(
+  kind: MobileArtifactKind,
+  error: unknown,
+): MobileEvidenceAvailability {
+  if (error instanceof Error && (error as NodeError).code === 'ENOENT') {
+    return {
+      kind,
+      state: 'missing',
+      message: `Captured ${kind} file is missing`,
+    }
+  }
+  return { kind, state: 'capture-failed', message: errorMessage(error) }
+}
 
 function redactText(
   value: string,
@@ -37,60 +65,80 @@ function redactText(
   )
 }
 
+async function capturedArtifact(
+  kind: MobileArtifactKind,
+  path: string,
+  mediaType?: string,
+): Promise<MobileArtifact> {
+  const capturedAt = new Date().toISOString()
+  const sizeBytes = (await stat(path)).size
+  return {
+    kind,
+    path,
+    mediaType,
+    name: basename(path),
+    capturedAt,
+    sizeBytes,
+  }
+}
+
 export async function startScenarioEvidence(
   sessionId: string,
   session: AgentDeviceEvidenceSession,
 ): Promise<ActiveScenarioEvidence> {
-  if (!session.artifactDirectory || session.artifacts.size === 0) return {}
-  const directory = join(session.artifactDirectory, sessionId)
-  await mkdir(directory, { recursive: true })
-  const active: ActiveScenarioEvidence = { directory }
-  try {
-    if (session.artifacts.has('recording')) {
-      active.recordingPath = join(directory, 'scenario.mp4')
-      await session.client.recording.record({
-        action: 'start',
-        path: active.recordingPath,
-      })
+  if (session.artifacts.size === 0) return { availability: [] }
+  if (!session.artifactDirectory) {
+    return {
+      availability: [...session.artifacts].map((kind) => ({
+        kind,
+        state: 'capture-failed',
+        message: 'Mobile evidence requires an artifact directory',
+      })),
     }
-    if (session.artifacts.has('trace')) {
-      active.tracePath = join(directory, 'scenario.trace')
-      await session.client.recording.trace({
-        action: 'start',
-        path: active.tracePath,
-      })
-    }
-    return active
-  } catch (error) {
-    await Promise.allSettled([
-      ...(active.recordingPath
-        ? [
-            session.client.recording.record({
-              action: 'stop',
-              path: active.recordingPath,
-            }),
-          ]
-        : []),
-      ...(active.tracePath
-        ? [
-            session.client.recording.trace({
-              action: 'stop',
-              path: active.tracePath,
-            }),
-          ]
-        : []),
-    ])
-    throw error
   }
+
+  const directory = join(session.artifactDirectory, sessionId)
+  try {
+    await mkdir(directory, { recursive: true })
+  } catch (error) {
+    return {
+      availability: [...session.artifacts].map((kind) => ({
+        kind,
+        state: 'capture-failed',
+        message: errorMessage(error),
+      })),
+    }
+  }
+  const active: ActiveScenarioEvidence = { directory, availability: [] }
+
+  if (session.artifacts.has('recording')) {
+    const path = join(directory, 'scenario.mp4')
+    try {
+      await session.client.recording.record({ action: 'start', path })
+      active.recordingPath = path
+    } catch (error) {
+      active.availability.push(unavailableEvidence('recording', error))
+    }
+  }
+  if (session.artifacts.has('trace')) {
+    const path = join(directory, 'scenario.trace')
+    try {
+      await session.client.recording.trace({ action: 'start', path })
+      active.tracePath = path
+    } catch (error) {
+      active.availability.push(unavailableEvidence('trace', error))
+    }
+  }
+  return active
 }
 
 export async function finishScenarioEvidence(
   session: AgentDeviceEvidenceSession,
   active: ActiveScenarioEvidence,
-): Promise<MobileArtifact[]> {
-  if (!active.directory) return []
+): Promise<FinishedScenarioEvidence> {
   const artifacts: MobileArtifact[] = []
-  const errors: unknown[] = []
+  const availability = [...active.availability]
+  if (!active.directory) return { artifacts, availability }
 
   if (active.recordingPath) {
     try {
@@ -98,13 +146,12 @@ export async function finishScenarioEvidence(
         action: 'stop',
         path: active.recordingPath,
       })
-      artifacts.push({
-        kind: 'recording',
-        path: active.recordingPath,
-        mediaType: 'video/mp4',
-      })
+      artifacts.push(
+        await capturedArtifact('recording', active.recordingPath, 'video/mp4'),
+      )
+      availability.push({ kind: 'recording', state: 'available' })
     } catch (error) {
-      errors.push(error)
+      availability.push(unavailableEvidence('recording', error))
     }
   }
   if (active.tracePath) {
@@ -113,9 +160,10 @@ export async function finishScenarioEvidence(
         action: 'stop',
         path: active.tracePath,
       })
-      artifacts.push({ kind: 'trace', path: active.tracePath })
+      artifacts.push(await capturedArtifact('trace', active.tracePath))
+      availability.push({ kind: 'trace', state: 'available' })
     } catch (error) {
-      errors.push(error)
+      availability.push(unavailableEvidence('trace', error))
     }
   }
   if (session.artifacts.has('device-log')) {
@@ -126,9 +174,10 @@ export async function finishScenarioEvidence(
       const path = join(active.directory, 'scenario.log')
       const log = await readFile(session.deviceLogPath, 'utf8')
       await writeFile(path, redactText(log, session.redactions), 'utf8')
-      artifacts.push({ kind: 'device-log', path, mediaType: 'text/plain' })
+      artifacts.push(await capturedArtifact('device-log', path, 'text/plain'))
+      availability.push({ kind: 'device-log', state: 'available' })
     } catch (error) {
-      errors.push(error)
+      availability.push(unavailableEvidence('device-log', error))
     }
   }
   if (session.artifacts.has('screenshot')) {
@@ -137,17 +186,18 @@ export async function finishScenarioEvidence(
       const screenshot = screenshotResultSchema.parse(
         await session.client.capture.screenshot({ path: requestedPath }),
       )
-      artifacts.push({
-        kind: 'screenshot',
-        path: screenshot.path,
-        mediaType: 'image/png',
-      })
+      if (resolve(screenshot.path) !== resolve(requestedPath)) {
+        throw new Error(
+          'Agent Device returned a screenshot path outside the requested evidence location',
+        )
+      }
+      artifacts.push(
+        await capturedArtifact('screenshot', screenshot.path, 'image/png'),
+      )
+      availability.push({ kind: 'screenshot', state: 'available' })
     } catch (error) {
-      errors.push(error)
+      availability.push(unavailableEvidence('screenshot', error))
     }
   }
-  if (errors.length > 0) {
-    throw new AggregateError(errors, 'Mobile Scenario evidence capture failed')
-  }
-  return artifacts
+  return { artifacts, availability }
 }

--- a/packages/mobile/src/agent-device-gateway.test.ts
+++ b/packages/mobile/src/agent-device-gateway.test.ts
@@ -261,14 +261,24 @@ test('keeps Agent Device infrastructure failures out of divergence fallback', as
 test('captures Scenario-wide evidence around the exact Replay', async () => {
   const artifactDirectory = await mkdtemp(join(tmpdir(), 'pickle-evidence-'))
   const record = mock(
-    async (_options: { action: 'start' | 'stop'; path?: string }) => {},
+    async (options: { action: 'start' | 'stop'; path?: string }) => {
+      if (options.action === 'stop' && options.path) {
+        await Bun.write(options.path, 'recording')
+      }
+    },
   )
   const trace = mock(
-    async (_options: { action: 'start' | 'stop'; path?: string }) => {},
+    async (options: { action: 'start' | 'stop'; path?: string }) => {
+      if (options.action === 'stop' && options.path) {
+        await Bun.write(options.path, 'trace')
+      }
+    },
   )
-  const screenshot = mock(async (options: { path?: string }) => ({
-    path: options.path ?? '',
-  }))
+  const screenshot = mock(async (options: { path?: string }) => {
+    const path = options.path ?? ''
+    await Bun.write(path, 'screenshot')
+    return { path }
+  })
   const gateway = new AgentDeviceGateway(() =>
     client({
       recording: { record, trace },
@@ -292,13 +302,36 @@ test('captures Scenario-wide evidence around the exact Replay', async () => {
         {
           state: 'passed',
           artifacts: [
-            { kind: 'recording', mediaType: 'video/mp4' },
-            { kind: 'trace' },
-            { kind: 'screenshot', mediaType: 'image/png' },
+            {
+              kind: 'recording',
+              mediaType: 'video/mp4',
+              name: 'scenario.mp4',
+            },
+            { kind: 'trace', name: 'scenario.trace' },
+            {
+              kind: 'screenshot',
+              mediaType: 'image/png',
+              name: 'scenario.png',
+            },
+          ],
+          evidenceAvailability: [
+            { kind: 'recording', state: 'available' },
+            { kind: 'trace', state: 'available' },
+            { kind: 'screenshot', state: 'available' },
           ],
         },
       ],
     })
+    const artifacts = (
+      await gateway.executeScenario('session-1')
+    ).stepExecutions.at(-1)?.artifacts
+    expect(
+      artifacts?.every((artifact) =>
+        artifact.capturedAt
+          ? /^\d{4}-\d{2}-\d{2}T/.test(artifact.capturedAt)
+          : false,
+      ),
+    ).toBe(true)
     expect(record.mock.calls.map(([options]) => options.action)).toEqual([
       'start',
       'stop',
@@ -311,6 +344,195 @@ test('captures Scenario-wide evidence around the exact Replay', async () => {
   } finally {
     await gateway.dispose()
     await rm(artifactDirectory, { recursive: true, force: true })
+  }
+})
+
+test('retains successful Mobile artifacts when a sibling capture fails', async () => {
+  const artifactDirectory = await mkdtemp(join(tmpdir(), 'pickle-evidence-'))
+  const gateway = new AgentDeviceGateway(() =>
+    client({
+      recording: {
+        async record(options) {
+          if (options.action === 'stop' && options.path) {
+            await Bun.write(options.path, 'recording')
+          }
+        },
+        async trace() {},
+      },
+      capture: {
+        async screenshot() {
+          throw new Error('Screenshot transport closed')
+        },
+      },
+    }),
+  )
+
+  try {
+    await gateway.openSession({
+      sessionId: 'session-partial-evidence',
+      application,
+      artifactDirectory,
+      artifacts: ['recording', 'screenshot'],
+      mode: 'adaptive',
+      scenario,
+    })
+
+    const finalStep = (
+      await gateway.executeScenario('session-partial-evidence')
+    ).stepExecutions.at(-1)
+
+    expect(finalStep?.artifacts).toEqual([
+      expect.objectContaining({ kind: 'recording', name: 'scenario.mp4' }),
+    ])
+    expect(finalStep?.evidenceAvailability).toEqual([
+      { kind: 'recording', state: 'available' },
+      {
+        kind: 'screenshot',
+        state: 'capture-failed',
+        message: 'Screenshot transport closed',
+      },
+    ])
+  } finally {
+    await gateway.dispose()
+    await rm(artifactDirectory, { recursive: true, force: true })
+  }
+})
+
+test('reports unsupported requested Mobile evidence without failing the Scenario', async () => {
+  const artifactDirectory = await mkdtemp(join(tmpdir(), 'pickle-evidence-'))
+  const gateway = new AgentDeviceGateway(() =>
+    client({
+      devices: {
+        async list() {
+          return [androidEmulator, iosSimulator]
+        },
+        async capabilities() {
+          return {
+            device: androidEmulator,
+            availableCommands: ['screenshot'],
+          }
+        },
+      },
+      capture: {
+        async screenshot(options) {
+          const path = options.path ?? ''
+          await Bun.write(path, 'screenshot')
+          return { path }
+        },
+      },
+    }),
+  )
+
+  try {
+    await gateway.openSession({
+      sessionId: 'session-unsupported-evidence',
+      application,
+      artifactDirectory,
+      artifacts: ['recording', 'screenshot'],
+      mode: 'adaptive',
+      scenario,
+    })
+
+    const finalStep = (
+      await gateway.executeScenario('session-unsupported-evidence')
+    ).stepExecutions.at(-1)
+
+    expect(finalStep?.artifacts).toEqual([
+      expect.objectContaining({ kind: 'screenshot', name: 'scenario.png' }),
+    ])
+    expect(finalStep?.evidenceAvailability).toEqual([
+      {
+        kind: 'recording',
+        state: 'not-supported',
+        message: 'Android Emulator does not support recording evidence',
+      },
+      { kind: 'screenshot', state: 'available' },
+    ])
+  } finally {
+    await gateway.dispose()
+    await rm(artifactDirectory, { recursive: true, force: true })
+  }
+})
+
+test('reports a missing Mobile artifact when capture returns no file', async () => {
+  const artifactDirectory = await mkdtemp(join(tmpdir(), 'pickle-evidence-'))
+  const gateway = new AgentDeviceGateway(() =>
+    client({
+      capture: {
+        async screenshot(options) {
+          return { path: options.path ?? '' }
+        },
+      },
+    }),
+  )
+
+  try {
+    await gateway.openSession({
+      sessionId: 'session-missing-evidence',
+      application,
+      artifactDirectory,
+      artifacts: ['screenshot'],
+      mode: 'adaptive',
+      scenario,
+    })
+
+    const finalStep = (
+      await gateway.executeScenario('session-missing-evidence')
+    ).stepExecutions.at(-1)
+
+    expect(finalStep?.artifacts).toBeUndefined()
+    expect(finalStep?.evidenceAvailability).toEqual([
+      {
+        kind: 'screenshot',
+        state: 'missing',
+        message: 'Captured screenshot file is missing',
+      },
+    ])
+  } finally {
+    await gateway.dispose()
+    await rm(artifactDirectory, { recursive: true, force: true })
+  }
+})
+
+test('rejects a screenshot path outside the requested evidence directory', async () => {
+  const artifactDirectory = await mkdtemp(join(tmpdir(), 'pickle-evidence-'))
+  const outsidePath = join(artifactDirectory, '..', 'outside-screenshot.png')
+  await Bun.write(outsidePath, 'private')
+  const gateway = new AgentDeviceGateway(() =>
+    client({
+      capture: {
+        async screenshot() {
+          return { path: outsidePath }
+        },
+      },
+    }),
+  )
+
+  try {
+    await gateway.openSession({
+      sessionId: 'session-outside-evidence',
+      application,
+      artifactDirectory,
+      artifacts: ['screenshot'],
+      mode: 'adaptive',
+      scenario,
+    })
+
+    const finalStep = (
+      await gateway.executeScenario('session-outside-evidence')
+    ).stepExecutions.at(-1)
+
+    expect(finalStep?.artifacts).toBeUndefined()
+    expect(finalStep?.evidenceAvailability).toEqual([
+      expect.objectContaining({
+        kind: 'screenshot',
+        state: 'capture-failed',
+      }),
+    ])
+  } finally {
+    await gateway.dispose()
+    await rm(artifactDirectory, { recursive: true, force: true })
+    await rm(outsidePath, { force: true })
   }
 })
 

--- a/packages/mobile/src/agent-device-gateway.ts
+++ b/packages/mobile/src/agent-device-gateway.ts
@@ -12,6 +12,7 @@ import {
 } from './agent-device-client'
 import {
   finishScenarioEvidence,
+  type MobileEvidenceAvailability,
   startScenarioEvidence,
 } from './agent-device-evidence'
 import { executePrivateAgentDeviceReplay } from './agent-device-replay'
@@ -64,9 +65,11 @@ interface GatewaySession {
   compiled: CompiledMobileScenario
   deviceLogPath?: string
   execution?: WorkerScenarioExecution
+  evidenceAvailability: MobileEvidenceAvailability[]
   logsStarted: boolean
   mode: 'adaptive' | 'replay'
   redactions: readonly MobileTextRedaction[]
+  requestedArtifacts: readonly MobileArtifactKind[]
   selection?: MobileSelection
 }
 
@@ -289,6 +292,8 @@ export class AgentDeviceGateway {
       logsStarted: false,
       mode: input.mode,
       redactions: evidenceRedactions(input),
+      requestedArtifacts,
+      evidenceAvailability: [],
     }
     this.sessions.set(input.sessionId, session)
     const ensureSessionOwned = () => {
@@ -330,11 +335,16 @@ export class AgentDeviceGateway {
               artifactCommands[artifact],
             ),
         )
-        if (unsupportedArtifacts.length > 0) {
-          throw new Error(
-            `${policy.targetName} does not support requested evidence: ${unsupportedArtifacts.join(', ')}`,
-          )
-        }
+        session.artifacts = new Set(
+          requestedArtifacts.filter(
+            (artifact) => !unsupportedArtifacts.includes(artifact),
+          ),
+        )
+        session.evidenceAvailability = unsupportedArtifacts.map((kind) => ({
+          kind,
+          state: 'not-supported',
+          message: `${policy.targetName} does not support ${kind} evidence`,
+        }))
         const targetCapabilities = normalizedCapabilities(
           platform,
           capabilityResult.availableCommands,
@@ -440,9 +450,29 @@ export class AgentDeviceGateway {
         replayDiverged: true,
       }
     } finally {
-      const artifacts = await finishScenarioEvidence(session, activeEvidence)
+      const finishedEvidence = await finishScenarioEvidence(
+        session,
+        activeEvidence,
+      )
       const finalStep = session.execution?.stepExecutions.at(-1)
-      if (finalStep && artifacts.length > 0) finalStep.artifacts = artifacts
+      if (finalStep) {
+        if (finishedEvidence.artifacts.length > 0) {
+          finalStep.artifacts = finishedEvidence.artifacts
+        }
+        const availability = [
+          ...session.evidenceAvailability,
+          ...finishedEvidence.availability,
+        ]
+        if (availability.length > 0) {
+          const byKind = new Map(availability.map((item) => [item.kind, item]))
+          finalStep.evidenceAvailability = session.requestedArtifacts.flatMap(
+            (kind) => {
+              const item = byKind.get(kind)
+              return item ? [item] : []
+            },
+          )
+        }
+      }
     }
     return session.execution
   }

--- a/packages/mobile/src/worker-protocol.ts
+++ b/packages/mobile/src/worker-protocol.ts
@@ -42,6 +42,15 @@ const mobileArtifactKindSchema = z.enum([
   'device-log',
 ])
 
+const evidenceAvailabilityStateSchema = z.enum([
+  'available',
+  'not-requested',
+  'not-supported',
+  'not-retained',
+  'capture-failed',
+  'missing',
+])
+
 const mobileTextRedactionSchema = z.strictObject({
   match: z.string().min(1),
   replacement: z.string().optional(),
@@ -100,6 +109,18 @@ const workerStepExecutionSchema = z.strictObject({
         kind: mobileArtifactKindSchema,
         path: z.string(),
         mediaType: z.string().optional(),
+        name: z.string().min(1).optional(),
+        capturedAt: z.iso.datetime({ offset: true }).optional(),
+        sizeBytes: z.number().int().nonnegative().safe().optional(),
+      }),
+    )
+    .optional(),
+  evidenceAvailability: z
+    .array(
+      z.strictObject({
+        kind: mobileArtifactKindSchema,
+        state: evidenceAvailabilityStateSchema,
+        message: z.string().optional(),
       }),
     )
     .optional(),

--- a/packages/runner/index.ts
+++ b/packages/runner/index.ts
@@ -1,4 +1,19 @@
 export type {
+  AllureArchiveOptions,
+  AllureAttachment,
+  AllureAttachmentFile,
+  AllureResultFile,
+  AllureResultsProjection,
+  AllureStatusDetails,
+  AllureStep,
+  AllureTestResult,
+} from './src/allure-results'
+export {
+  assertAllureArtifactPath,
+  createAllureResultsZip,
+  projectAllureResults,
+} from './src/allure-results'
+export type {
   ImportedRunArchive,
   ImportRunArchiveInput,
   RunArchive,
@@ -91,6 +106,7 @@ export { publicRunEvent, publicTestResult } from './src/public-results'
 export type { RerunFilter } from './src/rerun'
 export { selectRerunResults } from './src/rerun'
 export type {
+  ApplicationOutputEvidenceAvailability,
   DiagnosticEntry,
   DiagnosticLevel,
   DiagnosticOrigin,
@@ -151,14 +167,31 @@ export {
   validateTargetSelection,
 } from './src/run-scenarios'
 export type {
+  PublishTestRunExportsInput,
+  TestRunExportFormat,
+  TestRunExportOutcome,
+  TestRunExportRequest,
+} from './src/test-run-exports'
+export {
+  publishTestRunExports,
+  testRunExportFormats,
+} from './src/test-run-exports'
+export type {
   ArtifactCapturePolicy,
   CreateTestRunOptions,
+  EvidencePersistencePolicy,
   PersistedTestRun,
   RetentionPolicy,
   RetentionResult,
   TestRunManifest,
+  TestRunStorageInspection,
   TestRunStore,
   TestRunStoreOptions,
   TestRunSummary,
 } from './src/test-run-store'
-export { defaultRetention, openTestRunStore, slug } from './src/test-run-store'
+export {
+  defaultRetention,
+  defaultRunStorageWarningBytes,
+  openTestRunStore,
+  slug,
+} from './src/test-run-store'

--- a/packages/runner/src/allure-results-zip.test.ts
+++ b/packages/runner/src/allure-results-zip.test.ts
@@ -1,0 +1,163 @@
+import { expect, test } from 'bun:test'
+import { mkdir, mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import {
+  createAllureResultsZip,
+  projectAllureResults,
+  type TestRunManifest,
+} from '../index'
+
+function readStoredZip(bytes: Uint8Array): Map<string, Uint8Array> {
+  const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength)
+  const decoder = new TextDecoder()
+  const files = new Map<string, Uint8Array>()
+  let offset = 0
+  while (view.getUint32(offset, true) === 0x04034b50) {
+    expect(view.getUint16(offset + 8, true)).toBe(0)
+    const compressedSize = view.getUint32(offset + 18, true)
+    const nameLength = view.getUint16(offset + 26, true)
+    const extraLength = view.getUint16(offset + 28, true)
+    const nameStart = offset + 30
+    const dataStart = nameStart + nameLength + extraLength
+    const name = decoder.decode(bytes.subarray(nameStart, dataStart))
+    files.set(name, bytes.slice(dataStart, dataStart + compressedSize))
+    offset = dataStart + compressedSize
+  }
+  expect(view.getUint32(offset, true)).toBe(0x02014b50)
+  return files
+}
+
+function manifest(artifactPath: string): TestRunManifest {
+  return {
+    schemaVersion: 2,
+    id: 'run-allure-zip',
+    startedAt: '2026-08-24T12:00:00.000Z',
+    finishedAt: '2026-08-24T12:00:01.000Z',
+    state: 'failed',
+    results: [
+      {
+        schemaVersion: 2,
+        specification: {
+          name: 'Checkout',
+          uri: 'features/checkout.feature',
+        },
+        scenario: { id: 'scenario-pay', name: 'Pay for the order' },
+        executionTargetProfile: { id: 'android' },
+        state: 'failed',
+        startedAt: '2026-08-24T12:00:00.000Z',
+        finishedAt: '2026-08-24T12:00:01.000Z',
+        durationMs: 1_000,
+        attempts: [
+          {
+            attempt: 1,
+            startedAt: '2026-08-24T12:00:00.000Z',
+            finishedAt: '2026-08-24T12:00:01.000Z',
+            durationMs: 1_000,
+            state: 'failed',
+            steps: [
+              {
+                index: 0,
+                startedAt: '2026-08-24T12:00:00.000Z',
+                finishedAt: '2026-08-24T12:00:01.000Z',
+                durationMs: 1_000,
+                step: {
+                  keyword: 'Then',
+                  text: 'payment is captured',
+                  type: 'outcome',
+                },
+                state: 'failed',
+                resolvedActions: [],
+                artifacts: [
+                  {
+                    kind: 'screenshot',
+                    path: artifactPath,
+                    mediaType: 'image/png',
+                  },
+                ],
+              },
+            ],
+            evidenceAvailability: [
+              { kind: 'screenshot', state: 'available' },
+              { kind: 'trace', state: 'not-requested' },
+              { kind: 'recording', state: 'not-requested' },
+              { kind: 'device-log', state: 'not-requested' },
+              { kind: 'diagnostics', state: 'not-requested' },
+            ],
+          },
+        ],
+      },
+    ],
+  }
+}
+
+test('creates an in-memory Allure ZIP equivalent to the directory projection', async () => {
+  const root = await mkdtemp(join(tmpdir(), 'pickle-allure-zip-'))
+  try {
+    const artifactsDirectory = join(root, 'artifacts')
+    await mkdir(artifactsDirectory)
+    const artifactPath = join(artifactsDirectory, 'failure.png')
+    const artifactBytes = new Uint8Array([0, 255, 80, 75, 3, 4])
+    await Bun.write(artifactPath, artifactBytes)
+    const testRun = manifest(artifactPath)
+    const projection = projectAllureResults(testRun)
+
+    const zipBytes = await createAllureResultsZip(testRun, {
+      artifactsDirectory,
+    })
+    const files = readStoredZip(zipBytes)
+
+    expect([...zipBytes.slice(0, 4)]).toEqual([0x50, 0x4b, 0x03, 0x04])
+    expect([...files.keys()].sort()).toEqual(
+      [
+        ...projection.results.map(({ fileName }) => fileName),
+        ...projection.attachments.map(({ fileName }) => fileName),
+      ].sort(),
+    )
+    for (const { fileName, result } of projection.results) {
+      expect(await new Blob([files.get(fileName)!]).text()).toBe(
+        `${JSON.stringify(result, null, 2)}\n`,
+      )
+    }
+    expect(files.get(projection.attachments[0]!.fileName)).toEqual(
+      artifactBytes,
+    )
+  } finally {
+    await rm(root, { recursive: true, force: true })
+  }
+})
+
+test('rejects Allure attachments outside the selected Test run', async () => {
+  const root = await mkdtemp(join(tmpdir(), 'pickle-allure-zip-'))
+  try {
+    const artifactPath = join(root, 'outside.png')
+    await Bun.write(artifactPath, 'private')
+
+    await expect(
+      createAllureResultsZip(manifest(artifactPath), {
+        artifactsDirectory: join(root, 'run', 'artifacts'),
+      }),
+    ).rejects.toThrow('escapes the Test run')
+  } finally {
+    await rm(root, { recursive: true, force: true })
+  }
+})
+
+test('bounds in-memory Allure ZIP creation', async () => {
+  const root = await mkdtemp(join(tmpdir(), 'pickle-allure-zip-'))
+  try {
+    const artifactsDirectory = join(root, 'artifacts')
+    await mkdir(artifactsDirectory)
+    const artifactPath = join(artifactsDirectory, 'large.png')
+    await Bun.write(artifactPath, new Uint8Array(32))
+
+    await expect(
+      createAllureResultsZip(manifest(artifactPath), {
+        artifactsDirectory,
+        maximumBytes: 1,
+      }),
+    ).rejects.toThrow('in-memory limit')
+  } finally {
+    await rm(root, { recursive: true, force: true })
+  }
+})

--- a/packages/runner/src/allure-results.ts
+++ b/packages/runner/src/allure-results.ts
@@ -1,0 +1,429 @@
+import { createHash } from 'node:crypto'
+import { realpath, stat } from 'node:fs/promises'
+import { extname, resolve, sep } from 'node:path'
+import type {
+  ScenarioAttempt,
+  TestArtifact,
+  TestResult,
+  TestResultState,
+  TestStepResult,
+} from './run-scenario'
+import type { TestRunManifest } from './test-run-store'
+
+type AllureStatus = 'failed' | 'broken' | 'passed' | 'skipped' | 'unknown'
+type AllureStage = 'finished' | 'interrupted'
+
+export interface AllureAttachment {
+  name: string
+  source: string
+  type?: string
+}
+
+export interface AllureStep {
+  name: string
+  status: AllureStatus
+  statusDetails?: AllureStatusDetails
+  stage: AllureStage
+  start: number
+  stop: number
+  steps: AllureStep[]
+}
+
+export interface AllureStatusDetails {
+  message?: string
+  flaky?: boolean
+}
+
+export interface AllureTestResult {
+  uuid: string
+  historyId: string
+  testCaseId: string
+  fullName: string
+  name: string
+  status: AllureStatus
+  statusDetails?: AllureStatusDetails
+  stage: AllureStage
+  start: number
+  stop: number
+  labels: Array<{ name: string; value: string }>
+  parameters: Array<{ name: string; value: string; excluded?: boolean }>
+  attachments: AllureAttachment[]
+  steps: AllureStep[]
+}
+
+export interface AllureResultFile {
+  fileName: string
+  result: AllureTestResult
+}
+
+export interface AllureAttachmentFile {
+  sourcePath: string
+  fileName: string
+}
+
+export interface AllureResultsProjection {
+  results: AllureResultFile[]
+  attachments: AllureAttachmentFile[]
+}
+
+type ZipEntry = {
+  name: Uint8Array
+  contents: Uint8Array
+  crc32: number
+  offset: number
+}
+
+const zipLocalHeaderSize = 30
+const zipCentralHeaderSize = 46
+const zipEndSize = 22
+const maximumZip32Value = 0xffff_ffff
+const defaultMaximumArchiveBytes = 128 * 1024 * 1024
+
+export interface AllureArchiveOptions {
+  artifactsDirectory: string
+  maximumBytes?: number
+}
+
+const extensionByMediaType: Readonly<Record<string, string>> = {
+  'image/png': '.png',
+  'image/jpeg': '.jpg',
+  'image/webp': '.webp',
+  'application/json': '.json',
+  'application/zip': '.zip',
+  'text/plain': '.txt',
+}
+
+function opaqueId(...parts: Array<string | number | undefined>): string {
+  return createHash('sha256')
+    .update(parts.map((part) => part ?? '').join('\0'))
+    .digest('hex')
+}
+
+function uuidFrom(...parts: Array<string | number | undefined>): string {
+  const hex = opaqueId(...parts).slice(0, 32)
+  return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20)}`
+}
+
+function time(value: string): number {
+  return new Date(value).getTime()
+}
+
+function allureStatus(state: TestResultState): AllureStatus {
+  if (state === 'infrastructure-error' || state === 'cancelled') return 'broken'
+  return state
+}
+
+function allureStage(state: TestResultState): AllureStage {
+  return state === 'cancelled' ? 'interrupted' : 'finished'
+}
+
+function statusDetails(
+  message: string | undefined,
+  flaky = false,
+): AllureStatusDetails | undefined {
+  if (!message && !flaky) return undefined
+  return {
+    ...(message ? { message } : {}),
+    ...(flaky ? { flaky: true } : {}),
+  }
+}
+
+function actionStep(description: string, step: TestStepResult): AllureStep {
+  return {
+    name: description,
+    status: 'passed',
+    stage: 'finished',
+    start: time(step.startedAt),
+    stop: time(step.finishedAt),
+    steps: [],
+  }
+}
+
+function allureStep(step: TestStepResult): AllureStep {
+  const details = statusDetails(step.message)
+  return {
+    name: `${step.step.keyword} ${step.step.text}`,
+    status: allureStatus(step.state),
+    ...(details ? { statusDetails: details } : {}),
+    stage: allureStage(step.state),
+    start: time(step.startedAt),
+    stop: time(step.finishedAt),
+    steps: step.resolvedActions.map(({ description }) =>
+      actionStep(description, step),
+    ),
+  }
+}
+
+function attachmentExtension(artifact: TestArtifact): string {
+  return (
+    (artifact.mediaType
+      ? extensionByMediaType[artifact.mediaType]
+      : undefined) ??
+    extname(artifact.path) ??
+    ''
+  )
+}
+
+function attemptArtifacts(attempt: ScenarioAttempt): TestArtifact[] {
+  return attempt.steps.flatMap((step) => step.artifacts ?? [])
+}
+
+function projectAttempt(
+  manifest: TestRunManifest,
+  result: TestResult,
+  attempt: ScenarioAttempt,
+): { result: AllureResultFile; attachments: AllureAttachmentFile[] } {
+  const scenarioId =
+    result.scenario.id ??
+    opaqueId(result.specification.uri, result.scenario.name)
+  const historyId = opaqueId(
+    scenarioId,
+    result.scenario.examplesRowId,
+    result.executionTargetProfile.id,
+  )
+  const uuid = uuidFrom(
+    manifest.id,
+    scenarioId,
+    result.scenario.examplesRowId,
+    result.executionTargetProfile.id,
+    attempt.attempt,
+  )
+  const attachments = attemptArtifacts(attempt).map((artifact, index) => {
+    const fileName = `${uuid}-${index + 1}-attachment${attachmentExtension(artifact)}`
+    return {
+      descriptor: {
+        name: artifact.name ?? artifact.kind,
+        source: fileName,
+        type: artifact.mediaType,
+      },
+      file: { sourcePath: artifact.path, fileName },
+    }
+  })
+  const parameters: AllureTestResult['parameters'] = [
+    ...(result.scenario.examplesRowId
+      ? [
+          {
+            name: 'examplesRowId',
+            value: result.scenario.examplesRowId,
+          },
+        ]
+      : []),
+    {
+      name: 'executionTargetProfile',
+      value: result.executionTargetProfile.id,
+    },
+    { name: 'attempt', value: String(attempt.attempt), excluded: true },
+  ]
+  const details = statusDetails(attempt.message, result.flaky)
+  const testResult: AllureTestResult = {
+    uuid,
+    historyId,
+    testCaseId: scenarioId,
+    fullName: `${result.specification.uri}#${result.scenario.name}`,
+    name: result.scenario.name,
+    status: allureStatus(attempt.state),
+    ...(details ? { statusDetails: details } : {}),
+    stage: allureStage(attempt.state),
+    start: time(attempt.startedAt),
+    stop: time(attempt.finishedAt),
+    labels: [
+      { name: 'framework', value: 'pickle-spec' },
+      { name: 'parentSuite', value: result.specification.name },
+      { name: 'suite', value: result.specification.uri },
+      { name: 'feature', value: result.specification.name },
+      { name: 'story', value: result.scenario.name },
+      {
+        name: 'executionTargetProfile',
+        value: result.executionTargetProfile.id,
+      },
+    ],
+    parameters,
+    attachments: attachments.map(({ descriptor }) => descriptor),
+    steps: attempt.steps.map(allureStep),
+  }
+  return {
+    result: { fileName: `${uuid}-result.json`, result: testResult },
+    attachments: attachments.map(({ file }) => file),
+  }
+}
+
+export function projectAllureResults(
+  manifest: TestRunManifest,
+): AllureResultsProjection {
+  const results: AllureResultFile[] = []
+  const attachments: AllureAttachmentFile[] = []
+  for (const testResult of manifest.results) {
+    for (const attempt of testResult.attempts) {
+      const projected = projectAttempt(manifest, testResult, attempt)
+      results.push(projected.result)
+      attachments.push(...projected.attachments)
+    }
+  }
+  return { results, attachments }
+}
+
+async function allureArchiveFiles(
+  projection: AllureResultsProjection,
+  options: AllureArchiveOptions,
+): Promise<Map<string, File>> {
+  const files: Record<string, string | Uint8Array> = {}
+  let projectedBytes = 0
+  const maximumBytes = options.maximumBytes ?? defaultMaximumArchiveBytes
+  for (const { fileName, result } of projection.results) {
+    const contents = `${JSON.stringify(result, null, 2)}\n`
+    projectedBytes += Buffer.byteLength(contents)
+    files[fileName] = contents
+  }
+  for (const { sourcePath, fileName } of projection.attachments) {
+    const source = Bun.file(sourcePath)
+    if (!(await source.exists())) {
+      throw new Error(`Artifact source file is missing: ${sourcePath}`)
+    }
+    await assertAllureArtifactPath(sourcePath, options.artifactsDirectory)
+    projectedBytes += (await stat(sourcePath)).size
+    if (projectedBytes > maximumBytes) {
+      throw new Error(
+        `Allure ZIP exceeds the ${Math.floor(maximumBytes / 1024 / 1024)} MiB in-memory limit`,
+      )
+    }
+    files[fileName] = await source.bytes()
+  }
+  if (projectedBytes > maximumBytes) {
+    throw new Error(
+      `Allure ZIP exceeds the ${Math.floor(maximumBytes / 1024 / 1024)} MiB in-memory limit`,
+    )
+  }
+  return new Bun.Archive(files).files()
+}
+
+export async function assertAllureArtifactPath(
+  sourcePath: string,
+  artifactsDirectory: string,
+): Promise<void> {
+  const source = resolve(sourcePath)
+  const allowed = resolve(artifactsDirectory)
+  if (source !== allowed && !source.startsWith(`${allowed}${sep}`)) {
+    throw new Error(`Artifact source path escapes the Test run: ${sourcePath}`)
+  }
+  const [realSource, realAllowed] = await Promise.all([
+    realpath(source),
+    realpath(allowed),
+  ])
+  if (
+    realSource !== realAllowed &&
+    !realSource.startsWith(`${realAllowed}${sep}`)
+  ) {
+    throw new Error(`Artifact source path escapes the Test run: ${sourcePath}`)
+  }
+}
+
+async function zipEntries(files: Map<string, File>): Promise<ZipEntry[]> {
+  if (files.size > 0xffff) {
+    throw new Error('Allure ZIP contains more than 65,535 files')
+  }
+  const encoder = new TextEncoder()
+  const entries: ZipEntry[] = []
+  let offset = 0
+  for (const [path, file] of files) {
+    const name = encoder.encode(path)
+    const contents = new Uint8Array(await file.arrayBuffer())
+    if (name.byteLength > 0xffff) {
+      throw new Error(`Allure ZIP file name is too long: ${path}`)
+    }
+    if (contents.byteLength > maximumZip32Value) {
+      throw new Error(`Allure ZIP file is larger than 4 GiB: ${path}`)
+    }
+    entries.push({
+      name,
+      contents,
+      crc32: Bun.hash.crc32(contents) >>> 0,
+      offset,
+    })
+    offset += zipLocalHeaderSize + name.byteLength + contents.byteLength
+  }
+  return entries
+}
+
+function writeLocalEntry(
+  output: Uint8Array,
+  view: DataView,
+  entry: ZipEntry,
+): void {
+  const offset = entry.offset
+  view.setUint32(offset, 0x04034b50, true)
+  view.setUint16(offset + 4, 20, true)
+  view.setUint16(offset + 6, 0x0800, true)
+  view.setUint16(offset + 8, 0, true)
+  view.setUint32(offset + 14, entry.crc32, true)
+  view.setUint32(offset + 18, entry.contents.byteLength, true)
+  view.setUint32(offset + 22, entry.contents.byteLength, true)
+  view.setUint16(offset + 26, entry.name.byteLength, true)
+  output.set(entry.name, offset + zipLocalHeaderSize)
+  output.set(
+    entry.contents,
+    offset + zipLocalHeaderSize + entry.name.byteLength,
+  )
+}
+
+function writeCentralEntry(
+  output: Uint8Array,
+  view: DataView,
+  entry: ZipEntry,
+  offset: number,
+): number {
+  view.setUint32(offset, 0x02014b50, true)
+  view.setUint16(offset + 4, 20, true)
+  view.setUint16(offset + 6, 20, true)
+  view.setUint16(offset + 8, 0x0800, true)
+  view.setUint16(offset + 10, 0, true)
+  view.setUint32(offset + 16, entry.crc32, true)
+  view.setUint32(offset + 20, entry.contents.byteLength, true)
+  view.setUint32(offset + 24, entry.contents.byteLength, true)
+  view.setUint16(offset + 28, entry.name.byteLength, true)
+  view.setUint32(offset + 42, entry.offset, true)
+  output.set(entry.name, offset + zipCentralHeaderSize)
+  return offset + zipCentralHeaderSize + entry.name.byteLength
+}
+
+function storedZip(entries: readonly ZipEntry[]): Uint8Array {
+  const localSize = entries.reduce(
+    (total, entry) =>
+      total +
+      zipLocalHeaderSize +
+      entry.name.byteLength +
+      entry.contents.byteLength,
+    0,
+  )
+  const centralSize = entries.reduce(
+    (total, entry) => total + zipCentralHeaderSize + entry.name.byteLength,
+    0,
+  )
+  const totalSize = localSize + centralSize + zipEndSize
+  if (totalSize > maximumZip32Value) {
+    throw new Error('Allure ZIP is larger than the ZIP32 in-memory limit')
+  }
+  const output = new Uint8Array(totalSize)
+  const view = new DataView(output.buffer)
+  for (const entry of entries) writeLocalEntry(output, view, entry)
+  let centralOffset = localSize
+  for (const entry of entries) {
+    centralOffset = writeCentralEntry(output, view, entry, centralOffset)
+  }
+  view.setUint32(centralOffset, 0x06054b50, true)
+  view.setUint16(centralOffset + 8, entries.length, true)
+  view.setUint16(centralOffset + 10, entries.length, true)
+  view.setUint32(centralOffset + 12, centralSize, true)
+  view.setUint32(centralOffset + 16, localSize, true)
+  return output
+}
+
+export async function createAllureResultsZip(
+  manifest: TestRunManifest,
+  options: AllureArchiveOptions,
+): Promise<Uint8Array> {
+  const files = await allureArchiveFiles(
+    projectAllureResults(manifest),
+    options,
+  )
+  return storedZip(await zipEntries(files))
+}

--- a/packages/runner/src/archive.test.ts
+++ b/packages/runner/src/archive.test.ts
@@ -122,7 +122,16 @@ function failedResultWithArtifact(path: string): TestResult {
     state: 'failed' as const,
     resolvedActions: [{ description: 'Click pay on chrome' }],
     message: 'Payment was declined',
-    artifacts: [{ kind: 'screenshot' as const, path, mediaType: 'image/png' }],
+    artifacts: [
+      {
+        kind: 'screenshot' as const,
+        path,
+        mediaType: 'image/png',
+        name: 'failure.png',
+        capturedAt: attempt.finishedAt,
+        sizeBytes: 16,
+      },
+    ],
   }
   return {
     ...result,
@@ -678,6 +687,14 @@ test('issue 77: exports and imports a schema-v2 archive with contained artifact 
     })
     const importedPath =
       imported.manifest.results[0]!.attempts[0]!.steps[0]!.artifacts![0]!.path
+    expect(
+      imported.manifest.results[0]!.attempts[0]!.steps[0]!.artifacts![0],
+    ).toMatchObject({
+      name: 'failure.png',
+      capturedAt: '2026-08-15T12:00:00.012Z',
+      sizeBytes: 16,
+      mediaType: 'image/png',
+    })
     const targetArtifacts = join(
       storageFor(targetRoot).runsDirectory,
       run.id,

--- a/packages/runner/src/atomic-output.ts
+++ b/packages/runner/src/atomic-output.ts
@@ -1,0 +1,123 @@
+import { randomUUID } from 'node:crypto'
+import {
+  link,
+  mkdir,
+  mkdtemp,
+  rename,
+  rm,
+  stat,
+  unlink,
+} from 'node:fs/promises'
+import { basename, dirname, join } from 'node:path'
+
+type OutputWriter = (stagedPath: string) => Promise<void>
+type NodeError = Error & { code?: string }
+
+async function pathExists(path: string): Promise<boolean> {
+  try {
+    await stat(path)
+    return true
+  } catch (error) {
+    if ((error as NodeError).code === 'ENOENT') return false
+    throw error
+  }
+}
+
+function destinationExists(path: string): Error {
+  return new Error(`Output destination already exists: ${path}`)
+}
+
+async function replaceStagedPath(
+  stagedPath: string,
+  destination: string,
+  backupPath: string,
+): Promise<void> {
+  const hadDestination = await pathExists(destination)
+  if (hadDestination) await rename(destination, backupPath)
+  try {
+    await rename(stagedPath, destination)
+  } catch (error) {
+    if (hadDestination) {
+      try {
+        await rename(backupPath, destination)
+      } catch (restoreError) {
+        throw new AggregateError(
+          [error, restoreError],
+          `Could not publish ${destination}; the previous output remains recoverable at ${backupPath}`,
+        )
+      }
+    }
+    throw error
+  }
+  if (hadDestination) await rm(backupPath, { recursive: true, force: true })
+}
+
+async function publishStagedFile(
+  stagedPath: string,
+  destination: string,
+  force: boolean,
+  backupPath: string,
+): Promise<void> {
+  if (force) {
+    await replaceStagedPath(stagedPath, destination, backupPath)
+    return
+  }
+  try {
+    await link(stagedPath, destination)
+    await unlink(stagedPath)
+  } catch (error) {
+    if ((error as NodeError).code === 'EEXIST')
+      throw destinationExists(destination)
+    throw error
+  }
+}
+
+async function publishStagedDirectory(
+  stagedPath: string,
+  destination: string,
+  force: boolean,
+  backupPath: string,
+): Promise<void> {
+  if (!force && (await pathExists(destination))) {
+    throw destinationExists(destination)
+  }
+  if (force) {
+    await replaceStagedPath(stagedPath, destination, backupPath)
+    return
+  }
+  try {
+    await rename(stagedPath, destination)
+  } catch (error) {
+    if ((error as NodeError).code === 'EEXIST')
+      throw destinationExists(destination)
+    throw error
+  }
+}
+
+export async function publishAtomicOutput(
+  destination: string,
+  kind: 'file' | 'directory',
+  force: boolean,
+  write: OutputWriter,
+): Promise<void> {
+  const parent = dirname(destination)
+  await mkdir(parent, { recursive: true })
+  const temporaryDirectory = await mkdtemp(
+    join(parent, `.${basename(destination)}.pickle-export-`),
+  )
+  const stagedPath = join(temporaryDirectory, 'output')
+  const backupPath = join(
+    parent,
+    `.${basename(destination)}.pickle-backup-${randomUUID()}`,
+  )
+  try {
+    await write(stagedPath)
+    if (kind === 'directory') {
+      await publishStagedDirectory(stagedPath, destination, force, backupPath)
+    } else {
+      await publishStagedFile(stagedPath, destination, force, backupPath)
+    }
+  } finally {
+    await rm(temporaryDirectory, { recursive: true, force: true })
+  }
+}

--- a/packages/runner/src/local-project-storage.ts
+++ b/packages/runner/src/local-project-storage.ts
@@ -10,6 +10,7 @@ export interface LocalProjectStorage {
   runsDirectory: string
   archivesDirectory: string
   runIndexPath: string
+  runPinsPath: string
   executionCachePath: string
 }
 
@@ -80,6 +81,7 @@ export function resolveLocalProjectStorage(
     runsDirectory: join(projectDirectory, 'runs'),
     archivesDirectory: join(projectDirectory, 'archives'),
     runIndexPath: join(projectDirectory, 'index.sqlite'),
+    runPinsPath: join(projectDirectory, 'pinned-runs.json'),
     executionCachePath: join(canonicalPickleHome, 'execution-cache.sqlite'),
   }
 }

--- a/packages/runner/src/public-results.ts
+++ b/packages/runner/src/public-results.ts
@@ -61,6 +61,9 @@ function publicArtifact(artifact: TestArtifact): TestArtifact {
     kind: artifact.kind,
     path: artifact.path,
     mediaType: artifact.mediaType,
+    name: artifact.name,
+    capturedAt: artifact.capturedAt,
+    sizeBytes: artifact.sizeBytes,
   }
 }
 
@@ -145,6 +148,9 @@ function projectAttempt(
     evidenceAvailability: attempt.evidenceAvailability.map(
       publicEvidenceAvailability,
     ),
+    applicationOutputAvailability: attempt.applicationOutputAvailability?.map(
+      (availability) => ({ ...availability }),
+    ),
     diagnostics: attempt.diagnostics?.map((entry) => ({ ...entry })),
   }
 }
@@ -213,6 +219,7 @@ function publicEventPayload(
           sourceRunId: event.run.sourceRunId,
           suite: event.run.suite,
           applicationRevision: event.run.applicationRevision,
+          evidencePersistence: event.run.evidencePersistence,
         },
       }
     case 'scenario-started':

--- a/packages/runner/src/run-scenario-types.ts
+++ b/packages/runner/src/run-scenario-types.ts
@@ -42,6 +42,9 @@ export interface TestArtifact {
   kind: 'screenshot' | 'trace' | 'recording' | 'device-log'
   path: string
   mediaType?: string
+  name?: string
+  capturedAt?: string
+  sizeBytes?: number
 }
 
 export const evidenceKinds = [
@@ -68,6 +71,12 @@ export interface EvidenceAvailability {
   message?: string
 }
 
+export interface ApplicationOutputEvidenceAvailability {
+  stream: 'stdout' | 'stderr'
+  state: EvidenceAvailabilityState
+  message?: string
+}
+
 export const diagnosticLevels = ['debug', 'info', 'warning', 'error'] as const
 export type DiagnosticLevel = (typeof diagnosticLevels)[number]
 
@@ -76,6 +85,7 @@ export const diagnosticOrigins = [
   'network',
   'runner',
   'adapter',
+  'application',
 ] as const
 export type DiagnosticOrigin = (typeof diagnosticOrigins)[number]
 
@@ -84,6 +94,7 @@ export interface DiagnosticEntry {
   causalAt?: string
   level: DiagnosticLevel
   origin: DiagnosticOrigin
+  stream?: 'stdout' | 'stderr'
   message: string
   scenarioId?: string
   scenarioName?: string
@@ -235,6 +246,7 @@ export interface ScenarioAttempt {
   message?: string
   fidelityPolicy?: FidelityPolicy
   evidenceAvailability: EvidenceAvailability[]
+  applicationOutputAvailability?: ApplicationOutputEvidenceAvailability[]
   diagnostics?: DiagnosticEntry[]
 }
 
@@ -285,6 +297,7 @@ export type RunEventPayload =
         sourceRunId?: string
         suite?: string
         applicationRevision?: string
+        evidencePersistence?: 'off' | 'on-failure' | 'always'
       }
     }
   | {

--- a/packages/runner/src/scenario-runtime.ts
+++ b/packages/runner/src/scenario-runtime.ts
@@ -123,6 +123,7 @@ function publicArtifacts(
     mediaType: artifact.mediaType
       ? redactString(artifact.mediaType, bindings)
       : undefined,
+    name: artifact.name ? redactString(artifact.name, bindings) : undefined,
   }))
 }
 

--- a/packages/runner/src/test-run-exports.test.ts
+++ b/packages/runner/src/test-run-exports.test.ts
@@ -1,0 +1,246 @@
+import { expect, test } from 'bun:test'
+import { mkdir, mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import {
+  openTestRunStore,
+  projectAllureResults,
+  publishTestRunExports,
+  resolveLocalProjectStorage,
+  type TestResult,
+  type TestRunManifest,
+} from '../index'
+
+const startedAt = '2026-08-15T12:00:01.000Z'
+const finishedAt = '2026-08-15T12:00:02.000Z'
+
+function manifest(artifactPath: string): TestRunManifest {
+  const failedAttempt: TestResult['attempts'][number] = {
+    attempt: 1,
+    startedAt,
+    finishedAt,
+    durationMs: 1_000,
+    state: 'failed',
+    message: 'Payment was declined',
+    steps: [
+      {
+        index: 0,
+        startedAt,
+        finishedAt,
+        durationMs: 1_000,
+        step: { keyword: 'Then', text: 'payment is captured', type: 'outcome' },
+        state: 'failed',
+        message: 'Payment was declined',
+        resolvedActions: [{ description: 'Inspect payment status' }],
+        artifacts: [
+          { kind: 'screenshot', path: artifactPath, mediaType: 'image/png' },
+        ],
+      },
+    ],
+    evidenceAvailability: [
+      { kind: 'screenshot', state: 'available' },
+      { kind: 'trace', state: 'not-supported' },
+      { kind: 'recording', state: 'not-supported' },
+      { kind: 'device-log', state: 'not-supported' },
+      { kind: 'diagnostics', state: 'not-supported' },
+    ],
+  }
+  const passedAttempt = {
+    ...failedAttempt,
+    attempt: 2,
+    state: 'passed' as const,
+    message: undefined,
+    steps: [],
+    evidenceAvailability: failedAttempt.evidenceAvailability.map(
+      (availability) =>
+        availability.kind === 'screenshot'
+          ? { ...availability, state: 'not-retained' as const }
+          : availability,
+    ),
+  }
+  return {
+    schemaVersion: 2,
+    id: 'run-exports',
+    startedAt,
+    finishedAt,
+    state: 'passed',
+    results: [
+      {
+        schemaVersion: 2,
+        specification: {
+          name: 'Checkout',
+          uri: 'features/checkout.feature',
+        },
+        scenario: {
+          name: 'Pay for the order',
+          id: 'scnpaybbbbbbbbbb',
+          examplesRowId: 'row-card',
+        },
+        executionTargetProfile: { id: 'chrome' },
+        state: 'passed',
+        startedAt,
+        finishedAt,
+        durationMs: 1_000,
+        attempts: [failedAttempt, passedAttempt],
+        flaky: true,
+      },
+    ],
+  }
+}
+
+test('projects every Scenario attempt to common-core Allure result files', () => {
+  const projected = projectAllureResults(manifest('/run/artifacts/failure.png'))
+
+  expect(projected.results).toHaveLength(2)
+  expect(projected.results[0]?.result).toMatchObject({
+    testCaseId: 'scnpaybbbbbbbbbb',
+    name: 'Pay for the order',
+    status: 'failed',
+    stage: 'finished',
+    statusDetails: { message: 'Payment was declined', flaky: true },
+    parameters: [
+      { name: 'examplesRowId', value: 'row-card' },
+      { name: 'executionTargetProfile', value: 'chrome' },
+      { name: 'attempt', value: '1', excluded: true },
+    ],
+  })
+  expect(projected.results[0]?.result.steps[0]).toMatchObject({
+    name: 'Then payment is captured',
+    status: 'failed',
+    steps: [{ name: 'Inspect payment status', status: 'passed' }],
+  })
+  expect(projected.results[0]?.result.attachments).toHaveLength(1)
+  expect(projected.results[0]?.result.historyId).toBe(
+    projected.results[1]?.result.historyId,
+  )
+  expect(projected.results[0]?.result.uuid).not.toBe(
+    projected.results[1]?.result.uuid,
+  )
+  expect(projected.attachments).toEqual([
+    {
+      sourcePath: '/run/artifacts/failure.png',
+      fileName: expect.stringMatching(/-attachment\.png$/),
+    },
+  ])
+})
+
+test('publishes requested outputs independently without replacing destinations', async () => {
+  const root = await mkdtemp(join(tmpdir(), 'pickle-exports-'))
+  const pickleHome = join(root, '.pickle-home')
+  try {
+    const sourceArtifact = join(root, 'failure.png')
+    await Bun.write(sourceArtifact, 'png-bytes')
+    const canonical = manifest(sourceArtifact)
+    const store = openTestRunStore({
+      root,
+      pickleHome,
+      createId: () => canonical.id,
+      artifactCapture: 'always',
+      now: () => new Date(finishedAt),
+    })
+    const run = await store.create()
+    await run.append({
+      type: 'run-started',
+      run: { id: run.id, startedAt },
+    })
+    for (const result of canonical.results) {
+      for (const attempt of result.attempts) {
+        await run.append({
+          type: 'scenario-finished',
+          specification: result.specification,
+          scenario: result.scenario,
+          executionTargetProfile: result.executionTargetProfile,
+          scope: {
+            scenarioId: result.scenario.id!,
+            examplesRowId: result.scenario.examplesRowId,
+            executionTargetProfileId: result.executionTargetProfile.id,
+            attempt: attempt.attempt,
+          },
+          attempt,
+        })
+      }
+    }
+    await run.materialize()
+
+    const outputsDirectory = join(root, 'outputs')
+    await mkdir(outputsDirectory)
+    const jsonPath = join(outputsDirectory, 'run.json')
+    const ndjsonPath = join(outputsDirectory, 'events.ndjson')
+    const occupiedPath = join(outputsDirectory, 'run.xml')
+    const htmlPath = join(outputsDirectory, 'run.html')
+    const archivePath = join(outputsDirectory, 'run.archive.json')
+    const allurePath = join(outputsDirectory, 'allure-results')
+    await Bun.write(occupiedPath, 'keep-me')
+    const runDirectory = join(
+      resolveLocalProjectStorage(root, pickleHome).runsDirectory,
+      run.id,
+    )
+    const manifestBefore = await Bun.file(
+      join(runDirectory, 'manifest.json'),
+    ).text()
+    const eventsBefore = await Bun.file(
+      join(runDirectory, 'events.ndjson'),
+    ).text()
+
+    const outcomes = await publishTestRunExports({
+      root,
+      pickleHome,
+      runId: run.id,
+      outputs: [
+        { format: 'json', path: jsonPath },
+        { format: 'ndjson', path: ndjsonPath },
+        { format: 'junit', path: occupiedPath },
+        { format: 'html', path: htmlPath },
+        { format: 'archive', path: archivePath },
+        { format: 'allure', path: allurePath },
+      ],
+    })
+
+    expect(outcomes.map(({ status }) => status)).toEqual([
+      'succeeded',
+      'succeeded',
+      'failed',
+      'succeeded',
+      'succeeded',
+      'succeeded',
+    ])
+    expect(await Bun.file(occupiedPath).text()).toBe('keep-me')
+    expect(await Bun.file(jsonPath).json()).toMatchObject({ id: run.id })
+    expect([
+      ...new Bun.Glob('*-result.json').scanSync({ cwd: allurePath }),
+    ]).toHaveLength(2)
+    expect([
+      ...new Bun.Glob('*-attachment.png').scanSync({ cwd: allurePath }),
+    ]).toHaveLength(1)
+    expect(await Bun.file(ndjsonPath).text()).toContain('"type":"run-started"')
+    expect(await Bun.file(htmlPath).text()).toContain('<!DOCTYPE html>')
+    expect(await Bun.file(archivePath).json()).toMatchObject({
+      kind: 'run-archive',
+    })
+
+    await Bun.write(jsonPath, 'replace-me')
+    const forced = await publishTestRunExports({
+      root,
+      pickleHome,
+      runId: run.id,
+      force: true,
+      outputs: [
+        { format: 'json', path: jsonPath },
+        { format: 'allure', path: allurePath },
+      ],
+    })
+    expect(forced.map(({ status }) => status)).toEqual([
+      'succeeded',
+      'succeeded',
+    ])
+    expect(await Bun.file(jsonPath).json()).toMatchObject({ id: run.id })
+    expect(await Bun.file(join(runDirectory, 'manifest.json')).text()).toBe(
+      manifestBefore,
+    )
+    expect(await Bun.file(join(runDirectory, 'events.ndjson')).text()).toBe(
+      eventsBefore,
+    )
+  } finally {
+    await rm(root, { recursive: true, force: true })
+  }
+})

--- a/packages/runner/src/test-run-exports.ts
+++ b/packages/runner/src/test-run-exports.ts
@@ -1,0 +1,177 @@
+import { mkdir } from 'node:fs/promises'
+import { join } from 'node:path'
+import {
+  assertAllureArtifactPath,
+  projectAllureResults,
+} from './allure-results'
+import { writeRunArchive } from './archive'
+import { publishAtomicOutput } from './atomic-output'
+import { resolveLocalProjectStorage } from './local-project-storage'
+import { formatHtml, formatJson, formatJunit, formatNdjson } from './outputs'
+import type { RunEvent } from './run-scenario'
+import { parseTestRunManifest } from './test-run-schema'
+import { openTestRunStore, type TestRunManifest } from './test-run-store'
+
+export const testRunExportFormats = [
+  'json',
+  'ndjson',
+  'junit',
+  'html',
+  'archive',
+  'allure',
+] as const
+
+export type TestRunExportFormat = (typeof testRunExportFormats)[number]
+
+export interface TestRunExportRequest {
+  format: TestRunExportFormat
+  path: string
+}
+
+export type TestRunExportOutcome = TestRunExportRequest &
+  ({ status: 'succeeded' } | { status: 'failed'; message: string })
+
+export interface PublishTestRunExportsInput {
+  root: string
+  pickleHome?: string
+  runId: string
+  outputs: readonly TestRunExportRequest[]
+  force?: boolean
+  htmlArtifacts?: 'failures' | 'all'
+}
+
+interface FinalizedTestRun {
+  manifest: TestRunManifest
+  events: RunEvent[]
+}
+
+async function loadFinalizedTestRun(
+  input: Pick<PublishTestRunExportsInput, 'root' | 'pickleHome' | 'runId'>,
+): Promise<FinalizedTestRun> {
+  const store = openTestRunStore({
+    root: input.root,
+    pickleHome: input.pickleHome,
+  })
+  const run = await store.open(input.runId)
+  const events = await run.events()
+  if (events.length === 0) throw new Error(`Unknown test run "${input.runId}"`)
+  const manifestPath = join(
+    resolveLocalProjectStorage(input.root, input.pickleHome).runsDirectory,
+    input.runId,
+    'manifest.json',
+  )
+  if (!(await Bun.file(manifestPath).exists())) {
+    throw new Error(`Test run "${input.runId}" must be finalized before export`)
+  }
+  const manifest = parseTestRunManifest(
+    await Bun.file(manifestPath).json(),
+    (version): never => {
+      throw new Error(
+        `Test run storage schema version ${String(version)} is unsupported`,
+      )
+    },
+  )
+  if (!manifest.finishedAt) {
+    throw new Error(`Test run "${input.runId}" must be finalized before export`)
+  }
+  return { manifest, events }
+}
+
+async function writeAllureResults(
+  destination: string,
+  manifest: TestRunManifest,
+  artifactsDirectory: string,
+): Promise<void> {
+  await mkdir(destination)
+  const projection = projectAllureResults(manifest)
+  for (const { fileName, result } of projection.results) {
+    await Bun.write(
+      join(destination, fileName),
+      `${JSON.stringify(result, null, 2)}\n`,
+    )
+  }
+  for (const { sourcePath, fileName } of projection.attachments) {
+    const source = Bun.file(sourcePath)
+    if (!(await source.exists())) {
+      throw new Error(`Artifact source file is missing: ${sourcePath}`)
+    }
+    await assertAllureArtifactPath(sourcePath, artifactsDirectory)
+    await Bun.write(join(destination, fileName), source)
+  }
+}
+
+async function writeExport(
+  input: PublishTestRunExportsInput,
+  evidence: FinalizedTestRun,
+  output: TestRunExportRequest,
+  stagedPath: string,
+): Promise<void> {
+  switch (output.format) {
+    case 'json':
+      await Bun.write(stagedPath, formatJson(evidence.manifest))
+      return
+    case 'ndjson':
+      await Bun.write(stagedPath, formatNdjson(evidence.events))
+      return
+    case 'junit':
+      await Bun.write(stagedPath, formatJunit(evidence.manifest))
+      return
+    case 'html':
+      await Bun.write(
+        stagedPath,
+        await formatHtml(evidence.manifest, {
+          artifacts: input.htmlArtifacts ?? 'failures',
+        }),
+      )
+      return
+    case 'archive':
+      await writeRunArchive({
+        root: input.root,
+        pickleHome: input.pickleHome,
+        runId: input.runId,
+        outputPath: stagedPath,
+      })
+      return
+    case 'allure':
+      await writeAllureResults(
+        stagedPath,
+        evidence.manifest,
+        join(
+          resolveLocalProjectStorage(input.root, input.pickleHome)
+            .runsDirectory,
+          input.runId,
+          'artifacts',
+        ),
+      )
+  }
+}
+
+function failureMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error)
+}
+
+export async function publishTestRunExports(
+  input: PublishTestRunExportsInput,
+): Promise<TestRunExportOutcome[]> {
+  if (input.outputs.length === 0) return []
+  const evidence = await loadFinalizedTestRun(input)
+  const outcomes: TestRunExportOutcome[] = []
+  for (const output of input.outputs) {
+    try {
+      await publishAtomicOutput(
+        output.path,
+        output.format === 'allure' ? 'directory' : 'file',
+        input.force ?? false,
+        (stagedPath) => writeExport(input, evidence, output, stagedPath),
+      )
+      outcomes.push({ ...output, status: 'succeeded' })
+    } catch (error) {
+      outcomes.push({
+        ...output,
+        status: 'failed',
+        message: failureMessage(error),
+      })
+    }
+  }
+  return outcomes
+}

--- a/packages/runner/src/test-run-schema.test.ts
+++ b/packages/runner/src/test-run-schema.test.ts
@@ -103,6 +103,27 @@ test('treats Diagnostic entries as persisted diagnostics evidence', () => {
   expect(() => parseTestRunManifest(input, incompatibleSchema)).not.toThrow()
 })
 
+test('retains the managed application stream on Diagnostic entries', () => {
+  const input = manifest()
+  const attempt = input.results[0]!.attempts[0]!
+  attempt.evidenceAvailability[4] = { kind: 'diagnostics', state: 'available' }
+  attempt.diagnostics = [
+    {
+      occurredAt: attempt.startedAt,
+      level: 'info',
+      origin: 'application',
+      stream: 'stderr',
+      message: 'Database connection retried',
+      executionTargetProfileId: 'web',
+    },
+  ]
+
+  expect(
+    parseTestRunManifest(input, incompatibleSchema).results[0]?.attempts[0]
+      ?.diagnostics?.[0],
+  ).toMatchObject({ origin: 'application', stream: 'stderr' })
+})
+
 test('treats Pickle-native trace entries as persisted trace evidence', () => {
   const input = manifest()
   const attempt = input.results[0]!.attempts[0]!
@@ -133,4 +154,44 @@ test('treats Pickle-native trace entries as persisted trace evidence', () => {
   ]
 
   expect(() => parseTestRunManifest(input, incompatibleSchema)).not.toThrow()
+})
+
+test('retains adapter-neutral Test artifact capture metadata', () => {
+  const input = manifest()
+  const attempt = input.results[0]!.attempts[0]!
+  attempt.evidenceAvailability[0] = {
+    kind: 'screenshot',
+    state: 'available',
+  }
+  attempt.steps = [
+    {
+      index: 0,
+      startedAt: attempt.startedAt,
+      finishedAt: attempt.finishedAt,
+      durationMs: 0,
+      step: { keyword: 'Then', text: 'receipt appears', type: 'outcome' },
+      state: 'passed',
+      resolvedActions: [],
+      artifacts: [
+        {
+          kind: 'screenshot',
+          path: '/tmp/receipt.png',
+          mediaType: 'image/png',
+          name: 'receipt.png',
+          capturedAt: attempt.finishedAt,
+          sizeBytes: 4_096,
+        },
+      ],
+    },
+  ]
+
+  const parsed = parseTestRunManifest(input, incompatibleSchema)
+
+  expect(
+    parsed.results[0]?.attempts[0]?.steps[0]?.artifacts?.[0],
+  ).toMatchObject({
+    name: 'receipt.png',
+    capturedAt: attempt.finishedAt,
+    sizeBytes: 4_096,
+  })
 })

--- a/packages/runner/src/test-run-schema.ts
+++ b/packages/runner/src/test-run-schema.ts
@@ -70,6 +70,9 @@ const artifactSchema = z.object({
   kind: z.enum(['screenshot', 'trace', 'recording', 'device-log']),
   path: z.string(),
   mediaType: z.string().optional(),
+  name: z.string().min(1).optional(),
+  capturedAt: timestampSchema.optional(),
+  sizeBytes: nonNegativeIntegerSchema.optional(),
 })
 
 const diagnosticEntrySchema = z.object({
@@ -77,6 +80,7 @@ const diagnosticEntrySchema = z.object({
   causalAt: timestampSchema.optional(),
   level: z.enum(diagnosticLevels),
   origin: z.enum(diagnosticOrigins),
+  stream: z.enum(['stdout', 'stderr']).optional(),
   message: z.string(),
   scenarioId: z.string().optional(),
   scenarioName: z.string().optional(),
@@ -115,6 +119,19 @@ const fidelityPolicySchema = z.object({
 
 const evidenceAvailabilitySchema = z.object({
   kind: z.enum(evidenceKinds),
+  state: z.enum([
+    'available',
+    'not-requested',
+    'not-supported',
+    'not-retained',
+    'capture-failed',
+    'missing',
+  ]),
+  message: z.string().optional(),
+})
+
+const applicationOutputEvidenceAvailabilitySchema = z.object({
+  stream: z.enum(['stdout', 'stderr']),
   state: z.enum([
     'available',
     'not-requested',
@@ -177,6 +194,52 @@ function validateEvidenceAvailability(
   }
 }
 
+function validateApplicationOutputAvailability(
+  attempt: ScenarioAttempt,
+  context: z.RefinementCtx,
+): void {
+  if (!attempt.applicationOutputAvailability) return
+  const streams = new Set<string>()
+  const persistedStreams = new Set(
+    [
+      ...(attempt.diagnostics ?? []),
+      ...attempt.steps.flatMap((step) => step.diagnostics ?? []),
+    ]
+      .filter((entry) => entry.origin === 'application' && entry.stream)
+      .map((entry) => entry.stream),
+  )
+  for (const [
+    index,
+    availability,
+  ] of attempt.applicationOutputAvailability.entries()) {
+    if (streams.has(availability.stream)) {
+      context.addIssue({
+        code: 'custom',
+        path: ['applicationOutputAvailability', index, 'stream'],
+        message: `Application output stream "${availability.stream}" must be unique`,
+      })
+    }
+    streams.add(availability.stream)
+    const hasPersistedOutput = persistedStreams.has(availability.stream)
+    if (hasPersistedOutput !== (availability.state === 'available')) {
+      context.addIssue({
+        code: 'custom',
+        path: ['applicationOutputAvailability', index, 'state'],
+        message: `Application output availability for "${availability.stream}" must match persisted Diagnostic entries`,
+      })
+    }
+  }
+  for (const stream of ['stdout', 'stderr']) {
+    if (!streams.has(stream)) {
+      context.addIssue({
+        code: 'custom',
+        path: ['applicationOutputAvailability'],
+        message: `Application output availability must include "${stream}"`,
+      })
+    }
+  }
+}
+
 const scenarioAttemptSchema: z.ZodType<ScenarioAttempt> = z
   .object({
     attempt: positiveIntegerSchema,
@@ -204,11 +267,15 @@ const scenarioAttemptSchema: z.ZodType<ScenarioAttempt> = z
     message: z.string().optional(),
     fidelityPolicy: fidelityPolicySchema.optional(),
     evidenceAvailability: z.array(evidenceAvailabilitySchema),
+    applicationOutputAvailability: z
+      .array(applicationOutputEvidenceAvailabilitySchema)
+      .optional(),
     diagnostics: z.array(diagnosticEntrySchema).optional(),
   })
   .superRefine((attempt, context) => {
     validateTiming(attempt, context)
     validateEvidenceAvailability(attempt, context)
+    validateApplicationOutputAvailability(attempt, context)
   })
 
 const specificationIdentitySchema = z.object({
@@ -328,6 +395,7 @@ const runEventSchema: z.ZodType<RunEvent> = z.discriminatedUnion('type', [
       sourceRunId: z.string().optional(),
       suite: z.string().optional(),
       applicationRevision: z.string().optional(),
+      evidencePersistence: z.enum(['off', 'on-failure', 'always']).optional(),
     }),
   }),
   z.object({

--- a/packages/runner/src/test-run-store.test.ts
+++ b/packages/runner/src/test-run-store.test.ts
@@ -1,6 +1,6 @@
 import { Database } from 'bun:sqlite'
 import { afterEach, expect, test } from 'bun:test'
-import { mkdir, mkdtemp, rm } from 'node:fs/promises'
+import { chmod, mkdir, mkdtemp, rm, truncate } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import {
@@ -961,6 +961,128 @@ test('retention removes eligible local data without changing retained test runs'
   ])
 })
 
+test('retention is disabled when no age or storage limit is configured', async () => {
+  const root = await tempRoot()
+  let clock = new Date('2026-07-01T00:00:00.000Z')
+  const store = openTestRunStore({
+    root,
+    createId: () => 'run-unconfigured-retention',
+    now: () => clock,
+  })
+  const run = await store.create()
+  await run.append(scenarioFinished(passedResult()))
+  await run.materialize()
+  const eventsPath = join(
+    storageFor(root).runsDirectory,
+    run.id,
+    'events.ndjson',
+  )
+  const eventsBefore = await Bun.file(eventsPath).text()
+  clock = new Date('2026-08-15T00:00:00.000Z')
+
+  const result = await store.applyRetention()
+
+  expect(result.removed).toEqual([])
+  expect(await Bun.file(eventsPath).text()).toBe(eventsBefore)
+})
+
+test('inspects total Test run storage against the default 5 GB warning threshold', async () => {
+  const root = await tempRoot()
+  const store = openTestRunStore({
+    root,
+    createId: () => 'run-storage-inspection',
+  })
+  const run = await store.create()
+  await run.append(scenarioFinished(passedResult()))
+  await run.materialize()
+
+  const inspection = await store.inspectStorage()
+
+  expect(inspection.totalBytes).toBeGreaterThan(0)
+  expect(inspection.warningThresholdBytes).toBe(5 * 1024 * 1024 * 1024)
+  expect(inspection.warning).toBe(false)
+  expect(inspection.pinnedRunIds).toEqual([])
+
+  const sparseArtifact = join(
+    storageFor(root).runsDirectory,
+    run.id,
+    'large-recording.bin',
+  )
+  await Bun.write(sparseArtifact, '')
+  await truncate(sparseArtifact, 5 * 1024 * 1024 * 1024)
+
+  expect((await store.inspectStorage()).warning).toBe(true)
+})
+
+test('persists explicit Pin state without changing the immutable Test run', async () => {
+  const root = await tempRoot()
+  const store = openTestRunStore({
+    root,
+    createId: () => 'run-pinned',
+  })
+  const run = await store.create()
+  await run.append(scenarioFinished(passedResult()))
+  await run.materialize()
+  const runDirectory = join(storageFor(root).runsDirectory, run.id)
+  const eventsBefore = await Bun.file(
+    join(runDirectory, 'events.ndjson'),
+  ).text()
+  const manifestBefore = await Bun.file(
+    join(runDirectory, 'manifest.json'),
+  ).text()
+
+  await store.pin(run.id)
+
+  const reopened = openTestRunStore({ root })
+  expect((await reopened.inspectStorage()).pinnedRunIds).toEqual([run.id])
+  expect(await Bun.file(join(runDirectory, 'events.ndjson')).text()).toBe(
+    eventsBefore,
+  )
+  expect(await Bun.file(join(runDirectory, 'manifest.json')).text()).toBe(
+    manifestBefore,
+  )
+
+  await reopened.unpin(run.id)
+  expect(
+    (await openTestRunStore({ root }).inspectStorage()).pinnedRunIds,
+  ).toEqual([])
+})
+
+test('retention removes only complete unpinned Test runs and reports storage totals', async () => {
+  const root = await tempRoot()
+  let clock = new Date('2026-07-01T00:00:00.000Z')
+  let nextId = 1
+  const store = openTestRunStore({
+    root,
+    createId: () => `run-${nextId++}`,
+    now: () => clock,
+  })
+  const expired = await store.create()
+  await expired.append(scenarioFinished(passedResult('Expired purchase')))
+  await expired.materialize()
+  const pinned = await store.create()
+  await pinned.append(scenarioFinished(passedResult('Pinned purchase')))
+  await pinned.materialize()
+  await store.pin(pinned.id)
+  const active = await store.create()
+  await active.append(scenarioFinished(passedResult('Active purchase')))
+  await active.materialize({ finished: false })
+  clock = new Date('2026-08-15T00:00:00.000Z')
+
+  const result = await store.applyRetention({
+    maxAgeMs: 14 * 24 * 60 * 60 * 1000,
+  })
+
+  expect(result.removed).toEqual([expired.id])
+  expect(result.beforeBytes).toBeGreaterThan(result.afterBytes)
+  expect(result.afterBytes).toBe((await store.inspectStorage()).totalBytes)
+  expect((await store.list()).map((run) => run.id)).toEqual([
+    pinned.id,
+    active.id,
+  ])
+  expect((await store.inspectStorage()).pinnedRunIds).toEqual([pinned.id])
+})
+
 test('a rerun creates a new test run with a source-run reference', async () => {
   const root = await tempRoot()
   let nextId = 1
@@ -1015,33 +1137,12 @@ test('retention evicts the oldest runs when stored bytes exceed the limit', asyn
   const second = await store.create()
   await second.append(scenarioFinished(passedResult('Second purchase')))
   await second.materialize()
-  const retainedEvents = await Bun.file(
-    join(storageFor(root).runsDirectory, 'run-2', 'events.ndjson'),
-  ).text()
-
   const result = await store.applyRetention({ maxBytes: 1 })
 
-  expect(result.removed).toEqual(['run-1'])
-  expect(
-    await Bun.file(
-      join(storageFor(root).runsDirectory, 'run-2', 'events.ndjson'),
-    ).text(),
-  ).toBe(retainedEvents)
-  expect(await store.list()).toEqual([
-    {
-      id: 'run-2',
-      executionTargetProfileIds: ['deterministic'],
-      specificationUris: ['features/checkout.feature'],
-      startedAt: '2026-08-15T00:00:00.000Z',
-      finishedAt: '2026-08-15T00:00:00.000Z',
-      durationMs: 0,
-      state: 'passed',
-      resultCount: 1,
-      executionModes: ['adaptive'],
-      cacheOutcomes: ['uncacheable'],
-      inferenceCount: 0,
-    },
-  ])
+  expect(result.removed).toEqual(['run-1', 'run-2'])
+  expect(result.beforeBytes).toBeGreaterThan(result.afterBytes)
+  expect(result.afterBytes).toBe(0)
+  expect(await store.list()).toEqual([])
 })
 
 function resultWithArtifact(
@@ -1085,6 +1186,277 @@ function resultWithArtifact(
     ],
   }
 }
+
+function withDiagnosticEvidence(result: TestResult): TestResult {
+  const attempt = result.attempts[0]!
+  const diagnostic = {
+    occurredAt: attempt.finishedAt,
+    level: 'error' as const,
+    origin: 'adapter' as const,
+    message: `Diagnostic for ${result.scenario.name}`,
+  }
+  return {
+    ...result,
+    attempts: [
+      {
+        ...attempt,
+        diagnostics: [diagnostic],
+        evidenceAvailability: attempt.evidenceAvailability.map((item) =>
+          item.kind === 'diagnostics'
+            ? { kind: item.kind, state: 'available' as const }
+            : item,
+        ),
+        steps: attempt.steps.map((step) => ({
+          ...step,
+          diagnostics: [diagnostic],
+        })),
+      },
+    ],
+  }
+}
+
+test('issue 83: resolves Evidence persistence per profile with a run-wide default', async () => {
+  const root = await tempRoot()
+  const persistSource = join(root, 'persist.png')
+  const dropSource = join(root, 'drop.png')
+  const defaultSource = join(root, 'default.png')
+  await Promise.all(
+    [persistSource, dropSource, defaultSource].map((path) =>
+      Bun.write(path, new Uint8Array([137, 80, 78, 71])),
+    ),
+  )
+  const store = openTestRunStore({
+    root,
+    createId: () => 'run-mixed-evidence-policy',
+    evidencePersistence: 'on-failure',
+    evidencePersistenceByProfile: {
+      persist: 'always',
+      drop: 'off',
+    },
+  })
+  const run = await store.create()
+  const forProfile = (result: TestResult, id: string): TestResult => ({
+    ...withDiagnosticEvidence(result),
+    executionTargetProfile: { id },
+  })
+
+  await run.append(
+    scenarioFinished(
+      forProfile(
+        resultWithArtifact('Persist passed evidence', 'passed', persistSource),
+        'persist',
+      ),
+    ),
+  )
+  const liveDropped = await run.append(
+    scenarioFinished(
+      forProfile(
+        resultWithArtifact('Drop failed evidence', 'failed', dropSource),
+        'drop',
+      ),
+    ),
+  )
+  await run.append(
+    scenarioFinished(
+      forProfile(
+        resultWithArtifact('Default failed evidence', 'failed', defaultSource),
+        'default',
+      ),
+    ),
+  )
+
+  expect(liveDropped).toMatchObject({
+    type: 'scenario-finished',
+    attempt: {
+      diagnostics: [{ message: 'Diagnostic for Drop failed evidence' }],
+      steps: [{ artifacts: [{ path: dropSource }] }],
+    },
+  })
+  const persisted = (await run.events()).filter(
+    (event) => event.type === 'scenario-finished',
+  )
+  expect(persisted).toHaveLength(3)
+  expect(persisted[0]).toMatchObject({
+    attempt: {
+      diagnostics: [{ message: 'Diagnostic for Persist passed evidence' }],
+      steps: [
+        { artifacts: [{ path: expect.stringContaining('/artifacts/') }] },
+      ],
+    },
+  })
+  expect(persisted[1]).toMatchObject({
+    attempt: {
+      evidenceAvailability: [
+        { kind: 'screenshot', state: 'not-retained' },
+        { kind: 'trace', state: 'not-supported' },
+        { kind: 'recording', state: 'not-supported' },
+        { kind: 'device-log', state: 'not-supported' },
+        { kind: 'diagnostics', state: 'not-retained' },
+      ],
+      steps: [{}],
+    },
+  })
+  expect(persisted[1]?.type).toBe('scenario-finished')
+  if (persisted[1]?.type !== 'scenario-finished') {
+    throw new Error('Expected persisted Scenario evidence')
+  }
+  expect(persisted[1].attempt.diagnostics).toBeUndefined()
+  expect(persisted[1].attempt.steps[0]?.artifacts).toBeUndefined()
+  expect(persisted[2]).toMatchObject({
+    attempt: {
+      diagnostics: [{ message: 'Diagnostic for Default failed evidence' }],
+      steps: [
+        { artifacts: [{ path: expect.stringContaining('/artifacts/') }] },
+      ],
+    },
+  })
+  expect((await run.materialize()).results).toHaveLength(3)
+})
+
+test('issue 83: an individual Test run overrides the profile Evidence persistence policy', async () => {
+  const root = await tempRoot()
+  const source = join(root, 'run-override.png')
+  await Bun.write(source, new Uint8Array([137, 80, 78, 71]))
+  const store = openTestRunStore({
+    root,
+    createId: () => 'run-evidence-override',
+    evidencePersistenceByProfile: { chrome: 'off' },
+  })
+  const run = await store.create({ evidencePersistence: 'always' })
+  const result = resultWithArtifact('Run override', 'passed', source)
+
+  await run.append(
+    scenarioFinished({
+      ...result,
+      executionTargetProfile: { id: 'chrome' },
+    }),
+  )
+
+  const persisted = (await run.events()).at(-1)
+  expect(persisted?.type).toBe('scenario-finished')
+  if (persisted?.type !== 'scenario-finished') {
+    throw new Error('Expected persisted Scenario evidence')
+  }
+  expect(persisted.attempt.steps[0]?.artifacts?.[0]?.path).toContain(
+    '/artifacts/',
+  )
+})
+
+test('issue 83: reopens an unfinished Test run with its Evidence persistence override', async () => {
+  const root = await tempRoot()
+  const source = join(root, 'reopened-run-override.png')
+  await Bun.write(source, new Uint8Array([137, 80, 78, 71]))
+  const store = openTestRunStore({
+    root,
+    createId: () => 'run-reopened-evidence-override',
+    evidencePersistence: 'off',
+  })
+  const created = await store.create({ evidencePersistence: 'always' })
+  const reopened = await openTestRunStoreBase({
+    root,
+    pickleHome: storageFor(root).pickleHome,
+    evidencePersistence: 'off',
+  }).open(created.id)
+
+  await reopened.append(
+    scenarioFinished(resultWithArtifact('Reopened override', 'passed', source)),
+  )
+
+  const persisted = (await reopened.events()).at(-1)
+  expect(persisted?.type).toBe('scenario-finished')
+  if (persisted?.type !== 'scenario-finished') {
+    throw new Error('Expected persisted Scenario result')
+  }
+  expect(persisted.attempt.steps[0]?.artifacts?.[0]?.path).toContain(
+    '/artifacts/',
+  )
+})
+
+test('issue 83: a missing temporary artifact records capture failure and preserves committed evidence', async () => {
+  const root = await tempRoot()
+  const source = join(root, 'committed.png')
+  const missing = join(root, 'missing.png')
+  await Bun.write(source, new Uint8Array([137, 80, 78, 71]))
+  const store = openTestRunStore({
+    root,
+    createId: () => 'run-capture-failure',
+    evidencePersistence: 'always',
+  })
+  const run = await store.create()
+  await run.append(
+    scenarioFinished(
+      resultWithArtifact('Committed evidence', 'passed', source),
+    ),
+  )
+  const firstEvent = (await run.events()).at(-1)
+  if (firstEvent?.type !== 'scenario-finished') {
+    throw new Error('Expected committed Scenario evidence')
+  }
+  const committedPath = firstEvent.attempt.steps[0]?.artifacts?.[0]?.path
+  if (!committedPath) throw new Error('Expected a committed Test artifact')
+  const committedBytes = await Bun.file(committedPath).bytes()
+
+  await run.append(
+    scenarioFinished(resultWithArtifact('Missing evidence', 'failed', missing)),
+  )
+
+  const persisted = (await run.events()).at(-1)
+  expect(persisted?.type).toBe('scenario-finished')
+  if (persisted?.type !== 'scenario-finished') {
+    throw new Error('Expected persisted Scenario result')
+  }
+  expect(persisted.attempt.steps[0]?.artifacts).toBeUndefined()
+  expect(
+    persisted.attempt.evidenceAvailability.find(
+      (item) => item.kind === 'screenshot',
+    ),
+  ).toMatchObject({
+    state: 'capture-failed',
+    message: expect.stringContaining('missing.png'),
+  })
+  expect(await Bun.file(committedPath).bytes()).toEqual(committedBytes)
+  expect(
+    await Bun.file(
+      join(storageFor(root).runsDirectory, run.id, '.evidence-staging'),
+    ).exists(),
+  ).toBe(false)
+})
+
+test('issue 83: failed event publication rolls back staged binary evidence', async () => {
+  const root = await tempRoot()
+  const source = join(root, 'rollback.png')
+  await Bun.write(source, new Uint8Array([137, 80, 78, 71]))
+  const store = openTestRunStore({
+    root,
+    createId: () => 'run-publication-rollback',
+    evidencePersistence: 'always',
+  })
+  const run = await store.create()
+  const runDirectory = join(storageFor(root).runsDirectory, run.id)
+  const eventsPath = join(runDirectory, 'events.ndjson')
+  await chmod(eventsPath, 0o444)
+  try {
+    await expect(
+      run.append(
+        scenarioFinished(
+          resultWithArtifact('Rollback evidence', 'passed', source),
+        ),
+      ),
+    ).rejects.toThrow()
+  } finally {
+    await chmod(eventsPath, 0o644)
+  }
+
+  expect([
+    ...new Bun.Glob('**/*').scanSync({
+      cwd: join(runDirectory, 'artifacts'),
+      onlyFiles: true,
+    }),
+  ]).toEqual([])
+  expect(await Bun.file(join(runDirectory, '.evidence-staging')).exists()).toBe(
+    false,
+  )
+})
 
 test('issue 77: persists and reopens only schema-v2 Test evidence', async () => {
   const root = await tempRoot()

--- a/packages/runner/src/test-run-store.ts
+++ b/packages/runner/src/test-run-store.ts
@@ -1,14 +1,24 @@
 import { Database } from 'bun:sqlite'
-import { appendFile, copyFile, mkdir, rm, stat } from 'node:fs/promises'
-import { dirname, extname, join } from 'node:path'
+import {
+  appendFile,
+  copyFile,
+  mkdir,
+  rename,
+  rm,
+  rmdir,
+  stat,
+} from 'node:fs/promises'
+import { basename, dirname, extname, join } from 'node:path'
 import type { CacheOutcome } from './execution-cache'
 import { resolveLocalProjectStorage } from './local-project-storage'
 import { recordableRunEventPayloadData } from './public-results'
 import type {
+  EvidenceKind,
   ExecutionMode,
   RunEvent,
   RunEventPayload,
   ScenarioAttempt,
+  TestArtifact,
   TestResult,
   TestResultState,
   TestStepResult,
@@ -16,13 +26,18 @@ import type {
 import { finalScenarioAttempt, testRunSchemaVersion } from './run-scenario'
 import { parseRunEvent, parseTestRunManifest } from './test-run-schema'
 
-export type ArtifactCapturePolicy = 'off' | 'on-failure' | 'always'
+export type EvidencePersistencePolicy = 'off' | 'on-failure' | 'always'
+export type ArtifactCapturePolicy = EvidencePersistencePolicy
 
 export interface TestRunStoreOptions {
   root: string
   pickleHome?: string
   createId?: () => string
   now?: () => Date
+  evidencePersistence?: EvidencePersistencePolicy
+  evidencePersistenceByProfile?: Readonly<
+    Record<string, EvidencePersistencePolicy>
+  >
   artifactCapture?: ArtifactCapturePolicy
 }
 
@@ -42,6 +57,7 @@ export interface CreateTestRunOptions {
   sourceRunId?: string
   suite?: string
   applicationRevision?: string
+  evidencePersistence?: EvidencePersistencePolicy
 }
 
 export interface TestRunSummary {
@@ -75,6 +91,15 @@ export interface RetentionPolicy {
 
 export interface RetentionResult {
   removed: string[]
+  beforeBytes: number
+  afterBytes: number
+}
+
+export interface TestRunStorageInspection {
+  totalBytes: number
+  warningThresholdBytes: number
+  warning: boolean
+  pinnedRunIds: string[]
 }
 
 export interface TestRunStore {
@@ -82,16 +107,16 @@ export interface TestRunStore {
   open(id: string): Promise<PersistedTestRun>
   list(): Promise<TestRunSummary[]>
   rebuildIndex(): Promise<void>
+  inspectStorage(): Promise<TestRunStorageInspection>
+  pin(id: string): Promise<void>
+  unpin(id: string): Promise<void>
   applyRetention(policy?: RetentionPolicy): Promise<RetentionResult>
 }
 
-const dayMs = 24 * 60 * 60 * 1000
 const indexSchemaVersion = 5
 
-export const defaultRetention = {
-  maxAgeMs: 30 * dayMs,
-  maxBytes: 2 * 1024 * 1024 * 1024,
-}
+export const defaultRetention: Readonly<RetentionPolicy> = {}
+export const defaultRunStorageWarningBytes = 5 * 1024 * 1024 * 1024
 
 const stateRank: Record<TestResultState, number> = {
   skipped: 0,
@@ -102,6 +127,7 @@ const stateRank: Record<TestResultState, number> = {
 }
 
 type NodeError = Error & { code?: string }
+type RunPinsFile = { schemaVersion: 1; runIds: string[] }
 type SerializeOperation = <Value>(
   operation: () => Promise<Value>,
 ) => Promise<Value>
@@ -109,11 +135,15 @@ type SerializeOperation = <Value>(
 export function openTestRunStore(options: TestRunStoreOptions): TestRunStore {
   const createId = options.createId ?? (() => crypto.randomUUID())
   const now = options.now ?? (() => new Date())
-  const artifactCapture = options.artifactCapture ?? 'on-failure'
+  const evidencePersistence =
+    options.evidencePersistence ?? options.artifactCapture ?? 'on-failure'
+  const evidencePersistenceByProfile =
+    options.evidencePersistenceByProfile ?? {}
   const storage = resolveLocalProjectStorage(options.root, options.pickleHome)
   const projectDirectory = storage.projectDirectory
   const runsDirectory = storage.runsDirectory
   const indexPath = storage.runIndexPath
+  const runPinsPath = storage.runPinsPath
   const incompatibleSchema = (version: unknown): never => {
     throw new Error(
       `Test run storage schema version ${String(version)} is unsupported. ` +
@@ -121,6 +151,7 @@ export function openTestRunStore(options: TestRunStoreOptions): TestRunStore {
     )
   }
   const runOperationQueues = new Map<string, Promise<void>>()
+  let managementOperationQueue = Promise.resolve()
 
   function serializeRunOperation<Value>(
     id: string,
@@ -139,6 +170,57 @@ export function openTestRunStore(options: TestRunStoreOptions): TestRunStore {
     return result
   }
 
+  function serializeManagementOperation<Value>(
+    operation: () => Promise<Value>,
+  ): Promise<Value> {
+    const result = managementOperationQueue.then(operation)
+    managementOperationQueue = result.then(
+      () => undefined,
+      () => undefined,
+    )
+    return result
+  }
+
+  async function readPinnedRunIds(): Promise<Set<string>> {
+    if (!(await Bun.file(runPinsPath).exists())) return new Set()
+    const source: unknown = await Bun.file(runPinsPath).json()
+    if (!isRunPinsFile(source)) {
+      throw new Error('Pinned Test run metadata is invalid')
+    }
+    source.runIds.forEach(validateRunId)
+    return new Set(source.runIds)
+  }
+
+  async function writePinnedRunIds(runIds: ReadonlySet<string>): Promise<void> {
+    await mkdir(projectDirectory, { recursive: true })
+    const temporaryPath = `${runPinsPath}.${crypto.randomUUID()}.tmp`
+    const contents: RunPinsFile = {
+      schemaVersion: 1,
+      runIds: [...runIds].sort(),
+    }
+    try {
+      await Bun.write(temporaryPath, `${JSON.stringify(contents, null, 2)}\n`)
+      await rename(temporaryPath, runPinsPath)
+    } finally {
+      await rm(temporaryPath, { force: true })
+    }
+  }
+
+  async function updatePin(id: string, pinned: boolean): Promise<void> {
+    validateRunId(id)
+    await serializeManagementOperation(async () => {
+      if (
+        !(await Bun.file(join(runsDirectory, id, 'events.ndjson')).exists())
+      ) {
+        throw new Error(`Test run "${id}" was not found`)
+      }
+      const runIds = await readPinnedRunIds()
+      if (pinned) runIds.add(id)
+      else runIds.delete(id)
+      await writePinnedRunIds(runIds)
+    })
+  }
+
   async function upsertManifest(manifest: TestRunManifest): Promise<void> {
     await mkdir(projectDirectory, { recursive: true })
     withIndex(indexPath, (db) => upsertRun(db, manifest))
@@ -154,7 +236,10 @@ export function openTestRunStore(options: TestRunStoreOptions): TestRunStore {
       join(runsDirectory, id),
       startedAt,
       now,
-      artifactCapture,
+      (executionTargetProfileId) =>
+        metadata.evidencePersistence ??
+        evidencePersistenceByProfile[executionTargetProfileId] ??
+        evidencePersistence,
       upsertManifest,
       metadata,
       incompatibleSchema,
@@ -176,10 +261,15 @@ export function openTestRunStore(options: TestRunStoreOptions): TestRunStore {
       started?.type === 'run-started'
         ? started.run.applicationRevision
         : undefined
+    const runEvidencePersistence =
+      started?.type === 'run-started'
+        ? started.run.evidencePersistence
+        : undefined
     return persistedRunFor(id, startedAtFrom(events, now().toISOString()), {
       sourceRunId,
       suite,
       applicationRevision,
+      evidencePersistence: runEvidencePersistence,
     })
   }
 
@@ -255,6 +345,9 @@ export function openTestRunStore(options: TestRunStoreOptions): TestRunStore {
             ...(options.applicationRevision
               ? { applicationRevision: options.applicationRevision }
               : {}),
+            ...(options.evidencePersistence
+              ? { evidencePersistence: options.evidencePersistence }
+              : {}),
           },
         })
         return run
@@ -280,33 +373,69 @@ export function openTestRunStore(options: TestRunStoreOptions): TestRunStore {
       return withIndex(indexPath, listRuns)
     },
     rebuildIndex: rebuild,
-    async applyRetention(policy: RetentionPolicy = {}) {
-      const maxAgeMs = policy.maxAgeMs ?? defaultRetention.maxAgeMs
-      const maxBytes = policy.maxBytes ?? defaultRetention.maxBytes
-      const cutoff = now().getTime() - maxAgeMs
-      const manifests = await loadManifests()
-      const removed: string[] = []
-      const retained: TestRunManifest[] = []
-
-      for (const manifest of manifests) {
-        if (Date.parse(manifest.startedAt) <= cutoff) {
-          await removeRun(runsDirectory, indexPath, manifest.id)
-          removed.push(manifest.id)
-        } else {
-          retained.push(manifest)
+    async inspectStorage() {
+      const totalBytes = await directorySize(runsDirectory)
+      const pinnedRunIds = [...(await readPinnedRunIds())].sort()
+      return {
+        totalBytes,
+        warningThresholdBytes: defaultRunStorageWarningBytes,
+        warning: totalBytes >= defaultRunStorageWarningBytes,
+        pinnedRunIds,
+      }
+    },
+    pin(id) {
+      return updatePin(id, true)
+    },
+    unpin(id) {
+      return updatePin(id, false)
+    },
+    applyRetention(policy: RetentionPolicy = {}) {
+      return serializeManagementOperation(async () => {
+        const beforeBytes = await directorySize(runsDirectory)
+        if (policy.maxAgeMs === undefined && policy.maxBytes === undefined) {
+          return { removed: [], beforeBytes, afterBytes: beforeBytes }
         }
-      }
+        const cutoff =
+          policy.maxAgeMs === undefined
+            ? undefined
+            : now().getTime() - policy.maxAgeMs
+        const manifests = await loadManifests()
+        const pinnedRunIds = await readPinnedRunIds()
+        const removed: string[] = []
+        const removedRunIds = new Set<string>()
+        const eligible = manifests
+          .filter(
+            (manifest) => manifest.finishedAt && !pinnedRunIds.has(manifest.id),
+          )
+          .sort(byOldest)
 
-      retained.sort(byOldest)
-      let total = await directorySize(runsDirectory)
-      while (retained.length > 1 && total > maxBytes) {
-        const oldest = retained.shift()
-        if (!oldest) break
-        await removeRun(runsDirectory, indexPath, oldest.id)
-        removed.push(oldest.id)
-        total = await directorySize(runsDirectory)
-      }
-      return { removed }
+        for (const manifest of eligible) {
+          const finishedAt = manifest.finishedAt
+          if (
+            cutoff !== undefined &&
+            finishedAt &&
+            Date.parse(finishedAt) <= cutoff
+          ) {
+            await removeRun(runsDirectory, indexPath, manifest.id)
+            removed.push(manifest.id)
+            removedRunIds.add(manifest.id)
+          }
+        }
+
+        let total = await directorySize(runsDirectory)
+        const remaining = eligible.filter(
+          (manifest) => !removedRunIds.has(manifest.id),
+        )
+        while (policy.maxBytes !== undefined && total > policy.maxBytes) {
+          const oldest = remaining.shift()
+          if (!oldest) break
+          await removeRun(runsDirectory, indexPath, oldest.id)
+          removedRunIds.add(oldest.id)
+          removed.push(oldest.id)
+          total = await directorySize(runsDirectory)
+        }
+        return { removed, beforeBytes, afterBytes: total }
+      })
     },
   }
 }
@@ -316,7 +445,9 @@ function persistedTestRun(
   directory: string,
   startedAt: string,
   now: () => Date,
-  artifactCapture: ArtifactCapturePolicy,
+  evidencePersistenceFor: (
+    executionTargetProfileId: string,
+  ) => EvidencePersistencePolicy,
   onMaterialize: (manifest: TestRunManifest) => Promise<void>,
   metadata: CreateTestRunOptions,
   incompatibleSchema: (version: unknown) => never,
@@ -343,24 +474,35 @@ function persistedTestRun(
         }
         const current = await readEvents(eventsPath, incompatibleSchema)
         const recordable = recordableRunEventPayloadData(eventPayload(event))
+        const policy =
+          'scope' in recordable
+            ? evidencePersistenceFor(recordable.scope.executionTargetProfileId)
+            : evidencePersistenceFor('')
         const envelope = {
           schemaVersion: testRunSchemaVersion,
           sequence: current.length + 1,
           occurredAt:
             'occurredAt' in event ? event.occurredAt : now().toISOString(),
         } as const
+        const persisted = await persistEventArtifacts(
+          recordable,
+          current,
+          policy,
+          artifactsDirectory,
+        )
         const versioned = {
-          ...(await persistEventArtifacts(
-            recordable,
-            current,
-            artifactCapture,
-            artifactsDirectory,
-          )),
+          ...persisted.event,
           ...envelope,
         } as RunEvent
-        await appendFile(eventsPath, `${JSON.stringify(versioned)}\n`)
-        return event.type === 'step-finished' &&
-          !shouldCapture(artifactCapture, event.result.state)
+        try {
+          await appendFile(eventsPath, `${JSON.stringify(versioned)}\n`)
+        } catch (error) {
+          await Promise.all(
+            persisted.publishedPaths.map((path) => rm(path, { force: true })),
+          )
+          throw error
+        }
+        return !shouldPersistEventEvidence(recordable, policy)
           ? ({ ...recordable, ...envelope } as RunEvent)
           : versioned
       })
@@ -749,44 +891,67 @@ async function readEvents(
 async function persistEventArtifacts(
   event: RunEventPayload,
   current: readonly RunEvent[],
-  policy: ArtifactCapturePolicy,
+  policy: EvidencePersistencePolicy,
   artifactsDirectory: string,
-): Promise<RunEventPayload> {
+): Promise<PersistedEventEvidence> {
   if (event.type === 'scenario-finished') {
+    const persisted = await persistAttemptArtifacts(
+      event.attempt,
+      event.scope,
+      current,
+      policy,
+      artifactsDirectory,
+    )
     return {
-      ...event,
-      attempt: await persistAttemptArtifacts(
-        event.attempt,
-        event.scope,
-        current,
-        policy,
-        artifactsDirectory,
-      ),
+      event: { ...event, attempt: persisted.attempt },
+      publishedPaths: persisted.publishedPaths,
     }
   }
   if (event.type === 'step-finished') {
+    const persisted = await persistStepArtifacts(
+      event.result,
+      policy,
+      artifactsDirectory,
+      artifactStepName(event.scope, event.result.index),
+    )
     return {
-      ...event,
-      result: await persistStepArtifacts(
-        event.result,
-        policy,
-        artifactsDirectory,
-        artifactStepName(event.scope, event.result.index),
-      ),
+      event: { ...event, result: persisted.step },
+      publishedPaths: persisted.publishedPaths,
     }
   }
-  return event
+  return { event, publishedPaths: [] }
+}
+
+type EvidenceCaptureFailure = {
+  kind: EvidenceKind
+  message: string
+}
+
+type PersistedEventEvidence = {
+  event: RunEventPayload
+  publishedPaths: string[]
+}
+
+type PersistedAttemptEvidence = {
+  attempt: ScenarioAttempt
+  publishedPaths: string[]
+}
+
+type PersistedStepEvidence = {
+  step: TestStepResult
+  publishedPaths: string[]
+  captureFailures: EvidenceCaptureFailure[]
 }
 
 async function persistAttemptArtifacts(
   attempt: ScenarioAttempt,
   scope: Extract<RunEventPayload, { type: 'scenario-finished' }>['scope'],
   current: readonly RunEvent[],
-  policy: ArtifactCapturePolicy,
+  policy: EvidencePersistencePolicy,
   artifactsDirectory: string,
-): Promise<ScenarioAttempt> {
-  if (!shouldCapture(policy, attempt.state)) {
-    return withoutAttemptEvidence(attempt)
+): Promise<PersistedAttemptEvidence> {
+  if (!shouldPersistEvidence(policy, attempt.state)) {
+    return { attempt: withoutAttemptEvidence(attempt), publishedPaths: [] }
   }
   const steps = await Promise.all(
     attempt.steps.map(async (step) => {
@@ -796,7 +961,31 @@ async function persistAttemptArtifacts(
           sameScope(event.scope, { ...scope, stepIndex: step.index }),
       )
       if (persisted?.type === 'step-finished' && persisted.result.artifacts) {
-        return { ...step, artifacts: persisted.result.artifacts }
+        if (persisted.result.artifacts.length === step.artifacts?.length) {
+          return {
+            step: { ...step, artifacts: persisted.result.artifacts },
+            publishedPaths: [],
+            captureFailures: [],
+          }
+        }
+        const artifacts = step.artifacts?.map((artifact, index) => {
+          const path = artifactDestination(
+            artifact,
+            index,
+            artifactsDirectory,
+            artifactStepName(scope, step.index),
+          )
+          return (
+            persisted.result.artifacts?.find(
+              (committed) => committed.path === path,
+            ) ?? artifact
+          )
+        })
+        return copyStepArtifacts(
+          { ...step, artifacts },
+          artifactsDirectory,
+          artifactStepName(scope, step.index),
+        )
       }
       return copyStepArtifacts(
         step,
@@ -805,7 +994,26 @@ async function persistAttemptArtifacts(
       )
     }),
   )
-  return { ...attempt, steps }
+  const captureFailures = steps.flatMap((step) => step.captureFailures)
+  return {
+    attempt: {
+      ...attempt,
+      steps: steps.map((step) => step.step),
+      evidenceAvailability: attempt.evidenceAvailability.map((availability) => {
+        const failures = captureFailures.filter(
+          (failure) => failure.kind === availability.kind,
+        )
+        return failures.length > 0
+          ? {
+              ...availability,
+              state: 'capture-failed' as const,
+              message: failures.map((failure) => failure.message).join('; '),
+            }
+          : availability
+      }),
+    },
+    publishedPaths: steps.flatMap((step) => step.publishedPaths),
+  }
 }
 
 function sameScope(
@@ -838,12 +1046,20 @@ function artifactStepName(
 
 async function persistStepArtifacts(
   step: TestStepResult,
-  policy: ArtifactCapturePolicy,
+  policy: EvidencePersistencePolicy,
   artifactsDirectory: string,
   name: string,
-): Promise<TestStepResult> {
-  if (!shouldCapture(policy, step.state)) return withoutStepEvidence(step)
-  if (!step.artifacts?.length) return step
+): Promise<PersistedStepEvidence> {
+  if (!shouldPersistEvidence(policy, step.state)) {
+    return {
+      step: withoutStepEvidence(step),
+      publishedPaths: [],
+      captureFailures: [],
+    }
+  }
+  if (!step.artifacts?.length) {
+    return { step, publishedPaths: [], captureFailures: [] }
+  }
   return copyStepArtifacts(step, artifactsDirectory, name)
 }
 
@@ -876,6 +1092,12 @@ function withoutAttemptEvidence(attempt: ScenarioAttempt): ScenarioAttempt {
         ? { ...availability, state: 'not-retained' }
         : availability
     }),
+    applicationOutputAvailability: attempt.applicationOutputAvailability?.map(
+      (availability) =>
+        availability.state === 'available'
+          ? { ...availability, state: 'not-retained' as const }
+          : availability,
+    ),
   }
 }
 
@@ -883,31 +1105,117 @@ async function copyStepArtifacts(
   step: TestStepResult,
   artifactsDirectory: string,
   name: string,
-): Promise<TestStepResult> {
-  if (!step.artifacts?.length) return step
-  await mkdir(artifactsDirectory, { recursive: true })
-  const artifacts = await Promise.all(
-    step.artifacts.map(async (artifact, index) => {
-      const extension = extname(artifact.path) || '.bin'
-      const filename =
-        index === 0
-          ? `${slug(name)}${extension}`
-          : `${slug(name)}-${index + 1}${extension}`
-      const path = join(artifactsDirectory, filename)
-      if (artifact.path !== path) await copyFile(artifact.path, path)
-      return { ...artifact, path }
-    }),
-  )
-  return { ...step, artifacts }
+): Promise<PersistedStepEvidence> {
+  if (!step.artifacts?.length) {
+    return { step, publishedPaths: [], captureFailures: [] }
+  }
+  const stagingRoot = join(dirname(artifactsDirectory), '.evidence-staging')
+  const stagingDirectory = join(stagingRoot, crypto.randomUUID())
+  try {
+    await Promise.all([
+      mkdir(artifactsDirectory, { recursive: true }),
+      mkdir(stagingDirectory, { recursive: true }),
+    ])
+  } catch (error) {
+    await rm(stagingDirectory, { recursive: true, force: true })
+    await rmdir(stagingRoot).catch(() => undefined)
+    return captureFailedStep(step, error)
+  }
+  const publishedPaths: string[] = []
+  const captureFailures: EvidenceCaptureFailure[] = []
+  const artifacts: TestArtifact[] = []
+  try {
+    for (const [index, artifact] of step.artifacts.entries()) {
+      const path = artifactDestination(
+        artifact,
+        index,
+        artifactsDirectory,
+        name,
+      )
+      const filename = basename(path)
+      if (artifact.path === path) {
+        artifacts.push(artifact)
+        continue
+      }
+      const stagedPath = join(stagingDirectory, filename)
+      try {
+        await copyFile(artifact.path, stagedPath)
+        if (await pathExists(path)) {
+          throw new Error(`Test artifact destination already exists: ${path}`)
+        }
+        await rename(stagedPath, path)
+        publishedPaths.push(path)
+        artifacts.push({ ...artifact, path })
+      } catch (error) {
+        captureFailures.push({
+          kind: artifact.kind,
+          message: `${artifact.path}: ${errorMessage(error)}`,
+        })
+      }
+    }
+  } finally {
+    await rm(stagingDirectory, { recursive: true, force: true })
+    await rmdir(stagingRoot).catch(() => undefined)
+  }
+  return {
+    step: {
+      ...step,
+      artifacts: artifacts.length > 0 ? artifacts : undefined,
+    },
+    publishedPaths,
+    captureFailures,
+  }
 }
 
-function shouldCapture(
-  policy: ArtifactCapturePolicy,
+function artifactDestination(
+  artifact: TestArtifact,
+  index: number,
+  artifactsDirectory: string,
+  name: string,
+): string {
+  const extension = extname(artifact.path) || '.bin'
+  const filename =
+    index === 0
+      ? `${slug(name)}${extension}`
+      : `${slug(name)}-${index + 1}${extension}`
+  return join(artifactsDirectory, filename)
+}
+
+function captureFailedStep(
+  step: TestStepResult,
+  error: unknown,
+): PersistedStepEvidence {
+  const { artifacts: _artifacts, ...stepWithoutArtifacts } = step
+  return {
+    step: stepWithoutArtifacts,
+    publishedPaths: [],
+    captureFailures: (step.artifacts ?? []).map((artifact) => ({
+      kind: artifact.kind,
+      message: `${artifact.path}: ${errorMessage(error)}`,
+    })),
+  }
+}
+
+function shouldPersistEvidence(
+  policy: EvidencePersistencePolicy,
   state: TestResultState,
 ): boolean {
   if (policy === 'always') return true
   if (policy === 'off') return false
   return state === 'failed' || state === 'infrastructure-error'
+}
+
+function shouldPersistEventEvidence(
+  event: RunEventPayload,
+  policy: EvidencePersistencePolicy,
+): boolean {
+  if (event.type === 'step-finished') {
+    return shouldPersistEvidence(policy, event.result.state)
+  }
+  if (event.type === 'scenario-finished') {
+    return shouldPersistEvidence(policy, event.attempt.state)
+  }
+  return true
 }
 
 async function removeRun(
@@ -932,8 +1240,22 @@ function validateRunId(id: string): void {
   }
 }
 
+function isRunPinsFile(value: unknown): value is RunPinsFile {
+  if (!value || typeof value !== 'object') return false
+  const candidate = value as Partial<RunPinsFile>
+  return (
+    candidate.schemaVersion === 1 &&
+    Array.isArray(candidate.runIds) &&
+    candidate.runIds.every((id: unknown) => typeof id === 'string')
+  )
+}
+
 function isAlreadyExists(error: unknown): boolean {
   return error instanceof Error && (error as NodeError).code === 'EEXIST'
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error)
 }
 
 async function pathExists(path: string): Promise<boolean> {
@@ -946,6 +1268,7 @@ async function pathExists(path: string): Promise<boolean> {
 }
 
 async function directorySize(directory: string): Promise<number> {
+  if (!(await pathExists(directory))) return 0
   let total = 0
   const files = new Bun.Glob('**/*').scan({
     cwd: directory,

--- a/packages/studio/package.json
+++ b/packages/studio/package.json
@@ -11,7 +11,8 @@
   "files": [
     "index.ts",
     "src",
-    "!src/*.test.ts"
+    "!src/*.test.ts",
+    "!src/*.test.tsx"
   ],
   "scripts": {
     "typecheck": "tsc --noEmit",

--- a/packages/studio/src/artifact-viewer.tsx
+++ b/packages/studio/src/artifact-viewer.tsx
@@ -1,0 +1,305 @@
+import type { TestArtifact, TestResultState } from '@pickle-spec/runner'
+import { useEffect, useRef, useState } from 'react'
+import { Button, ButtonLink } from './components/ui/button'
+import { Input } from './components/ui/input'
+import { Label } from './components/ui/label'
+import {
+  type ArtifactLoadFailure,
+  artifactLoadFailureGuidance,
+  artifactUrl,
+  artifactViewerKind,
+} from './result-evidence'
+
+type ArtifactViewerProps = {
+  artifact: TestArtifact
+  resultState: TestResultState
+  scenarioName: string
+  stepText: string
+}
+
+type TextLoadState =
+  | { kind: 'idle' }
+  | { kind: 'loading' }
+  | { kind: 'loaded'; text: string }
+  | { kind: 'error'; failure: ArtifactLoadFailure; detail?: string }
+
+const maximumInlineLogBytes = 10 * 1024 * 1024
+const maximumRenderedLogLines = 1_000
+
+function errorMessage(reason: unknown): string {
+  return reason instanceof Error ? reason.message : String(reason)
+}
+
+async function classifyMediaFailure(
+  href: string,
+): Promise<ArtifactLoadFailure> {
+  try {
+    const response = await fetch(href, { method: 'HEAD' })
+    if (response.status === 404) return 'missing'
+    return response.ok ? 'corrupt' : 'load-failed'
+  } catch {
+    return 'load-failed'
+  }
+}
+
+function ImageArtifact(props: ArtifactViewerProps) {
+  const href = artifactUrl(props.artifact.path)
+  const [revision, setRevision] = useState(0)
+  const [failure, setFailure] = useState<ArtifactLoadFailure>()
+  if (failure) {
+    return (
+      <ArtifactFailure
+        failure={failure}
+        action="Retry image preview"
+        onRetry={() => {
+          setRevision((value) => value + 1)
+          setFailure(undefined)
+        }}
+      />
+    )
+  }
+  return (
+    <ButtonLink
+      variant="ghost"
+      href={href}
+      className="h-auto w-full justify-start overflow-hidden border-border bg-muted/20 p-0 hover:bg-muted/30"
+    >
+      <img
+        key={revision}
+        alt={`${props.artifact.kind} from ${props.resultState} result for ${props.scenarioName}: ${props.stepText}`}
+        src={`${href}&preview=${revision}`}
+        loading="lazy"
+        className="max-h-[32rem] w-full object-contain"
+        onError={() => void classifyMediaFailure(href).then(setFailure)}
+      />
+    </ButtonLink>
+  )
+}
+
+function VideoArtifact(props: ArtifactViewerProps) {
+  const [state, setState] = useState<
+    'idle' | 'loaded' | { failure: ArtifactLoadFailure }
+  >('idle')
+  if (typeof state === 'object') {
+    return (
+      <ArtifactFailure
+        failure={state.failure}
+        action="Retry recording preview"
+        onRetry={() => setState('idle')}
+      />
+    )
+  }
+  if (state === 'idle') {
+    return (
+      <div className="flex min-h-32 flex-col items-center justify-center gap-3 rounded-md border border-dashed border-border px-4 text-center text-muted-foreground">
+        <p>The recording stays unloaded until you choose to play it.</p>
+        <Button
+          type="button"
+          variant="outline"
+          onClick={() => setState('loaded')}
+        >
+          Load recording
+        </Button>
+      </div>
+    )
+  }
+  return (
+    // biome-ignore lint/a11y/useMediaCaption: Mobile screen recordings do not contain an audio track.
+    <video
+      aria-label={`Recording for ${props.scenarioName}: ${props.stepText}`}
+      controls
+      preload="metadata"
+      className="max-h-[32rem] w-full rounded-md border border-border bg-black"
+      onError={() =>
+        void classifyMediaFailure(artifactUrl(props.artifact.path)).then(
+          (failure) => setState({ failure }),
+        )
+      }
+    >
+      <source
+        src={artifactUrl(props.artifact.path)}
+        type={props.artifact.mediaType}
+      />
+      This browser cannot play this recording. Download it instead.
+    </video>
+  )
+}
+
+function TextArtifact(props: ArtifactViewerProps) {
+  const [loadState, setLoadState] = useState<TextLoadState>({ kind: 'idle' })
+  const [query, setQuery] = useState('')
+  const request = useRef<AbortController | undefined>(undefined)
+  useEffect(
+    () => () => {
+      request.current?.abort()
+    },
+    [],
+  )
+
+  async function loadText() {
+    if (
+      props.artifact.sizeBytes !== undefined &&
+      props.artifact.sizeBytes > maximumInlineLogBytes
+    ) {
+      setLoadState({
+        kind: 'error',
+        failure: 'load-failed',
+        detail:
+          'This log is larger than the 10 MiB inline-view limit. Download it to inspect the complete file.',
+      })
+      return
+    }
+    request.current?.abort()
+    const controller = new AbortController()
+    request.current = controller
+    setLoadState({ kind: 'loading' })
+    try {
+      const href = artifactUrl(props.artifact.path)
+      const metadata = await fetch(href, {
+        method: 'HEAD',
+        signal: controller.signal,
+      })
+      if (!metadata.ok) {
+        setLoadState({
+          kind: 'error',
+          failure: metadata.status === 404 ? 'missing' : 'load-failed',
+          detail: `Artifact request returned ${metadata.status}.`,
+        })
+        return
+      }
+      const contentLength = Number(metadata.headers.get('content-length'))
+      if (
+        Number.isFinite(contentLength) &&
+        contentLength > maximumInlineLogBytes
+      ) {
+        setLoadState({
+          kind: 'error',
+          failure: 'load-failed',
+          detail:
+            'This log is larger than the 10 MiB inline-view limit. Download it to inspect the complete file.',
+        })
+        return
+      }
+      const response = await fetch(href, {
+        signal: controller.signal,
+      })
+      if (!response.ok) {
+        setLoadState({
+          kind: 'error',
+          failure: response.status === 404 ? 'missing' : 'load-failed',
+          detail: `Artifact request returned ${response.status}.`,
+        })
+        return
+      }
+      const bytes = await response.arrayBuffer()
+      try {
+        setLoadState({
+          kind: 'loaded',
+          text: new TextDecoder('utf-8', { fatal: true }).decode(bytes),
+        })
+      } catch {
+        setLoadState({ kind: 'error', failure: 'corrupt' })
+      }
+    } catch (reason) {
+      if (controller.signal.aborted) return
+      setLoadState({
+        kind: 'error',
+        failure: 'load-failed',
+        detail: errorMessage(reason),
+      })
+    }
+  }
+
+  if (loadState.kind !== 'loaded') {
+    return (
+      <div className="flex min-h-32 flex-col items-center justify-center gap-3 rounded-md border border-dashed border-border px-4 text-center text-muted-foreground">
+        <p>
+          {loadState.kind === 'error'
+            ? artifactLoadFailureGuidance(loadState.failure)
+            : 'The device log stays unloaded until you need to search it.'}
+        </p>
+        {loadState.kind === 'error' && loadState.detail ? (
+          <p className="break-words text-xs">{loadState.detail}</p>
+        ) : null}
+        <Button
+          type="button"
+          variant="outline"
+          disabled={loadState.kind === 'loading'}
+          onClick={() => void loadText()}
+        >
+          {loadState.kind === 'loading'
+            ? 'Loading device log…'
+            : loadState.kind === 'error'
+              ? 'Retry loading device log'
+              : 'Load device log'}
+        </Button>
+      </div>
+    )
+  }
+
+  const normalizedQuery = query.toLocaleLowerCase()
+  const matchingLines = loadState.text
+    .split('\n')
+    .filter(
+      (line) =>
+        !normalizedQuery || line.toLocaleLowerCase().includes(normalizedQuery),
+    )
+  const renderedLines = matchingLines.slice(0, maximumRenderedLogLines)
+  return (
+    <div className="min-w-0 space-y-3">
+      <div className="space-y-1">
+        <Label htmlFor={`device-log-search-${props.artifact.path}`}>
+          Search device log
+        </Label>
+        <Input
+          id={`device-log-search-${props.artifact.path}`}
+          type="search"
+          value={query}
+          onChange={(event) => setQuery(event.target.value)}
+          placeholder="Find text in the complete log"
+        />
+      </div>
+      {matchingLines.length > maximumRenderedLogLines ? (
+        <p className="text-xs text-muted-foreground">
+          Showing the first {maximumRenderedLogLines.toLocaleString()} of{' '}
+          {matchingLines.length.toLocaleString()} matching lines. Refine the
+          search or download the complete log.
+        </p>
+      ) : null}
+      <pre className="max-h-96 overflow-auto whitespace-pre-wrap break-words rounded-md border border-border bg-muted/20 p-3 font-mono text-xs">
+        {renderedLines.join('\n') || 'No device-log lines match this search.'}
+      </pre>
+    </div>
+  )
+}
+
+function ArtifactFailure(props: {
+  failure: ArtifactLoadFailure
+  action: string
+  onRetry: () => void
+}) {
+  return (
+    <div
+      role="status"
+      className="flex min-h-32 flex-col items-center justify-center gap-3 rounded-md border border-dashed border-border px-4 text-center text-muted-foreground"
+    >
+      <p>{artifactLoadFailureGuidance(props.failure)}</p>
+      <Button type="button" variant="outline" onClick={props.onRetry}>
+        {props.action}
+      </Button>
+    </div>
+  )
+}
+
+export function ArtifactViewer(props: ArtifactViewerProps) {
+  const viewer = artifactViewerKind(props.artifact)
+  if (viewer === 'image') return <ImageArtifact {...props} />
+  if (viewer === 'video') return <VideoArtifact {...props} />
+  if (viewer === 'text') return <TextArtifact {...props} />
+  return (
+    <div className="flex min-h-32 items-center justify-center rounded-md border border-dashed border-border px-4 text-center text-muted-foreground">
+      This artifact has no inline viewer. Download it to inspect the original
+      file.
+    </div>
+  )
+}

--- a/packages/studio/src/history.tsx
+++ b/packages/studio/src/history.tsx
@@ -215,15 +215,40 @@ export function HistoryPanel(props: HistoryPanelProps) {
     setError(undefined)
     setNotice(undefined)
     try {
-      const result = await props.api<{ removed: string[] }>(
-        '/api/history/retention',
-        { method: 'POST' },
+      const result = await props.api<{
+        removed: string[]
+        beforeBytes: number
+        afterBytes: number
+      }>('/api/history/retention', { method: 'POST' })
+      setSelectedRunIds((current) =>
+        current.filter((runId) => !result.removed.includes(runId)),
       )
-      setSelectedRunIds([])
-      setReviewed(undefined)
-      setComparison(undefined)
+      if (reviewed && result.removed.includes(reviewed.id)) {
+        setReviewed(undefined)
+      }
+      if (selectedRunIds.some((runId) => result.removed.includes(runId))) {
+        setComparison(undefined)
+      }
       await loadHistory()
-      setNotice(`Deleted ${result.removed.length} local test runs`)
+      setNotice(
+        result.removed.length === 0
+          ? 'No local test runs matched the configured retention policy'
+          : `Deleted ${result.removed.length} local test runs · ${bytesLabel(result.beforeBytes)} → ${bytesLabel(result.afterBytes)}`,
+      )
+    } catch (reason) {
+      setError(reasonMessage(reason))
+    }
+  }
+
+  async function setPinned(runId: string, pinned: boolean) {
+    setError(undefined)
+    setNotice(undefined)
+    try {
+      await props.api(`/api/history/${encodeURIComponent(runId)}/pin`, {
+        method: pinned ? 'POST' : 'DELETE',
+      })
+      await loadHistory()
+      setNotice(`${pinned ? 'Pinned' : 'Unpinned'} test run ${runId}`)
     } catch (reason) {
       setError(reasonMessage(reason))
     }
@@ -233,9 +258,13 @@ export function HistoryPanel(props: HistoryPanelProps) {
     ? runs.find((run) => run.id === reviewed.id)
     : undefined
   const artifactMode = includeAllArtifacts ? 'all' : 'failures'
-  const retentionDays = history
+  const retentionDays = history?.retention.maxAgeMs
     ? Math.round(history.retention.maxAgeMs / (24 * 60 * 60 * 1_000))
     : undefined
+  const retentionConfigured = Boolean(
+    history?.retention.maxAgeMs || history?.retention.maxBytes,
+  )
+  const pinnedRunIds = new Set(history?.storage.pinnedRunIds ?? [])
 
   return (
     <section
@@ -299,6 +328,7 @@ export function HistoryPanel(props: HistoryPanelProps) {
             <TableHeader>
               <TableRow>
                 <TableHead>Compare</TableHead>
+                <TableHead>Retention</TableHead>
                 <TableHead>Started</TableHead>
                 <TableHead>Suite</TableHead>
                 <TableHead>Targets</TableHead>
@@ -313,7 +343,7 @@ export function HistoryPanel(props: HistoryPanelProps) {
               </TableRow>
             </TableHeader>
             <TableBody>
-              <VirtualTableSpacer height={runWindow.before} colSpan={12} />
+              <VirtualTableSpacer height={runWindow.before} colSpan={13} />
               {visibleRuns.map((run) => (
                 <TableRow key={run.id} style={{ height: historyRowHeight }}>
                   <TableCell>
@@ -332,6 +362,19 @@ export function HistoryPanel(props: HistoryPanelProps) {
                         )
                       }
                     />
+                  </TableCell>
+                  <TableCell>
+                    <Button
+                      type="button"
+                      variant="outline"
+                      size="sm"
+                      aria-pressed={pinnedRunIds.has(run.id)}
+                      onClick={() =>
+                        void setPinned(run.id, !pinnedRunIds.has(run.id))
+                      }
+                    >
+                      {pinnedRunIds.has(run.id) ? 'Unpin' : 'Pin'}
+                    </Button>
                   </TableCell>
                   <TableCell>
                     <span className="block">
@@ -396,7 +439,7 @@ export function HistoryPanel(props: HistoryPanelProps) {
                   </TableCell>
                 </TableRow>
               ))}
-              <VirtualTableSpacer height={runWindow.after} colSpan={12} />
+              <VirtualTableSpacer height={runWindow.after} colSpan={13} />
             </TableBody>
           </Table>
         </section>
@@ -448,6 +491,20 @@ export function HistoryPanel(props: HistoryPanelProps) {
                 }
               >
                 Export HTML
+              </Button>
+              <Button
+                variant="outline"
+                nativeButton={false}
+                render={
+                  <a
+                    href={`/api/history/${encodeURIComponent(reviewed.id)}/allure`}
+                    // biome-ignore lint/a11y/noRedundantRoles: override Base UI's injected button role
+                    role="link"
+                    download
+                  />
+                }
+              >
+                Export Allure results
               </Button>
               <span className="flex items-center gap-2">
                 <Checkbox
@@ -576,16 +633,41 @@ export function HistoryPanel(props: HistoryPanelProps) {
       ) : null}
 
       {history ? (
-        <section className="flex flex-wrap items-center justify-between gap-3 rounded-lg border border-border bg-card p-4">
-          <div>
-            <h3 className="text-sm font-medium">Retention</h3>
+        <section
+          className="flex flex-wrap items-center justify-between gap-4 rounded-lg border border-border bg-card p-4"
+          aria-labelledby="run-storage-title"
+        >
+          <div className="min-w-0 space-y-1">
+            <h3 id="run-storage-title" className="text-sm font-medium">
+              Local test run storage
+            </h3>
             <p className="text-xs text-muted-foreground">
-              {retentionDays} days · {bytesLabel(history.retention.maxBytes)}
+              {bytesLabel(history.storage.totalBytes)} stored · Warning at{' '}
+              {bytesLabel(history.storage.warningThresholdBytes)}
             </p>
+            <p className="text-xs text-muted-foreground">
+              {retentionConfigured
+                ? [
+                    retentionDays ? `${retentionDays} days` : undefined,
+                    history.retention.maxBytes
+                      ? bytesLabel(history.retention.maxBytes)
+                      : undefined,
+                  ]
+                    .filter(Boolean)
+                    .join(' · ')
+                : 'No deletion policy configured. Test runs are retained until you configure a limit.'}
+            </p>
+            {history.storage.warning ? (
+              <p role="alert" className="text-sm text-destructive">
+                Local Test run storage reached the warning threshold. Configure
+                retention, export needed evidence, or remove eligible runs.
+              </p>
+            ) : null}
           </div>
           <Button
             type="button"
             variant="destructive"
+            disabled={!retentionConfigured}
             onClick={() => void deleteEligible()}
           >
             Delete eligible history

--- a/packages/studio/src/live-result-inspection.test.ts
+++ b/packages/studio/src/live-result-inspection.test.ts
@@ -216,6 +216,44 @@ test('live Run events update the same Overview, Timeline, Artifacts, and Diagnos
   ).toEqual(['Payment was declined'])
 })
 
+test('shows managed application output while a step is still running', () => {
+  let inspection = startLiveInspection({
+    specificationUri,
+    runId: 'run-live-output',
+  })
+  for (const event of [runStarted(), scenarioStarted(), stepStarted()]) {
+    inspection = receiveLiveStreamEvent(inspection, event)
+  }
+  inspection = receiveLiveStreamEvent(inspection, {
+    type: 'diagnostic-recorded',
+    profileId: 'chrome',
+    scope: scope(1),
+    diagnostic: {
+      occurredAt: '2026-08-23T12:00:00.0035Z',
+      level: 'info',
+      origin: 'application',
+      stream: 'stdout',
+      message: 'server is still working',
+      scenarioId: scenario.id,
+      scenarioName: scenario.name,
+      stepIndex: 0,
+      stepText: 'Then payment is captured',
+      executionTargetProfileId: 'chrome',
+    },
+  })
+
+  const inspected = findInspectedResult(
+    inspection.snapshot!,
+    inspection.location!,
+  )
+  expect(
+    diagnosticsFor(inspected!.attempt).map((entry) => entry.message),
+  ).toEqual(['server is still working'])
+  expect(inspected?.attempt.steps[0]?.finishedAt).toBe(
+    '2026-08-23T12:00:00.0035Z',
+  )
+})
+
 test('follows the newest causal activity until the user intervenes', () => {
   let inspection = startLiveInspection({
     specificationUri,

--- a/packages/studio/src/live-result-inspection.ts
+++ b/packages/studio/src/live-result-inspection.ts
@@ -1,4 +1,4 @@
-import type { RunEvent } from '@pickle-spec/runner'
+import type { DiagnosticEntry, RunEvent } from '@pickle-spec/runner'
 import { nextFollowedEntryId, nextLiveLocation } from './live-result-follow'
 import {
   cellsFromLiveSnapshot,
@@ -10,7 +10,7 @@ import type {
   ResultInspectorTab,
 } from './result-inspection'
 import type { MatrixCell } from './run-view'
-import type { StudioRunSnapshot } from './server'
+import type { StudioLiveDiagnosticEvent, StudioRunSnapshot } from './server'
 
 export {
   displayedAttemptState,
@@ -20,6 +20,7 @@ export {
 
 export type LiveStreamEvent =
   | RunEvent
+  | StudioLiveDiagnosticEvent
   | { type: 'run-finished'; run: { id: string } }
 
 export type LiveConnectionStatus =
@@ -36,6 +37,11 @@ export type LiveResultInspection = {
   runId: string
   phase: 'idle' | 'running' | 'finished'
   events: RunEvent[]
+  liveDiagnostics: Array<{
+    profileId: string
+    scope?: StudioLiveDiagnosticEvent['scope']
+    diagnostic: DiagnosticEntry
+  }>
   snapshot?: StudioRunSnapshot
   connection: LiveConnectionStatus
   following: boolean
@@ -62,6 +68,7 @@ export function startLiveInspection(
     runId: input.runId,
     phase: 'running',
     events: [],
+    liveDiagnostics: [],
     connection: { kind: 'connected' },
     following: true,
     pinned: false,
@@ -148,6 +155,7 @@ export function hydrateLiveInspection(
     {
       ...inspection,
       events: snapshot.events,
+      liveDiagnostics: [],
       phase: 'finished',
       connection: { kind: 'connected' },
     },
@@ -161,6 +169,19 @@ export function receiveLiveStreamEvent(
 ): LiveResultInspection {
   if (event.type === 'run-finished') {
     return withProjectedSnapshot({ ...inspection, phase: 'finished' })
+  }
+  if (event.type === 'diagnostic-recorded') {
+    return withProjectedSnapshot({
+      ...inspection,
+      liveDiagnostics: [
+        ...inspection.liveDiagnostics,
+        {
+          profileId: event.profileId,
+          scope: event.scope,
+          diagnostic: event.diagnostic,
+        },
+      ],
+    })
   }
   const events = insertRunEvent(inspection.events, event)
   return withProjectedSnapshot({

--- a/packages/studio/src/live-result-projection.ts
+++ b/packages/studio/src/live-result-projection.ts
@@ -36,6 +36,11 @@ type ProjectLiveSnapshotInput = {
   specificationUri: string
   phase: 'idle' | 'running' | 'finished'
   events: RunEvent[]
+  liveDiagnostics?: Array<{
+    profileId: string
+    scope?: AttemptEventScope
+    diagnostic: import('@pickle-spec/runner').DiagnosticEntry
+  }>
 }
 
 type AttemptEventScope = Extract<
@@ -147,6 +152,7 @@ function liveEvidenceAvailability(
 }
 
 function projectResults(input: ProjectLiveSnapshotInput): TestResult[] {
+  const liveDiagnostics = input.liveDiagnostics ?? []
   const finishedKeys = new Set<string>()
   const finished = new Map<string, TestResult>()
   for (const event of input.events) {
@@ -188,7 +194,7 @@ function projectResults(input: ProjectLiveSnapshotInput): TestResult[] {
   for (const event of input.events) {
     if (event.type !== 'scenario-started') continue
     if (finishedKeys.has(attemptKey(event.scope))) continue
-    const steps = inProgressSteps(input.events, event)
+    const steps = inProgressSteps(input.events, event, liveDiagnostics)
     const latest = steps.at(-1)
     const durationMs = latest
       ? Math.max(
@@ -218,6 +224,14 @@ function projectResults(input: ProjectLiveSnapshotInput): TestResult[] {
           state: latest?.state ?? 'passed',
           steps,
           evidenceAvailability: liveEvidenceAvailability(steps),
+          diagnostics: liveDiagnostics
+            .filter(
+              (entry) =>
+                entry.scope &&
+                sameAttemptScope(entry.scope, event.scope) &&
+                entry.diagnostic.stepIndex === undefined,
+            )
+            .map((entry) => entry.diagnostic),
         },
       ],
     })
@@ -228,13 +242,48 @@ function projectResults(input: ProjectLiveSnapshotInput): TestResult[] {
 function inProgressSteps(
   events: readonly RunEvent[],
   started: Extract<RunEvent, { type: 'scenario-started' }>,
+  liveDiagnostics: NonNullable<ProjectLiveSnapshotInput['liveDiagnostics']>,
 ): TestStepResult[] {
-  return events.flatMap((event) =>
+  const completed = events.flatMap((event) =>
     event.type === 'step-finished' &&
     sameAttemptScope(event.scope, started.scope)
       ? [event.result]
       : [],
   )
+  const activeStep = events.findLast(
+    (event) =>
+      event.type === 'step-started' &&
+      sameAttemptScope(event.scope, started.scope) &&
+      !completed.some(
+        (step) => step.index === (event.scope.stepIndex ?? step.index),
+      ),
+  )
+  if (activeStep?.type !== 'step-started') return completed
+  const diagnostics = liveDiagnostics
+    .filter(
+      (entry) =>
+        entry.scope &&
+        sameAttemptScope(entry.scope, started.scope) &&
+        entry.diagnostic.stepIndex === activeStep.scope.stepIndex,
+    )
+    .map((entry) => entry.diagnostic)
+  const finishedAt = diagnostics.at(-1)?.occurredAt ?? activeStep.occurredAt
+  return [
+    ...completed,
+    {
+      index: activeStep.scope.stepIndex ?? completed.length,
+      startedAt: activeStep.occurredAt,
+      finishedAt,
+      durationMs: Math.max(
+        0,
+        Date.parse(finishedAt) - Date.parse(activeStep.occurredAt),
+      ),
+      step: activeStep.step,
+      state: 'passed',
+      resolvedActions: [],
+      diagnostics: diagnostics.length > 0 ? diagnostics : undefined,
+    },
+  ]
 }
 
 function sameAttemptScope(

--- a/packages/studio/src/result-evidence-panels.test.tsx
+++ b/packages/studio/src/result-evidence-panels.test.tsx
@@ -1,0 +1,69 @@
+import { expect, test } from 'bun:test'
+import type { ScenarioAttempt } from '@pickle-spec/runner'
+import { renderToStaticMarkup } from 'react-dom/server'
+import { ArtifactViewer } from './artifact-viewer'
+import { ResultDiagnostics } from './result-evidence-panels'
+
+const diagnosticsAvailability: ScenarioAttempt['evidenceAvailability'] = [
+  { kind: 'diagnostics', state: 'available' },
+]
+
+test('renders an accessible bounded page for a 10,000-entry Diagnostic set', () => {
+  const diagnostics = Array.from({ length: 10_000 }, (_, index) => ({
+    id: `diagnostic-${index}`,
+    occurredAt: new Date(Date.UTC(2026, 7, 24, 12, 0, 0, index)).toISOString(),
+    level: 'info' as const,
+    origin: 'adapter' as const,
+    source: 'Scenario attempt' as const,
+    message: `Diagnostic message marker-${index}`,
+  }))
+
+  const markup = renderToStaticMarkup(
+    <ResultDiagnostics
+      diagnostics={diagnostics}
+      availability={diagnosticsAvailability}
+    />,
+  )
+
+  expect(markup).toContain('Search Diagnostic entries')
+  expect(markup).toContain('aria-live="polite"')
+  expect(markup).toContain(
+    'Showing 1–100 of 10000 matching Diagnostic entries (10000 total).',
+  )
+  expect(markup).toContain('Diagnostic message marker-99')
+  expect(markup).not.toContain('Diagnostic message marker-100')
+  expect(markup).not.toContain('Diagnostic message marker-9999')
+  expect(markup).toContain('Next 100')
+})
+
+test('keeps media and text payloads unloaded until investigation requests them', () => {
+  const recording = renderToStaticMarkup(
+    <ArtifactViewer
+      artifact={{
+        kind: 'recording',
+        path: '/tmp/recording.mp4',
+        mediaType: 'video/mp4',
+      }}
+      resultState="failed"
+      scenarioName="Checkout"
+      stepText="Then payment succeeds"
+    />,
+  )
+  const deviceLog = renderToStaticMarkup(
+    <ArtifactViewer
+      artifact={{
+        kind: 'device-log',
+        path: '/tmp/device.log',
+        mediaType: 'text/plain',
+      }}
+      resultState="failed"
+      scenarioName="Checkout"
+      stepText="Then payment succeeds"
+    />,
+  )
+
+  expect(recording).toContain('Load recording')
+  expect(recording).not.toContain('<video')
+  expect(deviceLog).toContain('Load device log')
+  expect(deviceLog).not.toContain('<pre')
+})

--- a/packages/studio/src/result-evidence-panels.tsx
+++ b/packages/studio/src/result-evidence-panels.tsx
@@ -1,10 +1,12 @@
 import type {
+  ApplicationOutputEvidenceAvailability,
   DiagnosticLevel,
   DiagnosticOrigin,
   EvidenceAvailability,
   TestResultState,
 } from '@pickle-spec/runner'
-import { useState } from 'react'
+import { useMemo, useState } from 'react'
+import { ArtifactViewer } from './artifact-viewer'
 import { Button, ButtonLink } from './components/ui/button'
 import {
   Card,
@@ -17,10 +19,12 @@ import { Input } from './components/ui/input'
 import { Label } from './components/ui/label'
 import {
   type ArtifactEvidence,
-  artifactUrl,
+  artifactDownloadUrl,
   type DiagnosticEvidence,
+  diagnosticPage,
   filterDiagnostics,
   type InspectedResult,
+  recoveryGuidance,
 } from './result-evidence'
 
 const diagnosticLevels = [
@@ -34,6 +38,7 @@ const diagnosticOrigins = [
   'network',
   'runner',
   'adapter',
+  'application',
 ] as const satisfies readonly DiagnosticOrigin[]
 
 type MetadataProps = {
@@ -44,6 +49,7 @@ type MetadataProps = {
 
 type ResultArtifactsProps = {
   artifacts: readonly ArtifactEvidence[]
+  availability: readonly EvidenceAvailability[]
   scenarioName: string
   resultState: TestResultState
 }
@@ -51,6 +57,7 @@ type ResultArtifactsProps = {
 type ResultDiagnosticsProps = {
   diagnostics: readonly DiagnosticEvidence[]
   availability: readonly EvidenceAvailability[]
+  applicationOutputAvailability?: readonly ApplicationOutputEvidenceAvailability[]
 }
 
 function Metadata(props: MetadataProps) {
@@ -87,6 +94,9 @@ function EvidenceAvailabilityCard(props: {
                 {item.state}
                 {item.message ? (
                   <span className="block">{item.message}</span>
+                ) : null}
+                {item.state !== 'available' ? (
+                  <span className="block">{recoveryGuidance(item.state)}</span>
                 ) : null}
               </dd>
             </div>
@@ -162,18 +172,61 @@ function EmptyEvidence(props: { message: string }) {
   )
 }
 
+type UnavailableEvidence = EvidenceAvailability & {
+  state: Exclude<EvidenceAvailability['state'], 'available'>
+}
+
+function isUnavailableArtifact(
+  item: EvidenceAvailability,
+): item is UnavailableEvidence {
+  return item.kind !== 'diagnostics' && item.state !== 'available'
+}
+
+function ArtifactAvailability(props: {
+  availability: readonly EvidenceAvailability[]
+}) {
+  const unavailable = props.availability.filter(isUnavailableArtifact)
+  if (unavailable.length === 0) return null
+  return (
+    <section
+      aria-labelledby="artifact-availability-title"
+      className="rounded-lg border border-border bg-card p-4"
+    >
+      <h4 id="artifact-availability-title" className="font-medium">
+        Artifact availability
+      </h4>
+      <dl className="mt-3 grid gap-3 sm:grid-cols-2">
+        {unavailable.map((item) => (
+          <div key={item.kind} className="min-w-0 space-y-1">
+            <dt className="font-medium">{item.kind}</dt>
+            <dd className="break-words text-muted-foreground">
+              <span>{item.state}</span>
+              {item.message ? <span> · {item.message}</span> : null}
+              <span className="block">{recoveryGuidance(item.state)}</span>
+            </dd>
+          </div>
+        ))}
+      </dl>
+    </section>
+  )
+}
+
+function formatBytes(sizeBytes: number | undefined): string {
+  if (sizeBytes === undefined) return 'Not recorded'
+  if (sizeBytes < 1_024) return `${sizeBytes} B`
+  return `${(sizeBytes / 1_024).toFixed(1)} KB`
+}
+
 export function ResultArtifacts(props: ResultArtifactsProps) {
-  if (props.artifacts.length === 0) {
-    return (
-      <EmptyEvidence message="No Test artifacts were retained for this Scenario attempt." />
-    )
-  }
   return (
     <div className="space-y-3">
+      <ArtifactAvailability availability={props.availability} />
+      {props.artifacts.length === 0 ? (
+        <EmptyEvidence message="No Test artifacts were retained for this Scenario attempt." />
+      ) : null}
       {props.artifacts.map((evidence) => {
         const { artifact } = evidence
-        const artifactHref = artifactUrl(artifact.path)
-        const isImage = artifact.mediaType?.startsWith('image/')
+        const downloadHref = artifactDownloadUrl(artifact.path, artifact.name)
         return (
           <Card key={`${artifact.path}:${evidence.stepIndex}`}>
             <CardHeader>
@@ -181,30 +234,27 @@ export function ResultArtifacts(props: ResultArtifactsProps) {
               <CardDescription>{evidence.stepText}</CardDescription>
             </CardHeader>
             <CardContent className="grid gap-4 lg:grid-cols-[minmax(0,2fr)_minmax(16rem,1fr)]">
-              {isImage ? (
-                <ButtonLink
-                  variant="ghost"
-                  href={artifactHref}
-                  className="h-auto w-full justify-start overflow-hidden border-border bg-muted/20 p-0 hover:bg-muted/30"
-                >
-                  <img
-                    alt={`${artifact.kind} from ${props.resultState} result for ${props.scenarioName}: ${evidence.stepText}`}
-                    src={artifactHref}
-                    className="max-h-[32rem] w-full object-contain"
-                  />
-                </ButtonLink>
-              ) : (
-                <div className="flex min-h-32 items-center justify-center rounded-md border border-dashed border-border text-muted-foreground">
-                  Preview is unavailable for{' '}
-                  {artifact.mediaType ?? artifact.kind}.
-                </div>
-              )}
+              <ArtifactViewer
+                artifact={artifact}
+                resultState={props.resultState}
+                scenarioName={props.scenarioName}
+                stepText={evidence.stepText}
+              />
               <div className="space-y-4">
                 <dl className="space-y-3">
                   <Metadata label="Kind" value={artifact.kind} />
                   <Metadata
+                    label="File name"
+                    value={artifact.name ?? 'Not recorded'}
+                    mono
+                  />
+                  <Metadata
                     label="Media type"
                     value={artifact.mediaType ?? 'Not recorded'}
+                  />
+                  <Metadata
+                    label="File size"
+                    value={formatBytes(artifact.sizeBytes)}
                   />
                   <Metadata
                     label="Captured"
@@ -216,7 +266,11 @@ export function ResultArtifacts(props: ResultArtifactsProps) {
                   />
                   <Metadata label="Persisted path" value={artifact.path} mono />
                 </dl>
-                <ButtonLink variant="outline" href={artifactHref} download>
+                <ButtonLink
+                  variant="outline"
+                  href={downloadHref}
+                  download={artifact.name ?? true}
+                >
                   Download {artifact.kind}
                 </ButtonLink>
               </div>
@@ -229,6 +283,7 @@ export function ResultArtifacts(props: ResultArtifactsProps) {
 }
 
 export function ResultDiagnostics(props: ResultDiagnosticsProps) {
+  const [query, setQuery] = useState('')
   const [level, setLevel] = useState<DiagnosticLevel>()
   const [origin, setOrigin] = useState<DiagnosticOrigin>()
   const [scenarioId, setScenarioId] = useState('')
@@ -240,22 +295,94 @@ export function ResultDiagnostics(props: ResultDiagnosticsProps) {
   const availabilityDescription = diagnosticsAvailability?.message
     ? `${diagnosticsAvailability.state} · ${diagnosticsAvailability.message}`
     : (diagnosticsAvailability?.state ?? 'Not recorded')
+  const availabilityRecovery =
+    diagnosticsAvailability && diagnosticsAvailability.state !== 'available'
+      ? recoveryGuidance(diagnosticsAvailability.state)
+      : undefined
   const parsedStepIndex = stepIndex === '' ? undefined : Number(stepIndex)
-  const diagnostics = filterDiagnostics(props.diagnostics, {
+  const diagnostics = useMemo(
+    () =>
+      filterDiagnostics(props.diagnostics, {
+        query,
+        level,
+        origin,
+        scenarioId: scenarioId || undefined,
+        stepIndex: Number.isInteger(parsedStepIndex)
+          ? parsedStepIndex
+          : undefined,
+        executionTargetProfileId: executionTargetProfileId || undefined,
+      }),
+    [
+      props.diagnostics,
+      query,
+      level,
+      origin,
+      scenarioId,
+      parsedStepIndex,
+      executionTargetProfileId,
+    ],
+  )
+  const filterKey = [
+    query,
     level,
     origin,
-    scenarioId: scenarioId || undefined,
-    stepIndex: Number.isInteger(parsedStepIndex) ? parsedStepIndex : undefined,
-    executionTargetProfileId: executionTargetProfileId || undefined,
-  })
+    scenarioId,
+    stepIndex,
+    executionTargetProfileId,
+  ].join(':')
+  const hasFilters = Boolean(
+    query ||
+      level ||
+      origin ||
+      scenarioId ||
+      stepIndex ||
+      executionTargetProfileId,
+  )
+
+  function clearFilters() {
+    setQuery('')
+    setLevel(undefined)
+    setOrigin(undefined)
+    setScenarioId('')
+    setStepIndex('')
+    setExecutionTargetProfileId('')
+  }
   return (
     <div className="space-y-3">
       <Card>
         <CardHeader>
           <CardTitle>Diagnostics availability</CardTitle>
-          <CardDescription>{availabilityDescription}</CardDescription>
+          <CardDescription>
+            <span>{availabilityDescription}</span>
+            {availabilityRecovery ? (
+              <span className="block">{availabilityRecovery}</span>
+            ) : null}
+          </CardDescription>
         </CardHeader>
       </Card>
+      {props.applicationOutputAvailability?.length ? (
+        <Card>
+          <CardHeader>
+            <CardTitle>Managed application streams</CardTitle>
+            <CardDescription>
+              stdout and stderr are tracked independently for this target.
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            <dl className="grid gap-3 sm:grid-cols-2">
+              {props.applicationOutputAvailability.map((item) => (
+                <div key={item.stream} className="space-y-1">
+                  <dt className="font-mono text-sm">{item.stream}</dt>
+                  <dd className="text-muted-foreground">
+                    {item.state}
+                    {item.message ? ` · ${item.message}` : ''}
+                  </dd>
+                </div>
+              ))}
+            </dl>
+          </CardContent>
+        </Card>
+      ) : null}
       {props.diagnostics.length > 0 ? (
         <Card>
           <CardHeader>
@@ -265,6 +392,24 @@ export function ResultDiagnostics(props: ResultDiagnosticsProps) {
             </CardDescription>
           </CardHeader>
           <CardContent className="space-y-4">
+            <div className="grid gap-2 sm:grid-cols-[minmax(0,1fr)_auto] sm:items-end">
+              <DiagnosticInput
+                label="Search Diagnostic entries"
+                value={query}
+                onChange={setQuery}
+                type="search"
+                placeholder="Search messages and metadata"
+              />
+              <Button
+                type="button"
+                variant="outline"
+                className="w-full sm:w-auto"
+                disabled={!hasFilters}
+                onClick={clearFilters}
+              >
+                Clear filters
+              </Button>
+            </div>
             <DiagnosticChoice
               label="Level"
               values={diagnosticLevels}
@@ -301,29 +446,93 @@ export function ResultDiagnostics(props: ResultDiagnosticsProps) {
       {props.diagnostics.length === 0 ? (
         <EmptyEvidence message="No Diagnostic entries were retained for this Scenario attempt." />
       ) : diagnostics.length === 0 ? (
-        <EmptyEvidence message="No Diagnostic entries match these filters." />
+        <div>
+          <p role="status" aria-live="polite" className="sr-only">
+            0 of {props.diagnostics.length} Diagnostic entries match.
+          </p>
+          <EmptyEvidence message="No Diagnostic entries match these filters. Clear or change the filters to continue investigating." />
+        </div>
       ) : (
-        <ol className="space-y-3" aria-label="Diagnostic entries">
-          {diagnostics.map((diagnostic) => (
-            <li key={diagnostic.id}>
-              <Card>
-                <CardHeader>
-                  <CardTitle>{diagnostic.source}</CardTitle>
-                  <CardDescription>
-                    {new Date(diagnostic.occurredAt).toLocaleString()}
-                    {` · ${diagnostic.level} · ${diagnostic.origin}`}
-                    {diagnostic.stepText ? ` · ${diagnostic.stepText}` : ''}
-                  </CardDescription>
-                </CardHeader>
-                <CardContent>
-                  <p className="text-destructive">{diagnostic.message}</p>
-                </CardContent>
-              </Card>
-            </li>
-          ))}
-        </ol>
+        <DiagnosticEntries
+          key={filterKey}
+          diagnostics={diagnostics}
+          total={props.diagnostics.length}
+        />
       )}
     </div>
+  )
+}
+
+function DiagnosticEntries(props: {
+  diagnostics: readonly DiagnosticEvidence[]
+  total: number
+}) {
+  const [requestedPage, setRequestedPage] = useState(0)
+  const page = diagnosticPage(props.diagnostics, requestedPage)
+  const resultLabel = `Showing ${page.first}–${page.last} of ${props.diagnostics.length} matching Diagnostic entries (${props.total} total).`
+  return (
+    <section className="space-y-3" aria-labelledby="diagnostic-results-title">
+      <div className="flex flex-col gap-3 rounded-lg border border-border bg-card p-3 sm:flex-row sm:items-center sm:justify-between">
+        <div className="min-w-0">
+          <h4 id="diagnostic-results-title" className="font-medium">
+            Diagnostic entries
+          </h4>
+          <p
+            role="status"
+            aria-live="polite"
+            className="break-words text-sm text-muted-foreground"
+          >
+            {resultLabel}
+          </p>
+        </div>
+        <nav
+          className="grid grid-cols-2 gap-2 sm:flex"
+          aria-label="Diagnostic result pages"
+        >
+          <Button
+            type="button"
+            size="sm"
+            variant="outline"
+            disabled={page.page === 0}
+            onClick={() => setRequestedPage(page.page - 1)}
+          >
+            Previous 100
+          </Button>
+          <Button
+            type="button"
+            size="sm"
+            variant="outline"
+            disabled={page.page === page.pageCount - 1}
+            onClick={() => setRequestedPage(page.page + 1)}
+          >
+            Next 100
+          </Button>
+        </nav>
+      </div>
+      <ol className="space-y-3" aria-label="Diagnostic entries">
+        {page.entries.map((diagnostic, index) => (
+          <li
+            key={diagnostic.id}
+            aria-posinset={page.first + index}
+            aria-setsize={props.diagnostics.length}
+            className="min-w-0 rounded-lg border border-border bg-card p-4"
+          >
+            <div className="flex flex-col gap-1 sm:flex-row sm:items-start sm:justify-between sm:gap-3">
+              <h5 className="font-medium">{diagnostic.source}</h5>
+              <p className="break-words text-xs text-muted-foreground sm:text-right">
+                {new Date(diagnostic.occurredAt).toLocaleString()}
+                {` · ${diagnostic.level} · ${diagnostic.origin}`}
+                {diagnostic.stream ? ` · ${diagnostic.stream}` : ''}
+                {diagnostic.stepText ? ` · ${diagnostic.stepText}` : ''}
+              </p>
+            </div>
+            <p className="mt-3 whitespace-pre-wrap break-words text-destructive">
+              {diagnostic.message}
+            </p>
+          </li>
+        ))}
+      </ol>
+    </section>
   )
 }
 
@@ -371,7 +580,8 @@ type DiagnosticInputProps = {
   label: string
   value: string
   onChange: (value: string) => void
-  type?: 'text' | 'number'
+  type?: 'text' | 'number' | 'search'
+  placeholder?: string
 }
 
 function DiagnosticInput(props: DiagnosticInputProps) {
@@ -383,6 +593,7 @@ function DiagnosticInput(props: DiagnosticInputProps) {
         id={id}
         type={props.type ?? 'text'}
         min={props.type === 'number' ? 0 : undefined}
+        placeholder={props.placeholder}
         value={props.value}
         onChange={(event) => props.onChange(event.currentTarget.value)}
       />

--- a/packages/studio/src/result-evidence-timeline.tsx
+++ b/packages/studio/src/result-evidence-timeline.tsx
@@ -52,7 +52,7 @@ export function ResultEvidenceTimeline(props: ResultEvidenceTimelineProps) {
         ) : null}
         <ol
           aria-label="Causal evidence timeline"
-          className="relative space-y-0 before:absolute before:top-2 before:bottom-2 before:left-[5.75rem] before:w-px before:bg-border sm:before:left-[7.75rem]"
+          className="relative min-w-0 space-y-0 before:absolute before:top-2 before:bottom-2 before:left-[4.375rem] before:w-px before:bg-border sm:before:left-[7.75rem]"
         >
           {props.entries.map((entry) => (
             <li
@@ -63,14 +63,14 @@ export function ResultEvidenceTimeline(props: ResultEvidenceTimelineProps) {
                   : undefined
               }
               aria-current={entry.causal ? 'true' : undefined}
-              className="relative grid grid-cols-[5rem_minmax(0,1fr)] gap-4 py-2 sm:grid-cols-[7rem_minmax(0,1fr)]"
+              className="relative grid min-w-0 grid-cols-[4rem_minmax(0,1fr)] gap-3 py-2 sm:grid-cols-[7rem_minmax(0,1fr)] sm:gap-4"
             >
-              <time className="pr-3 text-right font-mono text-[0.625rem] text-muted-foreground tabular-nums">
+              <time className="pr-2 text-right font-mono text-[0.625rem] text-muted-foreground tabular-nums sm:pr-3">
                 {relativeTimeLabel(entry.occurredAt, props.startedAt)}
               </time>
               <span
                 aria-hidden="true"
-                className={`absolute top-[0.875rem] left-[5.5rem] size-2 rounded-full border sm:left-[7.5rem] ${
+                className={`absolute top-[0.875rem] left-[4.125rem] size-2 rounded-full border sm:left-[7.5rem] ${
                   entry.causal
                     ? 'border-foreground/35 bg-foreground'
                     : 'border-border bg-card'
@@ -91,7 +91,7 @@ export function ResultEvidenceTimeline(props: ResultEvidenceTimelineProps) {
                     </span>
                   ) : null}
                 </div>
-                <p className="mt-1 font-medium">{entry.title}</p>
+                <p className="mt-1 break-words font-medium">{entry.title}</p>
                 {entry.detail ? (
                   <p
                     className={`mt-1 break-words ${

--- a/packages/studio/src/result-evidence.test.ts
+++ b/packages/studio/src/result-evidence.test.ts
@@ -6,10 +6,15 @@ import type {
   TestResultState,
 } from '@pickle-spec/runner'
 import {
+  artifactLoadFailureGuidance,
+  artifactsFor,
+  artifactViewerKind,
   defaultResultInspectorTab,
+  diagnosticPage,
   diagnosticsFor,
   filterDiagnostics,
   findInspectedResult,
+  recoveryGuidance,
   timelineFor,
 } from './result-evidence'
 import { historyLocationHref, parseHistoryLocation } from './result-inspection'
@@ -270,6 +275,16 @@ test('filters Diagnostic entries without changing chronological order', () => {
         stepIndex: 0,
         executionTargetProfileId: 'chrome',
       },
+      {
+        occurredAt: '2026-08-22T12:00:01.025Z',
+        level: 'info',
+        origin: 'application',
+        stream: 'stdout',
+        message: 'Application ready',
+        scenarioId: 'scenario-pay',
+        stepIndex: 0,
+        executionTargetProfileId: 'chrome',
+      },
     ],
     steps: [
       {
@@ -310,6 +325,7 @@ test('filters Diagnostic entries without changing chronological order', () => {
 
   expect(diagnostics.map((entry) => entry.message)).toEqual([
     'Opened chrome',
+    'Application ready',
     'Retrying capture',
     'Payment was declined',
   ])
@@ -324,10 +340,109 @@ test('filters Diagnostic entries without changing chronological order', () => {
     ),
   ).toEqual(['Retrying capture'])
   expect(
+    filterDiagnostics(diagnostics, { query: 'stdout' }).map(
+      (entry) => entry.message,
+    ),
+  ).toEqual(['Application ready'])
+  expect(
     filterDiagnostics(diagnostics, {
       scenarioId: 'scenario-pay',
       stepIndex: 0,
       executionTargetProfileId: 'chrome',
     }).map((entry) => entry.message),
-  ).toEqual(['Opened chrome', 'Retrying capture', 'Payment was declined'])
+  ).toEqual([
+    'Opened chrome',
+    'Application ready',
+    'Retrying capture',
+    'Payment was declined',
+  ])
+})
+
+test('searches the complete 10,000-entry Diagnostic set before rendering is bounded', () => {
+  const diagnostics = Array.from({ length: 10_000 }, (_, index) => ({
+    id: `diagnostic-${index}`,
+    occurredAt: new Date(Date.UTC(2026, 7, 22, 12, 0, 0, index)).toISOString(),
+    level: 'info' as const,
+    origin: 'adapter' as const,
+    source: 'Scenario attempt' as const,
+    message:
+      index === 9_999
+        ? 'Deep device failure marker omega-9999'
+        : `Routine device entry ${index}`,
+    scenarioName: 'Pay for the order',
+    executionTargetProfileId: 'android-pixel',
+  }))
+
+  expect(
+    filterDiagnostics(diagnostics, { query: 'OMEGA-9999' }).map(
+      (entry) => entry.id,
+    ),
+  ).toEqual(['diagnostic-9999'])
+  expect(
+    filterDiagnostics(diagnostics, { query: 'android-pixel' }),
+  ).toHaveLength(10_000)
+  const page = diagnosticPage(filterDiagnostics(diagnostics, {}), 99)
+  expect(page.entries).toHaveLength(100)
+  expect(page.entries.at(-1)?.id).toBe('diagnostic-9999')
+  expect(page).toMatchObject({ page: 99, pageCount: 100, first: 9_901 })
+})
+
+test('gives distinct recovery actions for unavailable and unreadable evidence', () => {
+  const guidance = [
+    recoveryGuidance('not-requested'),
+    recoveryGuidance('not-supported'),
+    recoveryGuidance('not-retained'),
+    recoveryGuidance('capture-failed'),
+    recoveryGuidance('missing'),
+    artifactLoadFailureGuidance('corrupt'),
+    artifactLoadFailureGuidance('load-failed'),
+  ]
+
+  expect(guidance[0]).toContain('Request')
+  expect(guidance[1]).toContain('execution target')
+  expect(guidance[2]).toContain('retention policy')
+  expect(guidance[3]).toContain('Diagnostics')
+  expect(guidance[4]).toContain('re-import')
+  expect(guidance[5]).toContain('corrupt')
+  expect(guidance[6]).toContain('Retry')
+  expect(new Set(guidance)).toHaveLength(guidance.length)
+})
+
+test('uses canonical artifact capture time and selects viewers without adapter knowledge', () => {
+  const inspectedAttempt: ScenarioAttempt = {
+    ...attempt(1),
+    steps: [
+      {
+        index: 0,
+        startedAt: '2026-08-22T12:00:00.000Z',
+        finishedAt: '2026-08-22T12:00:01.000Z',
+        durationMs: 1_000,
+        step: { keyword: 'Then', text: 'receipt appears', type: 'outcome' },
+        state: 'passed',
+        resolvedActions: [],
+        artifacts: [
+          {
+            kind: 'recording',
+            path: '/tmp/scenario.mp4',
+            mediaType: 'video/mp4',
+            capturedAt: '2026-08-22T12:00:00.750Z',
+          },
+        ],
+      },
+    ],
+  }
+
+  expect(artifactsFor(inspectedAttempt)[0]?.capturedAt).toBe(
+    '2026-08-22T12:00:00.750Z',
+  )
+  expect(
+    artifactViewerKind({ kind: 'recording', mediaType: 'video/mp4' }),
+  ).toBe('video')
+  expect(
+    artifactViewerKind({ kind: 'device-log', mediaType: 'text/plain' }),
+  ).toBe('text')
+  expect(artifactViewerKind({ kind: 'trace' })).toBe('download')
+  expect(
+    artifactViewerKind({ kind: 'screenshot', mediaType: 'image/png' }),
+  ).toBe('image')
 })

--- a/packages/studio/src/result-evidence.ts
+++ b/packages/studio/src/result-evidence.ts
@@ -1,6 +1,7 @@
 import type {
   DiagnosticLevel,
   DiagnosticOrigin,
+  EvidenceAvailability,
   RunEvent,
   ScenarioAttempt,
   TestArtifact,
@@ -26,6 +27,8 @@ export type ArtifactEvidence = {
   capturedAt: string
 }
 
+export type ArtifactViewerKind = 'image' | 'video' | 'text' | 'download'
+
 export type DiagnosticEvidence = {
   id: string
   occurredAt: string
@@ -34,6 +37,7 @@ export type DiagnosticEvidence = {
   source: 'Scenario attempt' | 'Step'
   level: DiagnosticLevel
   origin: DiagnosticOrigin
+  stream?: 'stdout' | 'stderr'
   scenarioId?: string
   scenarioName?: string
   stepIndex?: number
@@ -42,11 +46,46 @@ export type DiagnosticEvidence = {
 }
 
 export type DiagnosticFilter = {
+  query?: string
   level?: DiagnosticLevel
   origin?: DiagnosticOrigin
   scenarioId?: string
   stepIndex?: number
   executionTargetProfileId?: string
+}
+
+export type DiagnosticPage = {
+  entries: readonly DiagnosticEvidence[]
+  page: number
+  pageCount: number
+  first: number
+  last: number
+}
+
+export type ArtifactLoadFailure = 'missing' | 'corrupt' | 'load-failed'
+
+const evidenceRecoveryGuidance: Record<
+  Exclude<EvidenceAvailability['state'], 'available'>,
+  string
+> = {
+  'not-requested': 'Request this evidence before the next Test run.',
+  'not-supported':
+    'Choose an execution target that supports this evidence, then run the Scenario again.',
+  'not-retained':
+    'Change the evidence retention policy, then run the Scenario again.',
+  'capture-failed':
+    'Review Diagnostics for the capture error, then run the Scenario again.',
+  missing:
+    'Restore or re-import the archived artifact, or run the Scenario again.',
+}
+
+const artifactLoadGuidance: Record<ArtifactLoadFailure, string> = {
+  missing:
+    'The retained file could not be found. Restore or re-import the archive, or run the Scenario again.',
+  corrupt:
+    'The retained file could not be decoded and may be corrupt. Download the original file or run the Scenario again.',
+  'load-failed':
+    'The preview could not be loaded. Retry the preview, then download the original file if the problem continues.',
 }
 
 export type TimelineEntry = {
@@ -119,9 +158,24 @@ export function artifactsFor(attempt: ScenarioAttempt): ArtifactEvidence[] {
       artifact,
       stepIndex: step.index,
       stepText: `${step.step.keyword.trim()} ${step.step.text}`,
-      capturedAt: step.finishedAt,
+      capturedAt: artifact.capturedAt ?? step.finishedAt,
     })),
   )
+}
+
+export function artifactViewerKind(
+  artifact: Pick<TestArtifact, 'kind' | 'mediaType'>,
+): ArtifactViewerKind {
+  if (
+    artifact.mediaType?.startsWith('image/') ||
+    artifact.kind === 'screenshot'
+  )
+    return 'image'
+  if (artifact.mediaType?.startsWith('video/') || artifact.kind === 'recording')
+    return 'video'
+  if (artifact.mediaType?.startsWith('text/') || artifact.kind === 'device-log')
+    return 'text'
+  return 'download'
 }
 
 export function diagnosticsFor(attempt: ScenarioAttempt): DiagnosticEvidence[] {
@@ -188,8 +242,27 @@ export function filterDiagnostics(
   diagnostics: readonly DiagnosticEvidence[],
   filter: DiagnosticFilter,
 ): DiagnosticEvidence[] {
+  const query = filter.query?.trim().toLocaleLowerCase()
   return diagnostics.filter(
     (entry) =>
+      (!query ||
+        [
+          entry.message,
+          entry.source,
+          entry.occurredAt,
+          entry.level,
+          entry.origin,
+          entry.stream,
+          entry.scenarioId,
+          entry.scenarioName,
+          entry.stepIndex,
+          entry.stepText,
+          entry.executionTargetProfileId,
+        ]
+          .filter(Boolean)
+          .join('\n')
+          .toLocaleLowerCase()
+          .includes(query)) &&
       (filter.level === undefined || entry.level === filter.level) &&
       (filter.origin === undefined || entry.origin === filter.origin) &&
       (filter.scenarioId === undefined ||
@@ -199,6 +272,37 @@ export function filterDiagnostics(
       (filter.executionTargetProfileId === undefined ||
         entry.executionTargetProfileId === filter.executionTargetProfileId),
   )
+}
+
+export function diagnosticPage(
+  diagnostics: readonly DiagnosticEvidence[],
+  requestedPage: number,
+  pageSize = 100,
+): DiagnosticPage {
+  const safePageSize = Math.max(1, Math.floor(pageSize))
+  const pageCount = Math.max(1, Math.ceil(diagnostics.length / safePageSize))
+  const page = Math.min(Math.max(0, Math.floor(requestedPage)), pageCount - 1)
+  const start = page * safePageSize
+  const entries = diagnostics.slice(start, start + safePageSize)
+  return {
+    entries,
+    page,
+    pageCount,
+    first: entries.length === 0 ? 0 : start + 1,
+    last: start + entries.length,
+  }
+}
+
+export function recoveryGuidance(
+  state: Exclude<EvidenceAvailability['state'], 'available'>,
+): string {
+  return evidenceRecoveryGuidance[state]
+}
+
+export function artifactLoadFailureGuidance(
+  failure: ArtifactLoadFailure,
+): string {
+  return artifactLoadGuidance[failure]
 }
 
 export function timelineFor(
@@ -297,4 +401,10 @@ export function timelineFor(
 
 export function artifactUrl(path: string): string {
   return `/api/artifact?path=${encodeURIComponent(path)}`
+}
+
+export function artifactDownloadUrl(path: string, name?: string): string {
+  const query = new URLSearchParams({ path, download: 'true' })
+  if (name) query.set('name', name)
+  return `/api/artifact?${query.toString()}`
 }

--- a/packages/studio/src/result-inspector.tsx
+++ b/packages/studio/src/result-inspector.tsx
@@ -194,6 +194,7 @@ export function ResultInspector(props: ResultInspectorProps) {
         <TabsContent value="artifacts">
           <ResultArtifacts
             artifacts={artifacts}
+            availability={inspected.attempt.evidenceAvailability}
             scenarioName={inspected.result.scenario.name}
             resultState={
               displayState === 'running'
@@ -206,6 +207,9 @@ export function ResultInspector(props: ResultInspectorProps) {
           <ResultDiagnostics
             diagnostics={diagnostics}
             availability={inspected.attempt.evidenceAvailability}
+            applicationOutputAvailability={
+              inspected.attempt.applicationOutputAvailability
+            }
           />
         </TabsContent>
       </Tabs>

--- a/packages/studio/src/server.ts
+++ b/packages/studio/src/server.ts
@@ -2,11 +2,13 @@ import { mkdtemp, rm } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { basename, join, resolve, sep } from 'node:path'
 import type {
+  DiagnosticEntry,
   ExecutionCacheEntryMetadata,
   HtmlArtifactMode,
   RunEvent,
   TestRunComparison,
   TestRunManifest,
+  TestRunStorageInspection,
   TestRunSummary,
 } from '@pickle-spec/runner'
 import { resolveLocalProjectStorage } from '@pickle-spec/runner'
@@ -157,10 +159,22 @@ export interface StudioRunSnapshot {
   manifest?: TestRunManifest
 }
 
+export type StudioLiveDiagnosticEvent = {
+  type: 'diagnostic-recorded'
+  profileId: string
+  scope?: Extract<RunEvent, { type: 'scenario-started' }>['scope']
+  diagnostic: DiagnosticEntry
+}
+
+export type StudioRunStreamEvent =
+  | RunEvent
+  | StudioLiveDiagnosticEvent
+  | { type: 'run-finished'; run: { id: string } }
+
 export interface StudioRunGateway {
   start(
     request: StudioRunRequest | undefined,
-    onEvent: (event: RunEvent) => void,
+    onEvent: (event: StudioRunStreamEvent) => void,
   ): Promise<{ id: string; done: Promise<unknown> }>
   snapshot(id: string): Promise<StudioRunSnapshot>
   cancel(id: string): Promise<void>
@@ -175,17 +189,25 @@ export interface StudioHistoryGateway {
   importArchive(bytes: Uint8Array): Promise<TestRunManifest>
   exportArchive(runId: string): Promise<string>
   exportHtml(runId: string, artifacts: HtmlArtifactMode): Promise<string>
-  deleteEligible(): Promise<{ removed: string[] }>
+  exportAllure(runId: string): Promise<Uint8Array>
+  deleteEligible(): Promise<{
+    removed: string[]
+    beforeBytes: number
+    afterBytes: number
+  }>
+  pin(runId: string): Promise<void>
+  unpin(runId: string): Promise<void>
 }
 
 export interface StudioRetentionPolicy {
-  maxAgeMs: number
-  maxBytes: number
+  maxAgeMs?: number
+  maxBytes?: number
 }
 
 export interface StudioHistory {
   runs: readonly TestRunSummary[]
   retention: StudioRetentionPolicy
+  storage: TestRunStorageInspection
 }
 
 export interface StudioExecutionCacheInspection {
@@ -248,9 +270,7 @@ type HtmlAsset = {
   outdir: string
 }
 
-type StudioStreamEvent =
-  | RunEvent
-  | { type: 'run-finished'; run: { id: string } }
+type StudioStreamEvent = StudioRunStreamEvent
 
 type WorkspaceStreamEvent = DiskChangeEvent & { type: 'disk-changed' }
 
@@ -567,8 +587,25 @@ export async function startStudio(
           }
           return Response.json(await options.history.deleteEligible())
         }
+        const historyPinMatch = url.pathname.match(
+          /^\/api\/history\/([^/]+)\/pin$/,
+        )
+        if (
+          historyPinMatch &&
+          (request.method === 'POST' || request.method === 'DELETE')
+        ) {
+          if (!options.history) {
+            return new Response('Test run history is unavailable', {
+              status: 501,
+            })
+          }
+          const runId = decodeURIComponent(historyPinMatch[1]!)
+          if (request.method === 'POST') await options.history.pin(runId)
+          else await options.history.unpin(runId)
+          return Response.json({ runId, pinned: request.method === 'POST' })
+        }
         const historyExportMatch = url.pathname.match(
-          /^\/api\/history\/([^/]+)\/(html|archive)$/,
+          /^\/api\/history\/([^/]+)\/(html|archive|allure)$/,
         )
         if (historyExportMatch && request.method === 'GET') {
           if (!options.history) {
@@ -583,6 +620,15 @@ export async function startStudio(
               headers: {
                 'content-type': 'application/json; charset=utf-8',
                 'content-disposition': `attachment; filename="${runId}.pickle-run.json"`,
+              },
+            })
+          }
+          if (kind === 'allure') {
+            const bytes = await options.history.exportAllure(runId)
+            return new Response(bytes.buffer as ArrayBuffer, {
+              headers: {
+                'content-type': 'application/zip',
+                'content-disposition': `attachment; filename="${runId}-allure-results.zip"`,
               },
             })
           }
@@ -852,7 +898,10 @@ export async function startStudio(
             return new Response(message, { status: 500 })
           }
         }
-        if (url.pathname === '/api/artifact' && request.method === 'GET') {
+        if (
+          url.pathname === '/api/artifact' &&
+          (request.method === 'GET' || request.method === 'HEAD')
+        ) {
           const filePath = url.searchParams.get('path')
           if (!filePath) return new Response('Missing path', { status: 400 })
           const resolved = resolve(filePath)
@@ -868,7 +917,24 @@ export async function startStudio(
           const file = Bun.file(resolved)
           if (!(await file.exists()))
             return new Response('Not found', { status: 404 })
-          return new Response(file)
+          const headers = {
+            'content-type': file.type || 'application/octet-stream',
+            'content-length': String(file.size),
+          }
+          if (request.method === 'HEAD') return new Response(null, { headers })
+          if (url.searchParams.get('download') !== 'true') {
+            return new Response(file, { headers })
+          }
+          const requestedName = url.searchParams.get('name')
+          const downloadName = basename(requestedName || resolved).replace(
+            /["\r\n]/g,
+            '_',
+          )
+          return new Response(file, {
+            headers: {
+              'content-disposition': `attachment; filename="${downloadName}"`,
+            },
+          })
         }
         const cancelMatch = url.pathname.match(/^\/api\/runs\/([^/]+)\/cancel$/)
         if (cancelMatch && request.method === 'POST') {


### PR DESCRIPTION
## Summary

- Improve CLI output, diagnostics, configuration, server, and Studio history flows
- Add richer run results, evidence, artifacts, archives, and schema handling
- Extend mobile device evidence and gateway protocols
- Update example and Studio dependencies and documentation

Closes #81
Closes #82
Closes #83
Closes #84
Closes #85
Closes #86
Closes #87

## Testing

- Added and updated unit, integration, and Studio UI tests covering the changed behavior
- Not run (not requested)