### PR TITLE
Enforce cognitive complexity limit of 10

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -35,6 +35,12 @@
             ]
           }
         }
+      },
+      "complexity": {
+        "noExcessiveCognitiveComplexity": {
+          "level": "error",
+          "options": { "maxAllowedComplexity": 10 }
+        }
       }
     }
   },

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -18,7 +18,11 @@ import {
   type WebAdapterOptions,
 } from '@pickle-spec/web'
 import cliPackage from '../package.json' with { type: 'json' }
-import { defaultSpecificationGlob, loadConfig } from './configuration/config'
+import {
+  defaultSpecificationGlob,
+  loadConfig,
+  type PickleConfig,
+} from './configuration/config'
 import {
   checkProject,
   initializeProject,
@@ -44,7 +48,10 @@ import {
   type RunReporterName,
   terminalReporterCapabilities,
 } from './run/run-reporter'
-import { createRunReportingSession } from './run/run-reporting-session'
+import {
+  createRunReportingSession,
+  type RunReportingSession,
+} from './run/run-reporting-session'
 import { evaluateTestRunExitStatus } from './run/test-run-exit-status'
 import { createStudioExecutionCacheGateway } from './studio/studio-cache'
 import { createStudioHistoryGateway } from './studio/studio-history'
@@ -124,6 +131,163 @@ function parseShard(value: string): { index: number; total: number } {
   return { index: Number(match[1]), total: Number(match[2]) }
 }
 
+function parseRunSelectionOption(
+  args: RunArguments,
+  argv: string[],
+  index: number,
+): number | undefined {
+  const flag = argv[index]!
+  switch (flag) {
+    case '--suite':
+      args.suite = valueAfter(argv, index)
+      return index + 2
+    case '--profile':
+      args.profiles = [...(args.profiles ?? []), valueAfter(argv, index)]
+      return index + 2
+    case '--scenario':
+      args.selection.scenarioName = valueAfter(argv, index)
+      return index + 2
+    case '--tag':
+    case '-t':
+      args.selection.tagExpression = valueAfter(argv, index)
+      return index + 2
+    case '--state':
+      args.selection.states = [
+        ...(args.selection.states ?? []),
+        valueAfter(argv, index) as SpecificationState,
+      ]
+      return index + 2
+    case '--shard':
+      args.selection.shard = parseShard(valueAfter(argv, index))
+      return index + 2
+    default:
+      return undefined
+  }
+}
+
+function parseRunConfigurationOption(
+  args: RunArguments,
+  argv: string[],
+  index: number,
+): number | undefined {
+  const flag = argv[index]!
+  switch (flag) {
+    case '--config':
+      args.configPath = valueAfter(argv, index)
+      return index + 2
+    case '--extensions':
+      args.extensionsPath = valueAfter(argv, index)
+      return index + 2
+    case '--retries':
+      args.retries = integer(valueAfter(argv, index), flag, 0)
+      return index + 2
+    case '--concurrency':
+    case '-j':
+      args.concurrency = integer(valueAfter(argv, index), flag, 1)
+      return index + 2
+    case '--language':
+    case '-l':
+      args.language = valueAfter(argv, index)
+      return index + 2
+    case '--scenario-timeout':
+      args.scenarioTimeoutMs = integer(valueAfter(argv, index), flag, 1)
+      return index + 2
+    case '--step-timeout':
+      args.stepTimeoutMs = integer(valueAfter(argv, index), flag, 1)
+      return index + 2
+    case '--application-revision':
+      args.applicationRevision = valueAfter(argv, index)
+      return index + 2
+    default:
+      return undefined
+  }
+}
+
+function parseRunEvidenceOption(
+  args: RunArguments,
+  argv: string[],
+  index: number,
+): number | undefined {
+  const flag = argv[index]!
+  if (flag === '--screenshot') {
+    const mode = valueAfter(argv, index)
+    if (!screenshotModes.includes(mode as (typeof screenshotModes)[number])) {
+      throw new Error('--screenshot requires off, on-failure, or on-step')
+    }
+    args.screenshotMode = mode as RunArguments['screenshotMode']
+    return index + 2
+  }
+  if (flag === '--application-output') {
+    const stream = valueAfter(argv, index)
+    if (stream !== 'stdout' && stream !== 'stderr') {
+      throw new Error('--application-output requires stdout or stderr')
+    }
+    args.applicationOutput = { ...args.applicationOutput, [stream]: true }
+    return index + 2
+  }
+  if (flag !== '--evidence') return undefined
+  const persistence = valueAfter(argv, index)
+  if (
+    persistence !== 'off' &&
+    persistence !== 'on-failure' &&
+    persistence !== 'always'
+  ) {
+    throw new Error('--evidence requires off, on-failure, or always')
+  }
+  args.evidencePersistence = persistence
+  return index + 2
+}
+
+function parseRunOutputOption(
+  args: RunArguments,
+  argv: string[],
+  index: number,
+): number | undefined {
+  const flag = argv[index]!
+  switch (flag) {
+    case '--output':
+      args.outputs = [
+        ...(args.outputs ?? []),
+        parseTestRunOutput(valueAfter(argv, index)),
+      ]
+      return index + 2
+    case '--rerun':
+      args.rerunId = valueAfter(argv, index)
+      return index + 2
+    case '--reporter': {
+      const reporter = valueAfter(argv, index)
+      if (reporter !== 'default' && reporter !== 'ndjson') {
+        throw new Error('--reporter requires default or ndjson')
+      }
+      args.reporter = reporter
+      return index + 2
+    }
+    default:
+      return undefined
+  }
+}
+
+function parseRunBooleanOption(
+  args: RunArguments,
+  flag: string,
+  index: number,
+): number | undefined {
+  const fields: Partial<Record<string, keyof RunArguments>> = {
+    '--reuse-server': 'reuseServer',
+    '--headed': 'headed',
+    '--force': 'force',
+    '--all-artifacts': 'allArtifacts',
+    '--failures': 'failures',
+    '--fast': 'fast',
+    '--refresh-cache': 'refreshCache',
+    '--cache-only': 'cacheOnly',
+  }
+  const field = fields[flag]
+  if (!field) return undefined
+  Object.assign(args, { [field]: true })
+  return index + 1
+}
+
 function parseRunArguments(argv: string[]): RunArguments {
   if (argv[0] !== 'run')
     throw new Error('Usage: pickle run [specifications] [options]')
@@ -133,141 +297,166 @@ function parseRunArguments(argv: string[]): RunArguments {
 
   while (index < argv.length) {
     const flag = argv[index]!
-    switch (flag) {
-      case '--config':
-        args.configPath = valueAfter(argv, index++)
-        break
-      case '--extensions':
-        args.extensionsPath = valueAfter(argv, index++)
-        break
-      case '--suite':
-        args.suite = valueAfter(argv, index++)
-        break
-      case '--profile':
-        args.profiles = [...(args.profiles ?? []), valueAfter(argv, index++)]
-        break
-      case '--scenario':
-        args.selection.scenarioName = valueAfter(argv, index++)
-        break
-      case '--tag':
-      case '-t':
-        args.selection.tagExpression = valueAfter(argv, index++)
-        break
-      case '--state': {
-        const state = valueAfter(argv, index++)
-        args.selection.states = [
-          ...(args.selection.states ?? []),
-          state as SpecificationState,
-        ]
-        break
-      }
-      case '--shard':
-        args.selection.shard = parseShard(valueAfter(argv, index++))
-        break
-      case '--retries':
-        args.retries = integer(valueAfter(argv, index++), flag, 0)
-        break
-      case '--concurrency':
-      case '-j':
-        args.concurrency = integer(valueAfter(argv, index++), flag, 1)
-        break
-      case '--language':
-      case '-l':
-        args.language = valueAfter(argv, index++)
-        break
-      case '--scenario-timeout': {
-        args.scenarioTimeoutMs = integer(valueAfter(argv, index++), flag, 1)
-        break
-      }
-      case '--step-timeout':
-        args.stepTimeoutMs = integer(valueAfter(argv, index++), flag, 1)
-        break
-      case '--reuse-server':
-        args.reuseServer = true
-        break
-      case '--headed':
-        args.headed = true
-        break
-      case '--screenshot': {
-        const mode = valueAfter(argv, index++)
-        if (
-          !screenshotModes.includes(mode as (typeof screenshotModes)[number])
-        ) {
-          throw new Error('--screenshot requires off, on-failure, or on-step')
-        }
-        args.screenshotMode = mode as RunArguments['screenshotMode']
-        break
-      }
-      case '--application-revision':
-        args.applicationRevision = valueAfter(argv, index++)
-        break
-      case '--application-output': {
-        const stream = valueAfter(argv, index++)
-        if (stream !== 'stdout' && stream !== 'stderr') {
-          throw new Error('--application-output requires stdout or stderr')
-        }
-        args.applicationOutput = {
-          ...args.applicationOutput,
-          [stream]: true,
-        }
-        break
-      }
-      case '--evidence': {
-        const persistence = valueAfter(argv, index++)
-        if (
-          persistence !== 'off' &&
-          persistence !== 'on-failure' &&
-          persistence !== 'always'
-        ) {
-          throw new Error('--evidence requires off, on-failure, or always')
-        }
-        args.evidencePersistence = persistence
-        break
-      }
-      case '--output':
-        args.outputs = [
-          ...(args.outputs ?? []),
-          parseTestRunOutput(valueAfter(argv, index++)),
-        ]
-        break
-      case '--force':
-        args.force = true
-        break
-      case '--all-artifacts':
-        args.allArtifacts = true
-        break
-      case '--rerun':
-        args.rerunId = valueAfter(argv, index++)
-        break
-      case '--failures':
-        args.failures = true
-        break
-      case '--fast':
-        args.fast = true
-        break
-      case '--refresh-cache':
-        args.refreshCache = true
-        break
-      case '--cache-only':
-        args.cacheOnly = true
-        break
-      case '--reporter': {
-        const reporter = valueAfter(argv, index++)
-        if (reporter !== 'default' && reporter !== 'ndjson') {
-          throw new Error('--reporter requires default or ndjson')
-        }
-        args.reporter = reporter
-        break
-      }
-      default:
-        throw new Error(`Unknown option: ${flag}`)
-    }
-    index++
+    const nextIndex =
+      parseRunSelectionOption(args, argv, index) ??
+      parseRunConfigurationOption(args, argv, index) ??
+      parseRunEvidenceOption(args, argv, index) ??
+      parseRunOutputOption(args, argv, index) ??
+      parseRunBooleanOption(args, flag, index)
+    if (nextIndex === undefined) throw new Error(`Unknown option: ${flag}`)
+    index = nextIndex
   }
   if (args.refreshCache && args.cacheOnly) {
     throw new Error('--refresh-cache cannot be combined with --cache-only')
   }
   return args
+}
+
+interface RunCommandState {
+  startedRunId?: string
+  outputsWritten: boolean
+}
+
+interface RunCommandContext {
+  args: RunArguments
+  config: PickleConfig
+  root: string
+  controller: AbortController
+  reporting: RunReportingSession
+  startedAt: number
+  state: RunCommandState
+}
+
+async function executeRunCommand(context: RunCommandContext): Promise<number> {
+  const started = await startProjectRun({
+    root: context.root,
+    config: context.config,
+    options: context.args,
+    signal: context.controller.signal,
+    onEvent: context.reporting.event,
+    onSchedule: context.reporting.prepare,
+    onResult: context.reporting.complete,
+  })
+  context.state.startedRunId = started.id
+  context.reporting.start()
+  const { runs } = await started.done
+  const store = openTestRunStore({ root: context.root })
+  const outputOutcomes = await writeRunOutputs(
+    context.args,
+    context.root,
+    started.id,
+  )
+  context.state.outputsWritten = true
+  reportTestRunExportOutcomes(outputOutcomes, console.error)
+  const retention = await store.applyRetention({
+    maxAgeMs: context.config.retention?.days
+      ? context.config.retention.days * dayMs
+      : undefined,
+    maxBytes: context.config.retention?.maxBytes,
+  })
+  if (context.config.retention?.days || context.config.retention?.maxBytes) {
+    console.error(
+      `RETENTION removed ${retention.removed.length} Test runs (${retention.beforeBytes} → ${retention.afterBytes} bytes)${retention.removed.length > 0 ? `: ${retention.removed.join(', ')}` : ''}`,
+    )
+  }
+  const exitStatus = evaluateTestRunExitStatus(
+    runs.map(({ result }) => result),
+    { interrupted: context.controller.signal.aborted },
+  )
+  context.reporting.finish(
+    runs,
+    performance.now() - context.startedAt,
+    exitStatus,
+  )
+  const reporterFailure = context.reporting.failure()
+  if (reporterFailure) throw reporterFailure.error
+  return testRunExportFailed(outputOutcomes) ? 2 : exitStatus.exitCode
+}
+
+async function recoverMaterializedEvidence(
+  context: RunCommandContext,
+  commandError: unknown,
+  message: string,
+  includeEmptyRun = false,
+): Promise<unknown> {
+  const runId = context.state.startedRunId
+  if (!runId || context.state.outputsWritten) return commandError
+  try {
+    const outcomes = await finalizeMaterializedEvidence(
+      context.args,
+      context.root,
+      runId,
+      includeEmptyRun ? { includeEmptyRun: true } : undefined,
+    )
+    reportTestRunExportOutcomes(outcomes, console.error)
+    context.state.outputsWritten = true
+    return commandError
+  } catch (recoveryError) {
+    return withRecoveryFailure(commandError, message, recoveryError)
+  }
+}
+
+function isInterruptedRun(error: unknown, context: RunCommandContext): boolean {
+  return (
+    context.controller.signal.aborted &&
+    error instanceof Error &&
+    error.name === 'AbortError'
+  )
+}
+
+async function recoverInterruptedRun(
+  context: RunCommandContext,
+  commandError: unknown,
+): Promise<{ commandError: unknown; exitCode?: number }> {
+  if (!isInterruptedRun(commandError, context)) return { commandError }
+  commandError = await recoverMaterializedEvidence(
+    context,
+    commandError,
+    'Failed to finalize interrupted evidence',
+    true,
+  )
+  const exitStatus = evaluateTestRunExitStatus([], { interrupted: true })
+  context.reporting.finish(
+    [],
+    performance.now() - context.startedAt,
+    exitStatus,
+  )
+  const reporterFailure = context.reporting.failure()
+  if (reporterFailure) {
+    commandError = withRecoveryFailure(
+      commandError,
+      'Failed to render interrupted summary',
+      reporterFailure.error,
+    )
+  } else if (context.state.outputsWritten) {
+    return { commandError, exitCode: 130 }
+  }
+  return { commandError }
+}
+
+async function recoverRunCommand(
+  context: RunCommandContext,
+  error: unknown,
+): Promise<number> {
+  const interrupted = await recoverInterruptedRun(context, error)
+  if (interrupted.exitCode !== undefined) return interrupted.exitCode
+  let commandError = await recoverMaterializedEvidence(
+    context,
+    interrupted.commandError,
+    'Failed to finalize materialized evidence',
+  )
+  const reporterFailure = context.reporting.fail(
+    commandError,
+    performance.now() - context.startedAt,
+  )
+  if (reporterFailure) {
+    commandError = withRecoveryFailure(
+      commandError,
+      'Failed to restore reporter output',
+      reporterFailure.error,
+    )
+  }
+  throw commandError
 }
 
 async function run(argv: string[]): Promise<number> {
@@ -289,113 +478,21 @@ async function run(argv: string[]): Promise<number> {
   const reporting = createRunReportingSession(reporter)
   const onResize = reporting.refresh
   const startedAt = performance.now()
-  let startedRunId: string | undefined
-  let outputsWritten = false
+  const context: RunCommandContext = {
+    args,
+    config,
+    root,
+    controller,
+    reporting,
+    startedAt,
+    state: { outputsWritten: false },
+  }
   process.on('SIGINT', onSigint)
   if (process.stdout.isTTY) process.on('SIGWINCH', onResize)
   try {
-    const started = await startProjectRun({
-      root,
-      config,
-      options: args,
-      signal: controller.signal,
-      onEvent: reporting.event,
-      onSchedule: reporting.prepare,
-      onResult: reporting.complete,
-    })
-    startedRunId = started.id
-    reporting.start()
-    const { runs } = await started.done
-    const store = openTestRunStore({ root })
-    const outputOutcomes = await writeRunOutputs(args, root, started.id)
-    outputsWritten = true
-    reportTestRunExportOutcomes(outputOutcomes, console.error)
-    const retention = await store.applyRetention({
-      maxAgeMs: config.retention?.days
-        ? config.retention.days * dayMs
-        : undefined,
-      maxBytes: config.retention?.maxBytes,
-    })
-    if (config.retention?.days || config.retention?.maxBytes) {
-      console.error(
-        `RETENTION removed ${retention.removed.length} Test runs (${retention.beforeBytes} → ${retention.afterBytes} bytes)${retention.removed.length > 0 ? `: ${retention.removed.join(', ')}` : ''}`,
-      )
-    }
-
-    const exitStatus = evaluateTestRunExitStatus(
-      runs.map(({ result }) => result),
-      { interrupted: controller.signal.aborted },
-    )
-    reporting.finish(runs, performance.now() - startedAt, exitStatus)
-    const reporterFailure = reporting.failure()
-    if (reporterFailure) throw reporterFailure.error
-    return testRunExportFailed(outputOutcomes) ? 2 : exitStatus.exitCode
+    return await executeRunCommand(context)
   } catch (error) {
-    let commandError: unknown = error
-    if (
-      controller.signal.aborted &&
-      error instanceof Error &&
-      error.name === 'AbortError'
-    ) {
-      const exitStatus = evaluateTestRunExitStatus([], { interrupted: true })
-      if (startedRunId && !outputsWritten) {
-        try {
-          const outcomes = await finalizeMaterializedEvidence(
-            args,
-            root,
-            startedRunId,
-            { includeEmptyRun: true },
-          )
-          reportTestRunExportOutcomes(outcomes, console.error)
-          outputsWritten = true
-        } catch (recoveryError) {
-          commandError = withRecoveryFailure(
-            commandError,
-            'Failed to finalize interrupted evidence',
-            recoveryError,
-          )
-        }
-      }
-      reporting.finish([], performance.now() - startedAt, exitStatus)
-      const reporterFailure = reporting.failure()
-      if (reporterFailure) {
-        commandError = withRecoveryFailure(
-          commandError,
-          'Failed to render interrupted summary',
-          reporterFailure.error,
-        )
-      } else if (outputsWritten) {
-        return 130
-      }
-    }
-    if (startedRunId && !outputsWritten) {
-      try {
-        const outcomes = await finalizeMaterializedEvidence(
-          args,
-          root,
-          startedRunId,
-        )
-        reportTestRunExportOutcomes(outcomes, console.error)
-      } catch (recoveryError) {
-        commandError = withRecoveryFailure(
-          commandError,
-          'Failed to finalize materialized evidence',
-          recoveryError,
-        )
-      }
-    }
-    const reporterRecoveryFailure = reporting.fail(
-      commandError,
-      performance.now() - startedAt,
-    )
-    if (reporterRecoveryFailure) {
-      commandError = withRecoveryFailure(
-        commandError,
-        'Failed to restore reporter output',
-        reporterRecoveryFailure.error,
-      )
-    }
-    throw commandError
+    return recoverRunCommand(context, error)
   } finally {
     process.off('SIGINT', onSigint)
     process.off('SIGWINCH', onResize)
@@ -463,13 +560,24 @@ async function importArchive(argv: string[]): Promise<number> {
   return 0
 }
 
-async function exportRun(argv: string[]): Promise<number> {
+interface ExportArguments {
+  runId: string
+  outputs: TestRunExportRequest[]
+  allArtifacts: boolean
+  force: boolean
+}
+
+function exportRunId(argv: string[]): string {
   if (argv[0] !== 'export' || !argv[1]) {
     throw new Error(
       'Usage: pickle export <id> --output format=path [--output format=path] [--force] [--all-artifacts]',
     )
   }
-  const runId = argv[1]
+  return argv[1]
+}
+
+function parseExportArguments(argv: string[]): ExportArguments {
+  const runId = exportRunId(argv)
   const outputs: TestRunExportRequest[] = []
   let allArtifacts = false
   let force = false
@@ -485,6 +593,25 @@ async function exportRun(argv: string[]): Promise<number> {
   if (outputs.length === 0) {
     throw new Error('pickle export requires at least one --output format=path')
   }
+  return { runId, outputs, allArtifacts, force }
+}
+
+async function warnForLargeHtmlExports(
+  outputs: readonly TestRunExportRequest[],
+): Promise<void> {
+  const warningThreshold = 10 * 1024 * 1024
+  for (const output of outputs) {
+    if (output.format !== 'html') continue
+    const file = Bun.file(output.path)
+    if (!(await file.exists()) || file.size <= warningThreshold) continue
+    console.error(
+      `Warning: HTML export includes every available test artifact and is larger than 10 MB (${file.size} bytes).`,
+    )
+  }
+}
+
+async function exportRun(argv: string[]): Promise<number> {
+  const { runId, outputs, allArtifacts, force } = parseExportArguments(argv)
   const outcomes = await publishTestRunExports({
     root: process.cwd(),
     runId,
@@ -494,21 +621,7 @@ async function exportRun(argv: string[]): Promise<number> {
   })
   reportTestRunExportOutcomes(outcomes, console.log)
 
-  const warningThreshold = 10 * 1024 * 1024
-  if (allArtifacts) {
-    for (const output of outputs) {
-      const file = Bun.file(output.path)
-      if (
-        output.format === 'html' &&
-        (await file.exists()) &&
-        file.size > warningThreshold
-      ) {
-        console.error(
-          `Warning: HTML export includes every available test artifact and is larger than 10 MB (${file.size} bytes).`,
-        )
-      }
-    }
-  }
+  if (allArtifacts) await warnForLargeHtmlExports(outputs)
   return testRunExportFailed(outcomes) ? 2 : 0
 }
 
@@ -517,14 +630,25 @@ function parseStudioArguments(argv: string[]): StudioArguments {
   const options: StudioArguments = { open: true }
   for (let index = 1; index < argv.length; index++) {
     const flag = argv[index]!
-    if (flag === '--no-open') options.open = false
-    else if (flag === '--port')
-      options.port = integer(valueAfter(argv, index++), flag, 0)
-    else if (flag === '--config') options.configPath = valueAfter(argv, index++)
-    else if (flag === '--extensions')
-      options.extensionsPath = valueAfter(argv, index++)
-    else if (flag === '--remote') options.remoteHost = valueAfter(argv, index++)
-    else throw new Error(`Unknown option: ${flag}`)
+    switch (flag) {
+      case '--no-open':
+        options.open = false
+        break
+      case '--port':
+        options.port = integer(valueAfter(argv, index++), flag, 0)
+        break
+      case '--config':
+        options.configPath = valueAfter(argv, index++)
+        break
+      case '--extensions':
+        options.extensionsPath = valueAfter(argv, index++)
+        break
+      case '--remote':
+        options.remoteHost = valueAfter(argv, index++)
+        break
+      default:
+        throw new Error(`Unknown option: ${flag}`)
+    }
   }
   return options
 }

--- a/packages/cli/src/configuration/config.ts
+++ b/packages/cli/src/configuration/config.ts
@@ -427,39 +427,44 @@ function validateConfig(value: unknown): PickleConfig {
   return parseConfiguration(pickleConfigSchema, value, 'Invalid configuration')
 }
 
+function quotedJsonEnd(source: string, start: number): number {
+  let escaped = false
+  for (let index = start + 1; index < source.length; index++) {
+    const character = source[index]!
+    if (escaped) escaped = false
+    else if (character === '\\') escaped = true
+    else if (character === '"') return index
+  }
+  return source.length - 1
+}
+
+function lineCommentEnd(source: string, start: number): number {
+  const newline = source.indexOf('\n', start + 2)
+  return newline === -1 ? source.length : newline
+}
+
+function blockCommentEnd(source: string, start: number): number {
+  const closing = source.indexOf('*/', start + 2)
+  return closing === -1 ? source.length : closing + 2
+}
+
 function removeJsonComments(source: string): string {
   let result = ''
-  let inString = false
-  let escaped = false
-
   for (let index = 0; index < source.length; index++) {
     const character = source[index]!
-    const next = source[index + 1]
-    if (inString) {
-      result += character
-      if (escaped) escaped = false
-      else if (character === '\\') escaped = true
-      else if (character === '"') inString = false
-      continue
-    }
     if (character === '"') {
-      inString = true
-      result += character
+      const end = quotedJsonEnd(source, index)
+      result += source.slice(index, end + 1)
+      index = end
       continue
     }
-    if (character === '/' && next === '/') {
-      while (index < source.length && source[index] !== '\n') index++
-      result += '\n'
+    if (source.startsWith('//', index)) {
+      index = lineCommentEnd(source, index)
+      if (index < source.length) result += '\n'
       continue
     }
-    if (character === '/' && next === '*') {
-      index += 2
-      while (
-        index < source.length &&
-        !(source[index] === '*' && source[index + 1] === '/')
-      )
-        index++
-      index++
+    if (source.startsWith('/*', index)) {
+      index = blockCommentEnd(source, index) - 1
       continue
     }
     result += character

--- a/packages/cli/src/configuration/project.ts
+++ b/packages/cli/src/configuration/project.ts
@@ -108,6 +108,37 @@ async function readSpecificationFiles(
   return files
 }
 
+function migrationConfirmed(
+  options: ProjectCommandOptions,
+  report: (message: string) => void,
+): boolean {
+  if (options.yes) return true
+  if (!process.stdin.isTTY) {
+    report(
+      'No files were changed. Re-run pickle migrate --yes after reviewing the preview.',
+    )
+    return false
+  }
+  if (/^[yY]/.test((prompt('Apply these changes? [y/N]') ?? '').trim())) {
+    return true
+  }
+  report('No files were changed')
+  return false
+}
+
+async function writeMigration(
+  cwd: string,
+  files: readonly { uri: string; source: string; nextSource: string }[],
+): Promise<number> {
+  let updated = 0
+  for (const file of files) {
+    if (file.source === file.nextSource) continue
+    await Bun.write(resolve(cwd, file.uri), file.nextSource)
+    updated++
+  }
+  return updated
+}
+
 export async function migrateProject(
   options: ProjectCommandOptions = {},
 ): Promise<void> {
@@ -125,24 +156,8 @@ export async function migrateProject(
   const plan = planSpecificationMigration(files, config.language)
   report(formatMigrationPreview(plan))
   if (plan.changes.length === 0) return
-  if (!options.yes) {
-    if (!process.stdin.isTTY) {
-      report(
-        'No files were changed. Re-run pickle migrate --yes after reviewing the preview.',
-      )
-      return
-    }
-    if (!/^[yY]/.test((prompt('Apply these changes? [y/N]') ?? '').trim())) {
-      report('No files were changed')
-      return
-    }
-  }
-  let updated = 0
-  for (const file of plan.files) {
-    if (file.source === file.nextSource) continue
-    await Bun.write(resolve(cwd, file.uri), file.nextSource)
-    updated++
-  }
+  if (!migrationConfirmed(options, report)) return
+  const updated = await writeMigration(cwd, plan.files)
   report(`Updated ${updated} Specification file(s)`)
 }
 

--- a/packages/cli/src/execution-cache/execution-cache-confidentiality.test.ts
+++ b/packages/cli/src/execution-cache/execution-cache-confidentiality.test.ts
@@ -190,6 +190,55 @@ function runPickle(options: PickleRunOptions) {
   ])
 }
 
+type InspectedCache = Awaited<ReturnType<typeof inspectCache>>
+
+async function expectRuntimeSentinelsAbsent(
+  runtimeSentinels: readonly string[],
+  processOutput: string,
+  inferenceMarkers: readonly string[],
+  caches: readonly InspectedCache[],
+): Promise<void> {
+  for (const runtimeSentinel of runtimeSentinels) {
+    expect(processOutput).not.toContain(runtimeSentinel)
+    for (const marker of inferenceMarkers) {
+      expect(await fileContains(marker, runtimeSentinel)).toBe(false)
+    }
+    for (const cache of caches) {
+      expect(JSON.stringify(cache.keys)).not.toContain(runtimeSentinel)
+      expect(JSON.stringify(cache.entries)).not.toContain(runtimeSentinel)
+      expect(JSON.stringify(cache.leases)).not.toContain(runtimeSentinel)
+      expect(JSON.stringify(cache.leaseOutcomes)).not.toContain(runtimeSentinel)
+    }
+  }
+}
+
+async function expectPersistentFilesSanitized(
+  runtimeSentinels: readonly string[],
+  persistentFiles: readonly string[],
+  caches: readonly InspectedCache[],
+): Promise<void> {
+  for (const runtimeSentinel of runtimeSentinels) {
+    for (const path of persistentFiles) {
+      expect(await fileContains(path, runtimeSentinel)).toBe(false)
+    }
+    for (const cache of caches) {
+      await expectDatabaseFilesSanitized(cache, runtimeSentinel)
+    }
+  }
+}
+
+async function expectDatabaseFilesSanitized(
+  cache: InspectedCache,
+  runtimeSentinel: string,
+): Promise<void> {
+  for (const suffix of ['', '-wal', '-shm']) {
+    const path = `${cache.databasePath}${suffix}`
+    if (await Bun.file(path).exists()) {
+      expect(await fileContains(path, runtimeSentinel)).toBe(false)
+    }
+  }
+}
+
 test('keeps runtime values and model credentials out of public cache-only and concurrent runs', async () => {
   const projectRoot = await tempRoot('pickle-confidentiality-project')
   const cacheRoot = await tempRoot('pickle-confidentiality-cache')
@@ -449,19 +498,13 @@ export default {
     .map(outputText)
     .join('\n')
   const runtimeSentinels = [runtimeSentinelA, runtimeSentinelB]
-  for (const runtimeSentinel of runtimeSentinels) {
-    expect(processOutput).not.toContain(runtimeSentinel)
-    expect(await fileContains(inferenceMarker, runtimeSentinel)).toBe(false)
-    expect(await fileContains(concurrentInferenceMarker, runtimeSentinel)).toBe(
-      false,
-    )
-    for (const cache of [sequentialCache, concurrentCache]) {
-      expect(JSON.stringify(cache.keys)).not.toContain(runtimeSentinel)
-      expect(JSON.stringify(cache.entries)).not.toContain(runtimeSentinel)
-      expect(JSON.stringify(cache.leases)).not.toContain(runtimeSentinel)
-      expect(JSON.stringify(cache.leaseOutcomes)).not.toContain(runtimeSentinel)
-    }
-  }
+  const caches = [sequentialCache, concurrentCache]
+  await expectRuntimeSentinelsAbsent(
+    runtimeSentinels,
+    processOutput,
+    [inferenceMarker, concurrentInferenceMarker],
+    caches,
+  )
 
   const runStateFiles = (
     await Promise.all(
@@ -496,17 +539,9 @@ export default {
     ...sequentialCache.files,
     ...concurrentCache.files,
   ]
-  for (const runtimeSentinel of runtimeSentinels) {
-    for (const path of persistentFiles) {
-      expect(await fileContains(path, runtimeSentinel)).toBe(false)
-    }
-    for (const cache of [sequentialCache, concurrentCache]) {
-      for (const suffix of ['', '-wal', '-shm']) {
-        const path = `${cache.databasePath}${suffix}`
-        if (await Bun.file(path).exists()) {
-          expect(await fileContains(path, runtimeSentinel)).toBe(false)
-        }
-      }
-    }
-  }
+  await expectPersistentFilesSanitized(
+    runtimeSentinels,
+    persistentFiles,
+    caches,
+  )
 }, 30_000)

--- a/packages/cli/src/run/application-diagnostics.ts
+++ b/packages/cli/src/run/application-diagnostics.ts
@@ -178,136 +178,167 @@ export function createApplicationDiagnosticBuffer(
     }
   }
 
+  function recordForProfile(
+    profileId: string,
+    line: ApplicationOutputLine,
+  ): void {
+    const scenarios = [...active.values()].filter(
+      (scenario) => scenario.scope.executionTargetProfileId === profileId,
+    )
+    if (scenarios.length === 1) {
+      const scenario = scenarios[0]!
+      const diagnostic = appendDiagnostic(scenario, line)
+      options.onDiagnostic?.({ profileId, scope: scenario.scope, diagnostic })
+      return
+    }
+    pending.set(profileId, [...(pending.get(profileId) ?? []), line])
+    options.onDiagnostic?.({
+      profileId,
+      diagnostic: unscopedDiagnostic(profileId, line),
+    })
+  }
+
   function record(line: ApplicationOutputLine): void {
     const profiles = line.stream === 'stdout' ? stdoutProfiles : stderrProfiles
-    for (const profileId of profiles) {
-      const scenarios = [...active.values()].filter(
-        (scenario) => scenario.scope.executionTargetProfileId === profileId,
-      )
-      if (scenarios.length === 0) {
-        pending.set(profileId, [...(pending.get(profileId) ?? []), line])
-        options.onDiagnostic?.({
-          profileId,
-          diagnostic: unscopedDiagnostic(profileId, line),
-        })
-        continue
-      }
-      if (scenarios.length === 1) {
-        const scenario = scenarios[0]!
-        const diagnostic = appendDiagnostic(scenario, line)
-        options.onDiagnostic?.({
-          profileId,
-          scope: scenario.scope,
-          diagnostic,
-        })
-        continue
-      }
-      pending.set(profileId, [...(pending.get(profileId) ?? []), line])
-      options.onDiagnostic?.({
-        profileId,
-        diagnostic: unscopedDiagnostic(profileId, line),
-      })
+    for (const profileId of profiles) recordForProfile(profileId, line)
+  }
+
+  function startScenario(
+    event: Extract<RunEvent, { type: 'scenario-started' }>,
+  ): RunEvent {
+    active.set(scopeKey(event.scope), {
+      scenario: event.scenario,
+      scope: event.scope,
+      diagnostics: [],
+      stepDiagnostics: new Map(),
+    })
+    return event
+  }
+
+  function finishStep(
+    event: Extract<RunEvent, { type: 'step-finished' }>,
+    scenario: ActiveScenario,
+  ): RunEvent {
+    const stepIndex = event.scope.stepIndex ?? event.result.index
+    const diagnostics = scenario.diagnostics.filter(
+      (entry) => entry.stepIndex === stepIndex,
+    )
+    scenario.diagnostics = scenario.diagnostics.filter(
+      (entry) => entry.stepIndex !== stepIndex,
+    )
+    if (diagnostics.length > 0) {
+      scenario.stepDiagnostics.set(stepIndex, diagnostics)
+    }
+    scenario.step = undefined
+    if (diagnostics.length === 0) return event
+    return {
+      ...event,
+      result: {
+        ...event.result,
+        diagnostics: [...(event.result.diagnostics ?? []), ...diagnostics],
+      },
     }
   }
 
-  function project(event: RunEvent): RunEvent {
-    if (event.type === 'scenario-started') {
-      const scenario: ActiveScenario = {
-        scenario: event.scenario,
-        scope: event.scope,
-        diagnostics: [],
-        stepDiagnostics: new Map(),
-      }
-      active.set(scopeKey(event.scope), scenario)
-      return event
+  function claimPendingOutput(
+    event: Extract<RunEvent, { type: 'scenario-finished' }>,
+    scenario: ActiveScenario,
+  ): void {
+    const profileId = event.scope.executionTargetProfileId
+    const hasOtherActiveScenario = [...active.values()].some(
+      (candidate) =>
+        candidate !== scenario &&
+        candidate.scope.executionTargetProfileId === profileId,
+    )
+    const ownsSharedOutput =
+      event.attempt.state === 'failed' ||
+      event.attempt.state === 'infrastructure-error' ||
+      !hasOtherActiveScenario
+    if (!ownsSharedOutput) return
+    for (const line of pending.get(profileId) ?? []) {
+      appendDiagnostic(scenario, line, false)
     }
+    pending.delete(profileId)
+  }
 
-    const scenario = 'scope' in event ? active.get(scopeKey(event.scope)) : null
-    if (event.type === 'step-started' && scenario) {
-      scenario.step = {
-        index: event.scope.stepIndex ?? 0,
-        text: `${event.step.keyword.trim()} ${event.step.text}`,
-      }
-      return event
+  function finishScenario(
+    event: Extract<RunEvent, { type: 'scenario-finished' }>,
+    scenario: ActiveScenario,
+  ): RunEvent {
+    claimPendingOutput(event, scenario)
+    active.delete(scopeKey(event.scope))
+    const steps = event.attempt.steps.map((step) => {
+      const diagnostics = scenario.stepDiagnostics.get(step.index) ?? []
+      return diagnostics.length === 0
+        ? step
+        : {
+            ...step,
+            diagnostics: [...(step.diagnostics ?? []), ...diagnostics],
+          }
+    })
+    const diagnostics = [
+      ...(event.attempt.diagnostics ?? []),
+      ...scenario.diagnostics,
+    ]
+    const stepDiagnostics = steps.flatMap((step) => step.diagnostics ?? [])
+    return {
+      ...event,
+      attempt: {
+        ...event.attempt,
+        steps,
+        diagnostics: diagnostics.length > 0 ? diagnostics : undefined,
+        evidenceAvailability: availabilityFor(
+          event.attempt.evidenceAvailability,
+          options,
+          event.scope.executionTargetProfileId,
+          diagnostics.length > 0 || stepDiagnostics.length > 0,
+        ),
+        applicationOutputAvailability: applicationOutputAvailabilityFor(
+          options,
+          event.scope.executionTargetProfileId,
+          [...diagnostics, ...stepDiagnostics],
+        ),
+      },
     }
-    if (event.type === 'step-finished' && scenario) {
-      const stepIndex = event.scope.stepIndex ?? event.result.index
-      const diagnostics = scenario.diagnostics.filter(
-        (entry) => entry.stepIndex === stepIndex,
-      )
-      scenario.diagnostics = scenario.diagnostics.filter(
-        (entry) => entry.stepIndex !== stepIndex,
-      )
-      if (diagnostics.length > 0) {
-        scenario.stepDiagnostics.set(stepIndex, diagnostics)
-      }
-      scenario.step = undefined
-      if (diagnostics.length === 0) return event
-      return {
-        ...event,
-        result: {
-          ...event.result,
-          diagnostics: [...(event.result.diagnostics ?? []), ...diagnostics],
-        },
-      }
-    }
-    if (event.type === 'scenario-finished' && scenario) {
-      const profileId = event.scope.executionTargetProfileId
-      const otherActiveScenarios = [...active.values()].filter(
-        (candidate) =>
-          candidate !== scenario &&
-          candidate.scope.executionTargetProfileId === profileId,
-      )
-      const ownsSharedOutput =
-        event.attempt.state === 'failed' ||
-        event.attempt.state === 'infrastructure-error' ||
-        otherActiveScenarios.length === 0
-      if (ownsSharedOutput) {
-        for (const line of pending.get(profileId) ?? []) {
-          appendDiagnostic(scenario, line, false)
-        }
-        pending.delete(profileId)
-      }
-      active.delete(scopeKey(event.scope))
-      const steps = event.attempt.steps.map((step) => {
-        const diagnostics = scenario.stepDiagnostics.get(step.index) ?? []
-        if (diagnostics.length === 0) return step
-        return {
-          ...step,
-          diagnostics: [...(step.diagnostics ?? []), ...diagnostics],
-        }
-      })
-      const diagnostics = [
-        ...(event.attempt.diagnostics ?? []),
-        ...scenario.diagnostics,
-      ]
-      const stepsHaveDiagnostics = steps.some(
-        (step) => (step.diagnostics?.length ?? 0) > 0,
-      )
-      return {
-        ...event,
-        attempt: {
-          ...event.attempt,
-          steps,
-          diagnostics: diagnostics.length > 0 ? diagnostics : undefined,
-          evidenceAvailability: availabilityFor(
-            event.attempt.evidenceAvailability,
-            options,
-            event.scope.executionTargetProfileId,
-            diagnostics.length > 0 || stepsHaveDiagnostics,
-          ),
-          applicationOutputAvailability: applicationOutputAvailabilityFor(
-            options,
-            event.scope.executionTargetProfileId,
-            [
-              ...diagnostics,
-              ...steps.flatMap((step) => step.diagnostics ?? []),
-            ],
-          ),
-        },
-      }
+  }
+
+  function startStep(
+    event: Extract<RunEvent, { type: 'step-started' }>,
+  ): RunEvent {
+    const scenario = active.get(scopeKey(event.scope))
+    if (!scenario) return event
+    scenario.step = {
+      index: event.scope.stepIndex ?? 0,
+      text: `${event.step.keyword.trim()} ${event.step.text}`,
     }
     return event
+  }
+
+  function finishActiveStep(
+    event: Extract<RunEvent, { type: 'step-finished' }>,
+  ): RunEvent {
+    const scenario = active.get(scopeKey(event.scope))
+    return scenario ? finishStep(event, scenario) : event
+  }
+
+  function finishActiveScenario(
+    event: Extract<RunEvent, { type: 'scenario-finished' }>,
+  ): RunEvent {
+    const scenario = active.get(scopeKey(event.scope))
+    return scenario ? finishScenario(event, scenario) : event
+  }
+
+  function projectActiveEvent(event: RunEvent): RunEvent {
+    if (event.type === 'step-started') return startStep(event)
+    if (event.type === 'step-finished') return finishActiveStep(event)
+    if (event.type === 'scenario-finished') return finishActiveScenario(event)
+    return event
+  }
+
+  function project(event: RunEvent): RunEvent {
+    return event.type === 'scenario-started'
+      ? startScenario(event)
+      : projectActiveEvent(event)
   }
 
   return { record, project }

--- a/packages/cli/src/run/execute-run.ts
+++ b/packages/cli/src/run/execute-run.ts
@@ -200,6 +200,34 @@ function configuredAdapter(
   return createWebAdapter(web, extensions.webAutomationFactory)
 }
 
+function configureProfileAdapter(
+  adapters: Record<string, ExecutionTargetAdapter>,
+  extensions: Extensions,
+  config: PickleConfig,
+  args: ProjectRunOptions,
+  profile: ExecutionTargetProfile,
+): void {
+  if (adapters[profile.id]) return
+  if (profile.adapter === 'mobile') {
+    if (!adapters.mobile) {
+      adapters[profile.id] = configuredMobileAdapter(config, profile.id)
+    }
+    return
+  }
+  if (profile.adapter !== 'web') return
+  if (adapters.web) {
+    adapters[profile.id] = adapters.web
+    return
+  }
+  const web = configuredWebOptions(config, args, profile.id)
+  if (!web) {
+    throw new Error(
+      'Configure web.baseUrl or export an adapter from pickle.extensions.ts',
+    )
+  }
+  adapters[profile.id] = createWebAdapter(web, extensions.webAutomationFactory)
+}
+
 function configuredRunExtensions(
   extensions: Extensions,
   config: PickleConfig,
@@ -212,27 +240,7 @@ function configuredRunExtensions(
   if (extensions.adapter) adapters.custom ??= extensions.adapter
 
   for (const profile of profiles) {
-    if (profile.adapter === 'mobile') {
-      if (!adapters[profile.id] && !adapters.mobile) {
-        adapters[profile.id] = configuredMobileAdapter(config, profile.id)
-      }
-      continue
-    }
-    if (profile.adapter !== 'web' || adapters[profile.id]) continue
-    const web = configuredWebOptions(config, args, profile.id)
-    if (adapters.web) {
-      adapters[profile.id] = adapters.web
-      continue
-    }
-    if (!web) {
-      throw new Error(
-        'Configure web.baseUrl or export an adapter from pickle.extensions.ts',
-      )
-    }
-    adapters[profile.id] = createWebAdapter(
-      web,
-      extensions.webAutomationFactory,
-    )
+    configureProfileAdapter(adapters, extensions, config, args, profile)
   }
 
   return {
@@ -311,6 +319,355 @@ async function runSelectedResultPairs(
   return runs
 }
 
+type ProjectRunStore = ReturnType<typeof openTestRunStore>
+type PersistedProjectRun = Awaited<ReturnType<ProjectRunStore['create']>>
+type ResolvedProjectRunConfiguration = ReturnType<
+  typeof resolveRunConfiguration
+>
+type SelectedScenarios = ReturnType<typeof selectScenarios>
+type ManagedProjectServer = Awaited<ReturnType<typeof startServer>>
+
+type PreparedRunSelection = {
+  selections: SelectedScenarios
+  selectedResults?: TestResult[]
+  profileIds?: string[]
+}
+
+function requireSelections(
+  selections: SelectedScenarios,
+  rerun: boolean,
+): void {
+  if (selections.length > 0) return
+  throw new Error(
+    rerun
+      ? 'No Scenarios match the current rerun selection'
+      : 'No Scenarios match the current selection',
+  )
+}
+
+function selectedProfileIds(
+  args: ProjectRunOptions,
+  config: PickleConfig,
+  selectedResults: readonly TestResult[],
+): string[] | undefined {
+  if (args.profiles?.length) return args.profiles
+  if (!config.executionTargetProfiles) return undefined
+  return [
+    ...new Set(
+      selectedResults.map((result) => result.executionTargetProfile.id),
+    ),
+  ]
+}
+
+async function prepareRerunSelection(
+  root: string,
+  args: ProjectRunOptions,
+  config: PickleConfig,
+  specifications: Awaited<ReturnType<typeof discoverSpecifications>>,
+  baseSelection: SelectionOptions | undefined,
+  shardSelection: SelectionOptions['shard'],
+  historicalDurations: Record<string, number> | undefined,
+): Promise<PreparedRunSelection> {
+  const rerunId = args.rerunId!
+  const { manifest: sourceManifest } = await loadPersistedRun(root, rerunId)
+  const selectedResults = selectRerunResults(sourceManifest, {
+    failures: args.failures,
+    ...(args.scenarioIds?.length
+      ? { scenarioIds: args.scenarioIds }
+      : args.selection?.scenarioName
+        ? { scenarioNames: [args.selection.scenarioName] }
+        : {}),
+    ...(args.profiles?.length ? { profileIds: args.profiles } : {}),
+  })
+  if (selectedResults.length === 0) {
+    throw new Error('No results match the current rerun selection')
+  }
+  const selections = selectScenarios(
+    specifications,
+    {
+      ...baseSelection,
+      ...args.selection,
+      scenarioName: undefined,
+      shard: shardSelection,
+    },
+    historicalDurations ? { historicalDurations } : {},
+  ).filter((selection) =>
+    selectedResults.some((result) => selectionMatchesResult(selection, result)),
+  )
+  requireSelections(selections, true)
+  return {
+    selections,
+    selectedResults,
+    profileIds: selectedProfileIds(args, config, selectedResults),
+  }
+}
+
+function filterScenarioIds(
+  selections: SelectedScenarios,
+  scenarioIds: readonly string[] | undefined,
+): SelectedScenarios {
+  if (!scenarioIds?.length) return selections
+  const ids = new Set(scenarioIds)
+  return selections.filter((selection) =>
+    ids.has(scenarioSelectionId(selection)),
+  )
+}
+
+async function prepareRunSelection(
+  store: ProjectRunStore,
+  root: string,
+  config: PickleConfig,
+  args: ProjectRunOptions,
+): Promise<PreparedRunSelection> {
+  const specifications = await discoverSpecifications(
+    args.pattern ?? config.specifications ?? defaultSpecificationGlob,
+    args.language ?? config.language,
+    root,
+  )
+  const suiteSelection = args.suite ? config.suites?.[args.suite] : undefined
+  if (args.suite && !suiteSelection) {
+    throw new Error(`Unknown test suite "${args.suite}"`)
+  }
+  const baseSelection = suiteSelection ?? config.selection
+  const shardSelection = args.selection?.shard ?? baseSelection?.shard
+  const historicalDurations = shardSelection
+    ? await latestHistoricalDurations(store)
+    : undefined
+  if (args.rerunId) {
+    return prepareRerunSelection(
+      root,
+      args,
+      config,
+      specifications,
+      baseSelection,
+      shardSelection,
+      historicalDurations,
+    )
+  }
+  const selections = filterScenarioIds(
+    selectScenarios(
+      specifications,
+      { ...baseSelection, ...args.selection, shard: shardSelection },
+      historicalDurations ? { historicalDurations } : {},
+    ),
+    args.scenarioIds,
+  )
+  requireSelections(selections, false)
+  return { selections, profileIds: args.profiles }
+}
+
+async function resolveProjectRunConfiguration(
+  config: PickleConfig,
+  args: ProjectRunOptions,
+  applicationRevision: string | undefined,
+  profileIds: string[] | undefined,
+  root: string,
+): Promise<ResolvedProjectRunConfiguration> {
+  const extensions = await loadExtensions(args.extensionsPath, root)
+  const runConfiguration = {
+    ...runConfigurationFrom(config, profileIds),
+    concurrency: args.concurrency ?? config.concurrency,
+    applicationRevision,
+    execution: {
+      infrastructureRetries:
+        args.retries ?? config.execution?.infrastructureRetries,
+      functionalRetries: config.execution?.functionalRetries,
+      stepTimeoutMs: args.stepTimeoutMs ?? config.execution?.stepTimeoutMs,
+      scenarioTimeoutMs:
+        args.scenarioTimeoutMs ?? config.execution?.scenarioTimeoutMs,
+    },
+  }
+  return resolveRunConfiguration(
+    runConfiguration,
+    configuredRunExtensions(
+      extensions,
+      config,
+      args,
+      runConfiguration.executionTargetProfiles ?? [],
+    ),
+  )
+}
+
+function selectedTargetFilter(
+  selectedResults: readonly TestResult[] | undefined,
+) {
+  if (!selectedResults) return undefined
+  return (
+    selection: ScenarioSelection,
+    executionTargetProfile: ExecutionTargetProfile,
+  ) =>
+    selectedResults.some(
+      (result) =>
+        result.executionTargetProfile.id === executionTargetProfile.id &&
+        selectionMatchesResult(selection, result),
+    )
+}
+
+async function publishRunSchedule(
+  input: StartProjectRunInput,
+  selection: PreparedRunSelection,
+  configuration: ResolvedProjectRunConfiguration,
+): Promise<void> {
+  await input.onSchedule?.(
+    scheduleScenarios({
+      selections: selection.selections,
+      executionTargetProfiles: configuration.targets.map(
+        ({ executionTargetProfile }) => executionTargetProfile,
+      ),
+      includeTarget: selectedTargetFilter(selection.selectedResults),
+    }),
+  )
+}
+
+async function startApplicationDiagnostics(
+  input: StartProjectRunInput,
+  args: ProjectRunOptions,
+  targets: ResolvedProjectRunConfiguration['targets'],
+): Promise<{
+  server: ManagedProjectServer
+  diagnostics: ApplicationDiagnosticBuffer
+}> {
+  const applicationOutput = resolveApplicationOutput(
+    input.config,
+    targets.map(({ executionTargetProfile }) => executionTargetProfile),
+    args.applicationOutput,
+  )
+  const pendingOutput: ApplicationOutputLine[] = []
+  let diagnostics: ApplicationDiagnosticBuffer | undefined
+  const server = await startServer(
+    {
+      ...input.config.server,
+      output: applicationOutput.capture,
+      ...(args.reuseServer ? { reuseExisting: true } : {}),
+    },
+    {
+      signal: input.signal,
+      onOutput(line) {
+        if (diagnostics) diagnostics.record(line)
+        else pendingOutput.push(line)
+      },
+    },
+  )
+  const unavailableOutput: ApplicationOutputAvailability = {
+    stdout: applicationOutput.capture.stdout
+      ? 'not-supported'
+      : 'not-requested',
+    stderr: applicationOutput.capture.stderr
+      ? 'not-supported'
+      : 'not-requested',
+  }
+  diagnostics = createApplicationDiagnosticBuffer({
+    profiles: applicationOutput.profiles,
+    availability: server?.outputAvailability ?? unavailableOutput,
+    onDiagnostic: input.onApplicationDiagnostic,
+  })
+  for (const line of pendingOutput) diagnostics.record(line)
+  return { server, diagnostics }
+}
+
+function createPersistedEventHandler(
+  input: StartProjectRunInput,
+  testRun: PersistedProjectRun,
+  diagnostics: ApplicationDiagnosticBuffer,
+): (event: RunEvent) => Promise<void> {
+  return async (event) => {
+    const projected = diagnostics.project(event)
+    const persisted = await testRun.append(projected)
+    if (projected.type === 'scenario-finished') {
+      await testRun.materialize({ finished: false })
+    }
+    await input.onEvent?.(persisted)
+  }
+}
+
+async function replayPersistedEvents(
+  input: StartProjectRunInput,
+  testRun: PersistedProjectRun,
+): Promise<void> {
+  for (const event of await testRun.events()) await input.onEvent?.(event)
+}
+
+async function configuredExecutionCache(
+  input: StartProjectRunInput,
+  root: string,
+  targets: ResolvedProjectRunConfiguration['targets'],
+) {
+  if (!targets.some((target) => target.adapter.executionCache !== undefined)) {
+    return undefined
+  }
+  return openLocalExecutionCache({
+    projectRoot: root,
+    cacheRoot: process.env.PICKLE_CACHE_ROOT,
+    maxBytes: input.config.cache?.maxBytes,
+  })
+}
+
+async function executePreparedRun(
+  input: StartProjectRunInput,
+  args: ProjectRunOptions,
+  selection: PreparedRunSelection,
+  configuration: ResolvedProjectRunConfiguration,
+  testRun: PersistedProjectRun,
+  root: string,
+  onEvent: (event: RunEvent) => Promise<void>,
+): Promise<ScenarioRun[]> {
+  const executionCache = await configuredExecutionCache(
+    input,
+    root,
+    configuration.targets,
+  )
+  const shared = {
+    executionCache: executionCache
+      ? {
+          store: executionCache,
+          projectKey: executionCache.projectKey,
+          sourceRunId: testRun.id,
+        }
+      : undefined,
+    cachePolicy: args.cacheOnly
+      ? ('cache-only' as const)
+      : args.refreshCache
+        ? ('refresh' as const)
+        : ('prefer-cache' as const),
+    signal: input.signal,
+    onEvent,
+    onResult: input.onResult
+      ? (completion: ScenarioCompletion) => input.onResult?.(completion.result)
+      : undefined,
+  }
+  if (selection.selectedResults) {
+    return runSelectedResultPairs({
+      selectedResults: selection.selectedResults,
+      selections: selection.selections,
+      targets: configuration.targets,
+      retry: configuration.retry,
+      timeout: configuration.timeout,
+      concurrency: configuration.concurrency,
+      applicationRevision: configuration.applicationRevision,
+      ...shared,
+    })
+  }
+  return runScenarios({
+    selections: selection.selections,
+    ...configuration,
+    ...shared,
+  })
+}
+
+async function stopProjectResources(
+  server: ManagedProjectServer,
+  configuration: ResolvedProjectRunConfiguration | undefined,
+): Promise<void> {
+  if (server) {
+    server.stop()
+    await Promise.race([
+      server.outputComplete.catch(() => undefined),
+      Bun.sleep(1_000),
+    ])
+  }
+  if (configuration) await disposeAdapters(configuration.targets)
+}
+
 export async function loadPersistedRun(root: string, runId: string) {
   const store = openTestRunStore({ root })
   const run = await store.open(runId)
@@ -364,250 +721,49 @@ export async function startProjectRun(
   })
 
   async function runWork() {
-    let resolvedConfiguration:
-      | ReturnType<typeof resolveRunConfiguration>
-      | undefined
-    let server: Awaited<ReturnType<typeof startServer>> | undefined
+    let configuration: ResolvedProjectRunConfiguration | undefined
+    let server: ManagedProjectServer
     try {
-      const specifications = await discoverSpecifications(
-        args.pattern ?? input.config.specifications ?? defaultSpecificationGlob,
-        args.language ?? input.config.language,
+      const selection = await prepareRunSelection(
+        store,
+        root,
+        input.config,
+        args,
+      )
+      configuration = await resolveProjectRunConfiguration(
+        input.config,
+        args,
+        applicationRevision,
+        selection.profileIds,
         root,
       )
-      const suiteSelection = args.suite
-        ? input.config.suites?.[args.suite]
-        : undefined
-      if (args.suite && !suiteSelection) {
-        throw new Error(`Unknown test suite "${args.suite}"`)
-      }
-      const baseSelection = suiteSelection ?? input.config.selection
-      const shardSelection = args.selection?.shard ?? baseSelection?.shard
-      const historicalDurations = shardSelection
-        ? await latestHistoricalDurations(store)
-        : undefined
-
-      let selections = selectScenarios(
-        specifications,
-        {
-          ...baseSelection,
-          ...args.selection,
-          shard: shardSelection,
-        },
-        historicalDurations ? { historicalDurations } : {},
+      validateTargetSelection(selection.selections, configuration.targets)
+      await publishRunSchedule(input, selection, configuration)
+      const application = await startApplicationDiagnostics(
+        input,
+        args,
+        configuration.targets,
       )
-      if (args.scenarioIds?.length && !args.rerunId) {
-        const scenarioIds = new Set(args.scenarioIds)
-        selections = selections.filter((selection) =>
-          scenarioIds.has(scenarioSelectionId(selection)),
-        )
-      }
-      let profileIds = args.profiles
-      let selectedResults: TestResult[] | undefined
-
-      if (args.rerunId) {
-        const { manifest: sourceManifest } = await loadPersistedRun(
-          root,
-          args.rerunId,
-        )
-        selectedResults = selectRerunResults(sourceManifest, {
-          failures: args.failures,
-          ...(args.scenarioIds?.length
-            ? { scenarioIds: args.scenarioIds }
-            : args.selection?.scenarioName
-              ? { scenarioNames: [args.selection.scenarioName] }
-              : {}),
-          ...(args.profiles?.length ? { profileIds: args.profiles } : {}),
-        })
-        if (selectedResults.length === 0) {
-          throw new Error('No results match the current rerun selection')
-        }
-        selections = selectScenarios(
-          specifications,
-          {
-            ...baseSelection,
-            ...args.selection,
-            scenarioName: undefined,
-            shard: shardSelection,
-          },
-          historicalDurations ? { historicalDurations } : {},
-        ).filter((selection) =>
-          selectedResults!.some((result) =>
-            selectionMatchesResult(selection, result),
-          ),
-        )
-        if (selections.length === 0) {
-          throw new Error('No Scenarios match the current rerun selection')
-        }
-        profileIds = args.profiles?.length
-          ? args.profiles
-          : input.config.executionTargetProfiles
-            ? [
-                ...new Set(
-                  selectedResults.map(
-                    (result) => result.executionTargetProfile.id,
-                  ),
-                ),
-              ]
-            : undefined
-      }
-
-      if (selections.length === 0)
-        throw new Error('No Scenarios match the current selection')
-
-      const extensions = await loadExtensions(args.extensionsPath, root)
-      const runConfiguration = {
-        ...runConfigurationFrom(input.config, profileIds),
-        concurrency: args.concurrency ?? input.config.concurrency,
-        applicationRevision,
-        execution: {
-          infrastructureRetries:
-            args.retries ?? input.config.execution?.infrastructureRetries,
-          functionalRetries: input.config.execution?.functionalRetries,
-          stepTimeoutMs:
-            args.stepTimeoutMs ?? input.config.execution?.stepTimeoutMs,
-          scenarioTimeoutMs:
-            args.scenarioTimeoutMs ?? input.config.execution?.scenarioTimeoutMs,
-        },
-      }
-      resolvedConfiguration = resolveRunConfiguration(
-        runConfiguration,
-        configuredRunExtensions(
-          extensions,
-          input.config,
-          args,
-          runConfiguration.executionTargetProfiles ?? [],
-        ),
+      server = application.server
+      const onEvent = createPersistedEventHandler(
+        input,
+        testRun,
+        application.diagnostics,
       )
-      validateTargetSelection(selections, resolvedConfiguration.targets)
-      const includeTarget = selectedResults
-        ? (
-            selection: ScenarioSelection,
-            executionTargetProfile: ExecutionTargetProfile,
-          ) =>
-            selectedResults.some(
-              (result) =>
-                result.executionTargetProfile.id ===
-                  executionTargetProfile.id &&
-                selectionMatchesResult(selection, result),
-            )
-        : undefined
-      await input.onSchedule?.(
-        scheduleScenarios({
-          selections,
-          executionTargetProfiles: resolvedConfiguration.targets.map(
-            ({ executionTargetProfile }) => executionTargetProfile,
-          ),
-          includeTarget,
-        }),
-      )
-      const applicationOutput = resolveApplicationOutput(
-        input.config,
-        resolvedConfiguration.targets.map(
-          ({ executionTargetProfile }) => executionTargetProfile,
-        ),
-        args.applicationOutput,
-      )
-      const pendingApplicationOutput: ApplicationOutputLine[] = []
-      let applicationDiagnostics: ApplicationDiagnosticBuffer | undefined
-      server = await startServer(
-        {
-          ...input.config.server,
-          output: applicationOutput.capture,
-          ...(args.reuseServer ? { reuseExisting: true } : {}),
-        },
-        {
-          signal: input.signal,
-          onOutput(line) {
-            if (applicationDiagnostics) applicationDiagnostics.record(line)
-            else pendingApplicationOutput.push(line)
-          },
-        },
-      )
-      const unavailableOutput: ApplicationOutputAvailability = {
-        stdout: applicationOutput.capture.stdout
-          ? 'not-supported'
-          : 'not-requested',
-        stderr: applicationOutput.capture.stderr
-          ? 'not-supported'
-          : 'not-requested',
-      }
-      applicationDiagnostics = createApplicationDiagnosticBuffer({
-        profiles: applicationOutput.profiles,
-        availability: server?.outputAvailability ?? unavailableOutput,
-        onDiagnostic: input.onApplicationDiagnostic,
-      })
-      for (const line of pendingApplicationOutput)
-        applicationDiagnostics.record(line)
-      const onEvent = async (event: RunEvent) => {
-        const projected = applicationDiagnostics.project(event)
-        const persisted = await testRun.append(projected)
-        if (projected.type === 'scenario-finished') {
-          await testRun.materialize({ finished: false })
-        }
-        await input.onEvent?.(persisted)
-      }
-      for (const event of await testRun.events()) {
-        await input.onEvent?.(event)
-      }
-      const cacheCapable = resolvedConfiguration.targets.some(
-        (target) => target.adapter.executionCache !== undefined,
-      )
-      const executionCache = cacheCapable
-        ? await openLocalExecutionCache({
-            projectRoot: root,
-            cacheRoot: process.env.PICKLE_CACHE_ROOT,
-            maxBytes: input.config.cache?.maxBytes,
-          })
-        : undefined
-      const shared = {
-        executionCache: executionCache
-          ? {
-              store: executionCache,
-              projectKey: executionCache.projectKey,
-              sourceRunId: testRun.id,
-            }
-          : undefined,
-        cachePolicy: args.cacheOnly
-          ? ('cache-only' as const)
-          : args.refreshCache
-            ? ('refresh' as const)
-            : ('prefer-cache' as const),
-        signal: input.signal,
+      await replayPersistedEvents(input, testRun)
+      const runs = await executePreparedRun(
+        input,
+        args,
+        selection,
+        configuration,
+        testRun,
+        root,
         onEvent,
-        onResult: input.onResult
-          ? (completion: ScenarioCompletion) =>
-              input.onResult?.(completion.result)
-          : undefined,
-      }
-      const runs = selectedResults
-        ? await runSelectedResultPairs({
-            selectedResults,
-            selections,
-            targets: resolvedConfiguration.targets,
-            retry: resolvedConfiguration.retry,
-            timeout: resolvedConfiguration.timeout,
-            concurrency: resolvedConfiguration.concurrency,
-            applicationRevision: resolvedConfiguration.applicationRevision,
-            ...shared,
-          })
-        : await runScenarios({
-            selections,
-            ...resolvedConfiguration,
-            ...shared,
-          })
+      )
       const manifest = await testRun.materialize()
       return { runs, manifest }
     } finally {
-      if (server) {
-        server.stop()
-        await Promise.race([
-          server.outputComplete.catch(() => undefined),
-          Bun.sleep(1_000),
-        ])
-      }
-      if (resolvedConfiguration) {
-        await disposeAdapters(resolvedConfiguration.targets)
-      }
+      await stopProjectResources(server, configuration)
     }
   }
 

--- a/packages/cli/src/run/live-run-reporter.ts
+++ b/packages/cli/src/run/live-run-reporter.ts
@@ -143,39 +143,114 @@ export function createLiveRunReporter(
   ): string[] {
     const lines = renderActiveHeader(block, mark)
     for (const scheduleIndex of block.scheduleIndexes) {
-      if (!activeScheduleIndexes.has(scheduleIndex)) continue
-      const scheduled = schedule[scheduleIndex]
-      if (!scheduled) continue
-      const profile = multipleProfiles
-        ? `[${scheduled.executionTargetProfile.id}] `
-        : ''
-      writeWrapped(
-        (line) => lines.push(line),
-        `   ${mark} `,
-        `${profile}${scheduled.scenario.name}`,
-        '     ',
-        columns(),
-      )
-      const progress = progressByScheduleIndex.get(scheduleIndex)
-      for (const result of progress?.completedSteps ?? []) {
-        lines.push(
-          ...renderTestStepResult(result, {
-            color: options.color,
-            columns: columns(),
-          }),
-        )
-      }
-      if (progress?.runningStep) {
-        writeWrapped(
-          (line) => lines.push(line),
-          `     ${mark} `,
-          `${progress.runningStep.keyword} ${progress.runningStep.text}`,
-          '       ',
-          columns(),
-        )
-      }
+      lines.push(...renderActiveScenario(scheduleIndex, mark))
     }
     return lines
+  }
+
+  function renderActiveScenario(scheduleIndex: number, mark: string): string[] {
+    if (!activeScheduleIndexes.has(scheduleIndex)) return []
+    const scheduled = schedule[scheduleIndex]
+    if (!scheduled) return []
+    const lines: string[] = []
+    const profile = multipleProfiles
+      ? `[${scheduled.executionTargetProfile.id}] `
+      : ''
+    writeWrapped(
+      (line) => lines.push(line),
+      `   ${mark} `,
+      `${profile}${scheduled.scenario.name}`,
+      '     ',
+      columns(),
+    )
+    return [
+      ...lines,
+      ...renderScenarioProgress(
+        progressByScheduleIndex.get(scheduleIndex),
+        mark,
+      ),
+    ]
+  }
+
+  function renderScenarioProgress(
+    progress: LiveScenarioProgress | undefined,
+    mark: string,
+  ): string[] {
+    const lines = (progress?.completedSteps ?? []).flatMap((result) =>
+      renderTestStepResult(result, {
+        color: options.color,
+        columns: columns(),
+      }),
+    )
+    if (!progress?.runningStep) return lines
+    writeWrapped(
+      (line) => lines.push(line),
+      `     ${mark} `,
+      `${progress.runningStep.keyword} ${progress.runningStep.text}`,
+      '       ',
+      columns(),
+    )
+    return lines
+  }
+
+  function pagedBlocks(
+    activeBlocks: readonly PendingSpecificationBlock[],
+    allBlockLines: readonly string[][],
+    frameIndex: number,
+    maxRows: number,
+  ): { blockLines: string[][]; overflowLines: string[] } {
+    const { blockLines, usedRows } = collectPagedBlocks(
+      activeBlocks,
+      allBlockLines,
+      frameIndex,
+      maxRows,
+    )
+    const hiddenCount = activeBlocks.length - blockLines.length
+    if (hiddenCount === 0) return { blockLines, overflowLines: [] }
+    const overflowLines = wrappedLines(
+      ' … ',
+      `${hiddenCount} more active Specifications`,
+      '   ',
+      columns(),
+    )
+    trimPagedBlocks(blockLines, usedRows, overflowLines, maxRows)
+    return { blockLines, overflowLines }
+  }
+
+  function collectPagedBlocks(
+    activeBlocks: readonly PendingSpecificationBlock[],
+    allBlockLines: readonly string[][],
+    frameIndex: number,
+    maxRows: number,
+  ): { blockLines: string[][]; usedRows: number } {
+    const firstIndex = frameIndex % activeBlocks.length
+    const blockLines: string[][] = []
+    let usedRows = 0
+    for (let offset = 0; offset < activeBlocks.length; offset++) {
+      const index = (firstIndex + offset) % activeBlocks.length
+      const lines = allBlockLines[index]!
+      const lineRows = renderedRowCount(lines)
+      if (blockLines.length > 0 && usedRows + lineRows >= maxRows) break
+      blockLines.push(lines)
+      usedRows += lineRows
+      if (usedRows >= maxRows) break
+    }
+    return { blockLines, usedRows }
+  }
+
+  function trimPagedBlocks(
+    blockLines: string[][],
+    initialUsedRows: number,
+    overflowLines: readonly string[],
+    maxRows: number,
+  ): void {
+    let usedRows = initialUsedRows
+    while (
+      blockLines.length > 1 &&
+      usedRows + renderedRowCount(overflowLines) > maxRows
+    ) {
+      usedRows -= renderedRowCount(blockLines.pop()!)
+    }
   }
 
   function updateDynamicRegion(): void {
@@ -191,42 +266,10 @@ export function createLiveRunReporter(
       renderActiveBlock(block, mark),
     )
     const totalBlockRows = renderedRowCount(allBlockLines.flat())
-    let visibleBlocks = activeBlocks
-    let blockLines = allBlockLines
-    let overflowLines: string[] = []
     const isPaged = totalBlockRows > maxRows && activeBlocks.length > 1
-    if (isPaged) {
-      const firstIndex = frameIndex % activeBlocks.length
-      visibleBlocks = []
-      blockLines = []
-      let usedRows = 0
-      for (let offset = 0; offset < activeBlocks.length; offset++) {
-        const index = (firstIndex + offset) % activeBlocks.length
-        const lines = allBlockLines[index]!
-        const lineRows = renderedRowCount(lines)
-        if (blockLines.length > 0 && usedRows + lineRows >= maxRows) break
-        visibleBlocks.push(activeBlocks[index]!)
-        blockLines.push(lines)
-        usedRows += lineRows
-        if (usedRows >= maxRows) break
-      }
-      const hiddenCount = activeBlocks.length - visibleBlocks.length
-      if (hiddenCount > 0) {
-        overflowLines = wrappedLines(
-          ' … ',
-          `${hiddenCount} more active Specifications`,
-          '   ',
-          columns(),
-        )
-        while (
-          blockLines.length > 1 &&
-          usedRows + renderedRowCount(overflowLines) > maxRows
-        ) {
-          usedRows -= renderedRowCount(blockLines.pop()!)
-          visibleBlocks.pop()
-        }
-      }
-    }
+    const { blockLines, overflowLines } = isPaged
+      ? pagedBlocks(activeBlocks, allBlockLines, frameIndex, maxRows)
+      : { blockLines: allBlockLines, overflowLines: [] }
     const lines = blockLines.flat()
     terminal.update([...lines, ...overflowLines])
     setPagedRefresh(isPaged)
@@ -320,6 +363,46 @@ export function createLiveRunReporter(
     return scheduleIndex < 0 ? undefined : scheduleIndex
   }
 
+  function startScenario(
+    event: Extract<RunEvent, { type: 'scenario-started' }>,
+  ): void {
+    const scheduleIndex = schedule.findIndex(
+      (scheduled, index) =>
+        !completedResults[index] && scheduledEventMatches(scheduled, event),
+    )
+    if (scheduleIndex < 0) return
+    activeScheduleIndexes.add(scheduleIndex)
+    progressByScheduleIndex.set(scheduleIndex, { completedSteps: [] })
+    updateDynamicRegion()
+  }
+
+  function updateStep(
+    event: Extract<RunEvent, { type: 'step-started' | 'step-finished' }>,
+  ): void {
+    const scheduleIndex = activeScheduleIndex(event)
+    if (scheduleIndex === undefined) return
+    const progress = progressByScheduleIndex.get(scheduleIndex) ?? {
+      completedSteps: [],
+    }
+    if (event.type === 'step-started') progress.runningStep = event.step
+    else {
+      progress.completedSteps.push(event.result)
+      progress.runningStep = undefined
+    }
+    progressByScheduleIndex.set(scheduleIndex, progress)
+    updateDynamicRegion()
+  }
+
+  function recordEvent(event: RunEvent): void {
+    if (event.type === 'scenario-started') {
+      startScenario(event)
+      return
+    }
+    if (event.type === 'step-started' || event.type === 'step-finished') {
+      updateStep(event)
+    }
+  }
+
   return {
     start() {
       startTime = clockLabel(options.now())
@@ -337,35 +420,7 @@ export function createLiveRunReporter(
       terminal.commit(lines)
     },
     prepare,
-    event(event) {
-      if (event.type === 'scenario-started') {
-        const scheduleIndex = schedule.findIndex(
-          (scheduled, index) =>
-            !completedResults[index] && scheduledEventMatches(scheduled, event),
-        )
-        if (scheduleIndex < 0) return
-        activeScheduleIndexes.add(scheduleIndex)
-        progressByScheduleIndex.set(scheduleIndex, { completedSteps: [] })
-        updateDynamicRegion()
-        return
-      }
-      if (event.type !== 'step-started' && event.type !== 'step-finished') {
-        return
-      }
-      const scheduleIndex = activeScheduleIndex(event)
-      if (scheduleIndex === undefined) return
-      const progress = progressByScheduleIndex.get(scheduleIndex) ?? {
-        completedSteps: [],
-      }
-      if (event.type === 'step-started') {
-        progress.runningStep = event.step
-      } else {
-        progress.completedSteps.push(event.result)
-        progress.runningStep = undefined
-      }
-      progressByScheduleIndex.set(scheduleIndex, progress)
-      updateDynamicRegion()
-    },
+    event: recordEvent,
     complete,
     fail(error, durationMs) {
       const results = completedResults.flatMap((result) =>

--- a/packages/cli/src/run/run-report.ts
+++ b/packages/cli/src/run/run-report.ts
@@ -202,6 +202,14 @@ function resultSuffix(result: TestResult): string {
     : resultPresentations[result.state].detail
   if (stateDetail) details.push(stateDetail)
   if (result.flaky) details.push(`flaky, ${result.attempts.length} attempts`)
+  appendExecutionDetails(details, attempt)
+  return details.length > 0 ? ` (${details.join('; ')})` : ''
+}
+
+function appendExecutionDetails(
+  details: string[],
+  attempt: ReturnType<typeof finalScenarioAttempt>,
+): void {
   if (attempt.executionMode) {
     const mode = attempt.executionMode === 'replay' ? 'Replay' : 'Adaptive'
     details.push(`mode ${mode}`)
@@ -216,7 +224,6 @@ function resultSuffix(result: TestResult): string {
     const noun = attempt.inferenceCount === 1 ? 'inference' : 'inferences'
     details.push(`${attempt.inferenceCount} ${noun}`)
   }
-  return details.length > 0 ? ` (${details.join('; ')})` : ''
 }
 
 function scenarioKey(result: TestResult): string {
@@ -452,31 +459,41 @@ function writeDiagnostic(
     '                  ',
     options.columns,
   )
-  if (options.multipleProfiles) {
-    writeWrapped(
-      options.write,
-      '   Profile        ',
-      result.executionTargetProfile.id,
-      '                  ',
-      options.columns,
-    )
-  }
-  if (attempt.steps.length > 0) {
-    options.write('   Steps')
-    for (const step of attempt.steps) {
-      for (const line of renderTestStepResult(step, options)) {
-        options.write(line)
-      }
-      if (step.message) writeMessage(step.message, options)
-      writeArtifacts(step, options)
-    }
-  }
+  writeDiagnosticProfile(result, options)
+  writeDiagnosticSteps(attempt.steps, options)
   const messageBelongsToStep = attempt.steps.some(
     (step) => step.state === result.state && step.message === attempt.message,
   )
   if (attempt.message && !messageBelongsToStep) {
     options.write('   Message')
     writeMessage(attempt.message, options, '     ')
+  }
+}
+
+function writeDiagnosticProfile(
+  result: TestResult,
+  options: DiagnosticWriterOptions,
+): void {
+  if (!options.multipleProfiles) return
+  writeWrapped(
+    options.write,
+    '   Profile        ',
+    result.executionTargetProfile.id,
+    '                  ',
+    options.columns,
+  )
+}
+
+function writeDiagnosticSteps(
+  steps: readonly TestStepResult[],
+  options: DiagnosticWriterOptions,
+): void {
+  if (steps.length === 0) return
+  options.write('   Steps')
+  for (const step of steps) {
+    for (const line of renderTestStepResult(step, options)) options.write(line)
+    if (step.message) writeMessage(step.message, options)
+    writeArtifacts(step, options)
   }
 }
 

--- a/packages/cli/src/run/run-reporter.ts
+++ b/packages/cli/src/run/run-reporter.ts
@@ -97,6 +97,31 @@ function createBufferedRunReporter(options: RunReporterOptions): RunReporter {
     writeCompletedResult(result)
   }
 
+  function finishReport(
+    runs: readonly ScenarioRun[],
+    durationMs: number,
+    exitStatus: TestRunExitStatus,
+  ): void {
+    const results = runs.map((run) => run.result)
+    if (completedResults.length === 0) {
+      prepare(orderedScheduleFromResults(results))
+    }
+    if (completedResults.some((result) => !result)) {
+      for (const result of results) complete(result)
+    }
+    const lines = [
+      ...diagnosticLines(results, {
+        projectRoot,
+        color,
+        columns: options.columns,
+        multipleProfiles,
+      }),
+      ...interruptionLines(exitStatus, options.columns),
+      ...summaryLines(groupResults(results), results, startTime, durationMs),
+    ]
+    for (const line of lines) write(line)
+  }
+
   return {
     start() {
       startTime = clockLabel(now())
@@ -114,35 +139,7 @@ function createBufferedRunReporter(options: RunReporterOptions): RunReporter {
     prepare,
     event() {},
     complete,
-    finish(runs, durationMs, exitStatus) {
-      const results = runs.map((run) => run.result)
-      if (completedResults.length === 0) {
-        prepare(orderedScheduleFromResults(results))
-      }
-      if (completedResults.some((result) => !result)) {
-        for (const result of results) complete(result)
-      }
-      const specifications = groupResults(results)
-      for (const line of diagnosticLines(results, {
-        projectRoot,
-        color,
-        columns: options.columns,
-        multipleProfiles,
-      })) {
-        write(line)
-      }
-      for (const line of interruptionLines(exitStatus, options.columns)) {
-        write(line)
-      }
-      for (const line of summaryLines(
-        specifications,
-        results,
-        startTime,
-        durationMs,
-      )) {
-        write(line)
-      }
-    },
+    finish: finishReport,
   }
 }
 

--- a/packages/cli/src/server/server.ts
+++ b/packages/cli/src/server/server.ts
@@ -187,6 +187,67 @@ async function waitForPoll(
   })
 }
 
+async function reusableServer(
+  config: ServerConfig,
+  url: string,
+  deadline: number,
+  serverRuntime: ServerRuntime,
+  signal?: AbortSignal,
+): Promise<ManagedServer | undefined> {
+  if (!config.reuseExisting) return undefined
+  if (!(await isHealthy(config, url, deadline, serverRuntime, signal))) {
+    return undefined
+  }
+  throwIfCancelled(signal)
+  return {
+    mode: 'reused',
+    url,
+    outputAvailability: outputAvailability(config, false),
+    outputComplete: Promise.resolve(),
+    stop() {},
+  }
+}
+
+function observeConfiguredOutput(
+  config: ServerConfig,
+  child: ManagedApplicationProcess,
+  now: () => Date,
+  onOutput?: StartServerOptions['onOutput'],
+): Promise<void> {
+  const tasks: Promise<void>[] = []
+  if (config.output?.stdout && child.stdout instanceof ReadableStream) {
+    tasks.push(observeOutput(child.stdout, 'stdout', now, onOutput))
+  }
+  if (config.output?.stderr && child.stderr instanceof ReadableStream) {
+    tasks.push(observeOutput(child.stderr, 'stderr', now, onOutput))
+  }
+  return Promise.all(tasks).then(() => undefined)
+}
+
+async function waitForServer(
+  config: ServerConfig,
+  url: string,
+  deadline: number,
+  serverRuntime: ServerRuntime,
+  signal?: AbortSignal,
+): Promise<boolean> {
+  while (Date.now() < deadline) {
+    throwIfCancelled(signal)
+    if (await isHealthy(config, url, deadline, serverRuntime, signal)) {
+      return true
+    }
+    throwIfCancelled(signal)
+    const remaining = deadline - Date.now()
+    if (remaining <= 0) return false
+    await waitForPoll(
+      Math.min(config.pollIntervalMs ?? 500, remaining),
+      serverRuntime,
+      signal,
+    )
+  }
+  return false
+}
+
 export async function startServer(
   config: ServerConfig,
   options: StartServerOptions = {},
@@ -200,19 +261,14 @@ export async function startServer(
   const timeoutMs = config.startupTimeoutMs ?? 30_000
   const deadline = Date.now() + timeoutMs
 
-  if (
-    config.reuseExisting &&
-    (await isHealthy(config, url, deadline, serverRuntime, signal))
-  ) {
-    throwIfCancelled(signal)
-    return {
-      mode: 'reused',
-      url,
-      outputAvailability: outputAvailability(config, false),
-      outputComplete: Promise.resolve(),
-      stop() {},
-    }
-  }
+  const existing = await reusableServer(
+    config,
+    url,
+    deadline,
+    serverRuntime,
+    signal,
+  )
+  if (existing) return existing
 
   throwIfCancelled(signal)
   const child = serverRuntime.spawn(commandForShell(config.command), {
@@ -221,39 +277,29 @@ export async function startServer(
     stdout: config.output?.stdout ? 'pipe' : 'ignore',
     stderr: config.output?.stderr ? 'pipe' : 'ignore',
   })
-  const outputTasks: Promise<void>[] = []
-  if (config.output?.stdout && child.stdout instanceof ReadableStream) {
-    outputTasks.push(
-      observeOutput(child.stdout, 'stdout', now, options.onOutput),
-    )
-  }
-  if (config.output?.stderr && child.stderr instanceof ReadableStream) {
-    outputTasks.push(
-      observeOutput(child.stderr, 'stderr', now, options.onOutput),
-    )
-  }
-  const outputComplete = Promise.all(outputTasks).then(() => undefined)
+  const outputComplete = observeConfiguredOutput(
+    config,
+    child,
+    now,
+    options.onOutput,
+  )
   try {
-    while (Date.now() < deadline) {
-      throwIfCancelled(signal)
-      if (await isHealthy(config, url, deadline, serverRuntime, signal)) {
-        throwIfCancelled(signal)
-        return {
-          mode: 'spawned',
-          url,
-          outputAvailability: outputAvailability(config, true),
-          outputComplete,
-          stop: () => stopServerProcess(child),
-        }
+    const started = await waitForServer(
+      config,
+      url,
+      deadline,
+      serverRuntime,
+      signal,
+    )
+    throwIfCancelled(signal)
+    if (started) {
+      return {
+        mode: 'spawned',
+        url,
+        outputAvailability: outputAvailability(config, true),
+        outputComplete,
+        stop: () => stopServerProcess(child),
       }
-      throwIfCancelled(signal)
-      const remaining = deadline - Date.now()
-      if (remaining <= 0) break
-      await waitForPoll(
-        Math.min(config.pollIntervalMs ?? 500, remaining),
-        serverRuntime,
-        signal,
-      )
     }
     throw new Error(
       `Server failed to start within ${timeoutMs}ms. Command: "${config.command}", URL: "${url}"`,

--- a/packages/cli/src/studio/studio-mobile-targets.ts
+++ b/packages/cli/src/studio/studio-mobile-targets.ts
@@ -51,6 +51,58 @@ export function configuredMobileAdapter(
   return createAdapter(profile.mobile)
 }
 
+type MobileProfile = NonNullable<
+  PickleConfig['executionTargetProfiles']
+>[string]
+
+async function discoverMobileProfile(
+  config: PickleConfig,
+  profileId: string,
+  profile: MobileProfile,
+  createAdapter: StudioMobileAdapterFactory,
+  extensionAdapters?: Readonly<Record<string, ExecutionTargetAdapter>>,
+): Promise<StudioMobileTargetDiscovery> {
+  const executionTarget = profile.mobile?.executionTarget
+  if (!executionTarget) {
+    throw new Error(
+      `Mobile execution target profile "${profileId}" is incomplete`,
+    )
+  }
+  let adapter = discoverableMobileAdapter(
+    extensionAdapters?.[profileId] ?? extensionAdapters?.[profile.adapter],
+    profileId,
+  )
+  const ownsAdapter = !adapter
+  let discovery: StudioMobileTargetDiscovery
+  try {
+    adapter ??= configuredMobileAdapter(config, profileId, createAdapter)
+    discovery = {
+      profileId,
+      executionTarget,
+      targets: (await adapter.discoverTargets()).map((target) => ({
+        id: target.id,
+        name: target.name,
+        state: target.state,
+        capabilities: [...target.capabilities],
+      })),
+    }
+  } catch (reason) {
+    discovery = {
+      profileId,
+      executionTarget,
+      targets: [],
+      error: errorMessage(reason),
+    }
+  }
+  if (!ownsAdapter) return discovery
+  try {
+    await adapter?.dispose?.()
+    return discovery
+  } catch (reason) {
+    return { ...discovery, error: errorMessage(reason) }
+  }
+}
+
 export async function discoverStudioMobileTargets(
   config: PickleConfig,
   createAdapter: StudioMobileAdapterFactory = defaultMobileAdapterFactory,
@@ -69,53 +121,55 @@ export async function discoverStudioMobileTargets(
     ) {
       continue
     }
-    const executionTarget = profile.mobile.executionTarget
-    if (!executionTarget) continue
-    let adapter: MobileExecutionTargetAdapter | undefined
-    let ownsAdapter = false
-    try {
-      adapter = discoverableMobileAdapter(
-        extensionAdapters?.[profileId] ?? extensionAdapters?.[profile.adapter],
+    if (!profile.mobile.executionTarget) continue
+    discoveries.push(
+      await discoverMobileProfile(
+        config,
         profileId,
-      )
-      if (!adapter) {
-        adapter = configuredMobileAdapter(config, profileId, createAdapter)
-        ownsAdapter = true
-      }
-      discoveries.push({
-        profileId,
-        executionTarget,
-        targets: (await adapter.discoverTargets()).map((target) => ({
-          id: target.id,
-          name: target.name,
-          state: target.state,
-          capabilities: [...target.capabilities],
-        })),
-      })
-    } catch (reason) {
-      discoveries.push({
-        profileId,
-        executionTarget,
-        targets: [],
-        error: errorMessage(reason),
-      })
-    } finally {
-      if (ownsAdapter) {
-        try {
-          await adapter?.dispose?.()
-        } catch (reason) {
-          const current = discoveries.at(-1)
-          if (current?.profileId === profileId) {
-            discoveries[discoveries.length - 1] = {
-              ...current,
-              error: errorMessage(reason),
-            }
-          }
-        }
-      }
-    }
+        profile,
+        createAdapter,
+        extensionAdapters,
+      ),
+    )
   }
   return discoveries
+}
+
+function validateMobileProfileCapabilities(
+  profileId: string,
+  profile: MobileProfile,
+  discoveries: readonly StudioMobileTargetDiscovery[],
+): void {
+  const discovery = discoveries.find((item) => item.profileId === profileId)
+  if (!discovery) {
+    throw new Error(
+      `Execution target profile "${profileId}" was not discovered before the test run`,
+    )
+  }
+  if (discovery.error) throw new Error(discovery.error)
+  const target = discovery.targets.find(
+    (item) =>
+      item.state === 'booted' &&
+      (profile.mobile?.targetId === undefined ||
+        item.id === profile.mobile.targetId),
+  )
+  if (!target) {
+    const targetDescription = profile.mobile?.targetId
+      ? `Booted mobile target "${profile.mobile.targetId}" was not found`
+      : 'No booted mobile target was found'
+    throw new Error(
+      `${targetDescription} for execution target profile "${profileId}"`,
+    )
+  }
+  const available = new Set(target.capabilities)
+  const missing = (profile.capabilities ?? []).filter(
+    (capability) => !available.has(capability),
+  )
+  if (missing.length > 0) {
+    throw new Error(
+      `Selected target "${target.name}" for execution target profile "${profileId}" lacks configured capabilities: ${missing.join(', ')}`,
+    )
+  }
 }
 
 export function validateStudioMobileTargetCapabilities(
@@ -134,35 +188,6 @@ export function validateStudioMobileTargetCapabilities(
     if (profile.adapter !== 'mobile' || !selectedProfiles.has(profileId)) {
       continue
     }
-    const discovery = discoveries.find((item) => item.profileId === profileId)
-    if (!discovery) {
-      throw new Error(
-        `Execution target profile "${profileId}" was not discovered before the test run`,
-      )
-    }
-    if (discovery.error) throw new Error(discovery.error)
-    const target = discovery.targets.find(
-      (item) =>
-        item.state === 'booted' &&
-        (profile.mobile?.targetId === undefined ||
-          item.id === profile.mobile.targetId),
-    )
-    if (!target) {
-      const targetDescription = profile.mobile?.targetId
-        ? `Booted mobile target "${profile.mobile.targetId}" was not found`
-        : 'No booted mobile target was found'
-      throw new Error(
-        `${targetDescription} for execution target profile "${profileId}"`,
-      )
-    }
-    const available = new Set(target.capabilities)
-    const missing = (profile.capabilities ?? []).filter(
-      (capability) => !available.has(capability),
-    )
-    if (missing.length > 0) {
-      throw new Error(
-        `Selected target "${target.name}" for execution target profile "${profileId}" lacks configured capabilities: ${missing.join(', ')}`,
-      )
-    }
+    validateMobileProfileCapabilities(profileId, profile, discoveries)
   }
 }

--- a/packages/cli/src/studio/studio-project.ts
+++ b/packages/cli/src/studio/studio-project.ts
@@ -94,31 +94,7 @@ async function studioCatalog(
 
 function profileDetails(config: PickleConfig): StudioProfile[] {
   if (config.executionTargetProfiles) {
-    return Object.entries(config.executionTargetProfiles).map(
-      ([id, profile]) => ({
-        id,
-        adapter: profile.adapter,
-        ...(profile.capabilities
-          ? { capabilities: [...profile.capabilities] }
-          : {}),
-        ...(profile.mobile
-          ? {
-              mobile: {
-                ...profile.mobile,
-                executionTarget:
-                  profile.mobile.executionTarget ?? 'android-emulator',
-                application: { ...profile.mobile.application },
-                artifacts: profile.mobile.artifacts
-                  ? [...profile.mobile.artifacts]
-                  : undefined,
-                redactions: profile.mobile.redactions?.map((redaction) => ({
-                  ...redaction,
-                })),
-              },
-            }
-          : {}),
-      }),
-    )
+    return Object.entries(config.executionTargetProfiles).map(profileDetail)
   }
   const profile = config.executionTargetProfile
   return [
@@ -130,6 +106,33 @@ function profileDetails(config: PickleConfig): StudioProfile[] {
         : {}),
     },
   ]
+}
+
+function profileDetail([id, profile]: [
+  string,
+  ProjectExecutionTargetProfile,
+]): StudioProfile {
+  const mobile = profile.mobile
+    ? {
+        ...profile.mobile,
+        executionTarget: profile.mobile.executionTarget ?? 'android-emulator',
+        application: { ...profile.mobile.application },
+        artifacts: profile.mobile.artifacts
+          ? [...profile.mobile.artifacts]
+          : undefined,
+        redactions: profile.mobile.redactions?.map((redaction) => ({
+          ...redaction,
+        })),
+      }
+    : undefined
+  return {
+    id,
+    adapter: profile.adapter,
+    ...(profile.capabilities
+      ? { capabilities: [...profile.capabilities] }
+      : {}),
+    ...(mobile ? { mobile } : {}),
+  }
 }
 
 function suiteDetails(config: PickleConfig): StudioSuite[] {
@@ -151,6 +154,93 @@ function stubAdapter(capabilities?: readonly string[]): ExecutionTargetAdapter {
   }
 }
 
+function readinessSelections(
+  request: StudioRunRequest | undefined,
+  config: PickleConfig,
+  specifications: readonly Specification[],
+  reasons: string[],
+) {
+  const suiteSelection = request?.suite
+    ? config.suites?.[request.suite]
+    : undefined
+  if (request?.suite && !suiteSelection) {
+    reasons.push(`Unknown test suite "${request.suite}"`)
+  }
+  const selections = selectScenarios(specifications, {
+    ...suiteSelection,
+    ...studioRunSelection(request),
+  })
+  if (selections.length === 0) {
+    reasons.push('No Scenarios match the current selection')
+  }
+  return selections
+}
+
+function validateReadinessTargets(
+  request: StudioRunRequest | undefined,
+  config: PickleConfig,
+  selections: ReturnType<typeof selectScenarios>,
+  reasons: string[],
+): void {
+  const runConfiguration = runConfigurationFrom(config, request?.profiles)
+  const profiles =
+    runConfiguration.executionTargetProfiles ??
+    (runConfiguration.executionTargetProfile
+      ? [runConfiguration.executionTargetProfile]
+      : [])
+  if (profiles.length === 0) {
+    reasons.push('A test run must select at least one execution target profile')
+  }
+  validateTargetSelection(
+    selections,
+    profiles.map((profile) => ({
+      executionTargetProfile: profile,
+      adapter: stubAdapter(profile.capabilities),
+    })),
+  )
+}
+
+function hasEnvironmentModelCredential(config: PickleConfig): boolean {
+  return Boolean(
+    config.web?.browser?.modelApiKey ||
+      process.env.OPENAI_API_KEY ||
+      process.env.ANTHROPIC_API_KEY ||
+      process.env.GOOGLE_API_KEY ||
+      process.env.GEMINI_API_KEY ||
+      process.env.GOOGLE_GENERATIVE_AI_API_KEY,
+  )
+}
+
+async function hasReferencedModelCredential(
+  context: StudioProjectContext,
+  config: PickleConfig,
+): Promise<boolean> {
+  for (const [name, ref] of Object.entries(config.secrets ?? {})) {
+    if (process.env[name] || (await context.credentials.has(ref.keychain))) {
+      return true
+    }
+  }
+  return false
+}
+
+async function appendCredentialReadiness(
+  context: StudioProjectContext,
+  config: PickleConfig,
+  reasons: string[],
+): Promise<void> {
+  const usesWeb = profileDetails(config).some(
+    (profile) => profile.adapter === 'web',
+  )
+  if (!usesWeb || hasEnvironmentModelCredential(config)) return
+  const secretNames = Object.keys(config.secrets ?? {})
+  if (await hasReferencedModelCredential(context, config)) return
+  reasons.push(
+    secretNames.length === 0
+      ? 'Store a model credential in the system keychain before a web test run'
+      : 'The referenced model credential is not available',
+  )
+}
+
 export async function studioRunReadiness(
   context: StudioProjectContext,
   request: StudioRunRequest | undefined,
@@ -159,72 +249,57 @@ export async function studioRunReadiness(
 ): Promise<StudioRunReadiness> {
   const reasons: string[] = []
   try {
-    const suiteSelection = request?.suite
-      ? config.suites?.[request.suite]
-      : undefined
-    if (request?.suite && !suiteSelection) {
-      reasons.push(`Unknown test suite "${request.suite}"`)
-    }
-    const selection = {
-      ...suiteSelection,
-      ...studioRunSelection(request),
-    }
-    const selections = selectScenarios(specifications, selection)
-    if (selections.length === 0) {
-      reasons.push('No Scenarios match the current selection')
-    }
-    const runConfiguration = runConfigurationFrom(config, request?.profiles)
-    const profiles =
-      runConfiguration.executionTargetProfiles ??
-      (runConfiguration.executionTargetProfile
-        ? [runConfiguration.executionTargetProfile]
-        : [])
-    if (profiles.length === 0) {
-      reasons.push(
-        'A test run must select at least one execution target profile',
-      )
-    }
-    const targets = profiles.map((profile) => ({
-      executionTargetProfile: profile,
-      adapter: stubAdapter(profile.capabilities),
-    }))
-    validateTargetSelection(selections, targets)
-    const usesWeb = profileDetails(config).some(
-      (profile) => profile.adapter === 'web',
+    const selections = readinessSelections(
+      request,
+      config,
+      specifications,
+      reasons,
     )
-    if (usesWeb) {
-      const secretNames = Object.keys(config.secrets ?? {})
-      let present = Boolean(
-        config.web?.browser?.modelApiKey ||
-          process.env.OPENAI_API_KEY ||
-          process.env.ANTHROPIC_API_KEY ||
-          process.env.GOOGLE_API_KEY ||
-          process.env.GEMINI_API_KEY ||
-          process.env.GOOGLE_GENERATIVE_AI_API_KEY,
-      )
-      if (!present) {
-        for (const [name, ref] of Object.entries(config.secrets ?? {})) {
-          if (
-            process.env[name] ||
-            (await context.credentials.has(ref.keychain))
-          ) {
-            present = true
-            break
-          }
-        }
-      }
-      if (!present && secretNames.length === 0) {
-        reasons.push(
-          'Store a model credential in the system keychain before a web test run',
-        )
-      } else if (!present) {
-        reasons.push('The referenced model credential is not available')
-      }
-    }
+    validateReadinessTargets(request, config, selections, reasons)
+    await appendCredentialReadiness(context, config, reasons)
   } catch (error) {
     reasons.push(error instanceof Error ? error.message : String(error))
   }
   return { ready: reasons.length === 0, reasons }
+}
+
+function patchedExecutionTargetProfile(
+  profile: NonNullable<StudioConfigPatch['executionTargetProfiles']>[string],
+  existing: ProjectExecutionTargetProfile | undefined,
+): ProjectExecutionTargetProfile {
+  const retainedMobile =
+    profile.adapter === 'mobile' && existing?.mobile
+      ? { mobile: existing.mobile }
+      : {}
+  return {
+    adapter: profile.adapter,
+    ...(profile.capabilities
+      ? { capabilities: [...profile.capabilities] }
+      : {}),
+    ...(existing?.web ? { web: existing.web } : {}),
+    ...retainedMobile,
+    ...(profile.mobile
+      ? {
+          mobile: {
+            ...profile.mobile,
+            application: { ...profile.mobile.application },
+          },
+        }
+      : {}),
+  }
+}
+
+function patchExecutionTargetProfiles(
+  config: PickleConfig,
+  patch: NonNullable<StudioConfigPatch['executionTargetProfiles']>,
+): Record<string, ProjectExecutionTargetProfile> {
+  const existing = config.executionTargetProfiles ?? {}
+  return Object.fromEntries(
+    Object.entries(patch).map(([id, profile]) => [
+      id,
+      patchedExecutionTargetProfile(profile, existing[id]),
+    ]),
+  )
 }
 
 export async function loadStudioProject(
@@ -281,28 +356,10 @@ export async function patchStudioConfig(
   if (patch.links) next.links = patch.links
   if (patch.secrets) next.secrets = patch.secrets
   if (patch.executionTargetProfiles) {
-    const existing = config.executionTargetProfiles ?? {}
-    const profiles: Record<string, ProjectExecutionTargetProfile> = {}
-    for (const [id, profile] of Object.entries(patch.executionTargetProfiles)) {
-      profiles[id] = {
-        adapter: profile.adapter,
-        ...(profile.capabilities
-          ? { capabilities: [...profile.capabilities] }
-          : {}),
-        ...(existing[id]?.web ? { web: existing[id].web } : {}),
-        ...(profile.mobile
-          ? {
-              mobile: {
-                ...profile.mobile,
-                application: { ...profile.mobile.application },
-              },
-            }
-          : profile.adapter === 'mobile' && existing[id]?.mobile
-            ? { mobile: existing[id].mobile }
-            : {}),
-      }
-    }
-    next.executionTargetProfiles = profiles
+    next.executionTargetProfiles = patchExecutionTargetProfiles(
+      config,
+      patch.executionTargetProfiles,
+    )
     next.executionTargetProfile = undefined
   }
   await saveConfig(next, context.configPath, context.root)

--- a/packages/cli/src/studio/studio.test.ts
+++ b/packages/cli/src/studio/studio.test.ts
@@ -1658,11 +1658,7 @@ Feature: Reloaded
       )
       await page.getByRole('button', { name: 'Edit Specification' }).click()
       await page.locator('.monaco-editor').waitFor()
-      const reloadedDeadline = Date.now() + 10_000
-      while (Date.now() < reloadedDeadline) {
-        if ((await gherkinValue(page)).includes('Feature: Reloaded')) break
-        await Bun.sleep(50)
-      }
+      await waitForGherkinValue(page, 'Feature: Reloaded')
       expect(await gherkinValue(page)).toContain('Feature: Reloaded')
       await setGherkinValue(
         page,
@@ -1691,11 +1687,7 @@ Feature: Disk edit
       await page
         .getByRole('dialog', { name: 'Specification changed on disk' })
         .waitFor({ state: 'hidden' })
-      const deadline = Date.now() + 10_000
-      while (Date.now() < deadline) {
-        if ((await gherkinValue(page)).includes('Feature: Disk edit')) break
-        await Bun.sleep(50)
-      }
+      await waitForGherkinValue(page, 'Feature: Disk edit')
       expect(await gherkinValue(page)).toContain('Feature: Disk edit')
     } finally {
       await page.close()
@@ -2006,13 +1998,7 @@ Feature: Checkout
       ],
       cwd: project,
     })
-    const branch =
-      Bun.spawnSync({
-        cmd: ['git', 'branch', '--show-current'],
-        cwd: project,
-      })
-        .stdout.toString()
-        .trim() || 'main'
+    const branch = currentGitBranch(project)
     await Bun.spawnSync({
       cmd: ['git', 'update-ref', `refs/remotes/github/${branch}`, 'HEAD'],
       cwd: project,
@@ -2079,32 +2065,14 @@ exit 0
         .getByRole('dialog', { name: 'Commit selected changes?' })
         .waitFor()
       await page.getByRole('button', { name: 'Confirm commit' }).click()
-      const deadline = Date.now() + 10_000
-      let log = ''
-      while (Date.now() < deadline) {
-        const result = Bun.spawnSync({
-          cmd: ['git', 'log', '-1', '--pretty=%s'],
-          cwd: project,
-        })
-        log = result.stdout.toString().trim()
-        if (log === 'Update Checkout') break
-        await Bun.sleep(50)
-      }
+      const log = await waitForCommitMessage(project, 'Update Checkout')
       expect(log).toBe('Update Checkout')
       const remoteHeads = Bun.spawnSync({
         cmd: ['git', 'ls-remote', remote, 'HEAD'],
       })
       expect(remoteHeads.stdout.toString().trim()).toBe('')
       await page.getByRole('button', { name: 'Create pull request' }).click()
-      const ghDeadline = Date.now() + 10_000
-      let ghInvoked = ''
-      while (Date.now() < ghDeadline) {
-        if (await Bun.file(ghLog).exists()) {
-          ghInvoked = await Bun.file(ghLog).text()
-          if (ghInvoked.includes('pr create --web')) break
-        }
-        await Bun.sleep(50)
-      }
+      const ghInvoked = await waitForFileContent(ghLog, 'pr create --web')
       expect(ghInvoked).toContain('pr create --web')
       expect(ghInvoked).not.toContain('push')
     } finally {
@@ -2122,6 +2090,61 @@ async function gherkinValue(page: Page): Promise<string> {
     ).monaco?.editor.getEditors()[0]
     return editor?.getValue() ?? ''
   })
+}
+
+async function waitForGherkinValue(
+  page: Page,
+  expected: string,
+): Promise<void> {
+  const deadline = Date.now() + 10_000
+  while (Date.now() < deadline) {
+    if ((await gherkinValue(page)).includes(expected)) return
+    await Bun.sleep(50)
+  }
+}
+
+function currentGitBranch(project: string): string {
+  return (
+    Bun.spawnSync({
+      cmd: ['git', 'branch', '--show-current'],
+      cwd: project,
+    })
+      .stdout.toString()
+      .trim() || 'main'
+  )
+}
+
+async function waitForCommitMessage(
+  project: string,
+  expected: string,
+): Promise<string> {
+  const deadline = Date.now() + 10_000
+  let message = ''
+  while (Date.now() < deadline) {
+    message = Bun.spawnSync({
+      cmd: ['git', 'log', '-1', '--pretty=%s'],
+      cwd: project,
+    })
+      .stdout.toString()
+      .trim()
+    if (message === expected) return message
+    await Bun.sleep(50)
+  }
+  return message
+}
+
+async function waitForFileContent(
+  path: string,
+  expected: string,
+): Promise<string> {
+  const deadline = Date.now() + 10_000
+  let content = ''
+  while (Date.now() < deadline) {
+    if (await Bun.file(path).exists()) content = await Bun.file(path).text()
+    if (content.includes(expected)) return content
+    await Bun.sleep(50)
+  }
+  return content
 }
 
 async function setGherkinValue(page: Page, source: string) {

--- a/packages/cli/src/studio/studio.test.ts
+++ b/packages/cli/src/studio/studio.test.ts
@@ -1172,7 +1172,7 @@ Feature: Search
       expect(timelineText).toContain('Run event')
       expect(timelineText).toContain('Diagnostic entry')
       expect(timelineText).toContain('Test artifact')
-      expect(timelineText).toContain('Causal point')
+      expect(timelineText).toContain('Failure context')
       await page.getByRole('tab', { name: 'Artifacts' }).click()
       expect(
         await page

--- a/packages/cli/src/terminal/terminal-surface.ts
+++ b/packages/cli/src/terminal/terminal-surface.ts
@@ -62,29 +62,36 @@ export function createInteractiveTerminalSurface(
     return renderedTerminalRows(lines, options.columns())
   }
 
+  function hiddenLine(hiddenCount: number): string {
+    const label = ` … +${hiddenCount}`
+    const columns = options.columns()
+    return columns && Bun.stringWidth(label) > columns ? '…' : label
+  }
+
+  function visibleTail(
+    lines: readonly string[],
+    maxRows: number,
+  ): readonly string[] {
+    const tail: string[] = []
+    let usedRows = renderedRows([lines[0]!, '…'])
+    for (let index = lines.length - 1; index > 0; index--) {
+      const line = lines[index]!
+      const lineRows = renderedRows([line])
+      if (usedRows + lineRows > maxRows) break
+      tail.unshift(line)
+      usedRows += lineRows
+    }
+    return tail
+  }
+
   function visibleDynamicLines(lines: readonly string[]): readonly string[] {
     const maxRows = availableTerminalRows(options.rows?.())
     if (renderedRows(lines) <= maxRows) return lines
     if (maxRows === 1) return ['…']
     const firstLine = lines[0]!
-    const visibleTail: string[] = []
-    let usedRows = renderedRows([firstLine, '…'])
-    for (let index = lines.length - 1; index > 0; index--) {
-      const line = lines[index]!
-      const lineRows = renderedRows([line])
-      if (usedRows + lineRows > maxRows) break
-      visibleTail.unshift(line)
-      usedRows += lineRows
-    }
-    const hiddenCount = lines.length - visibleTail.length - 1
-    const hiddenLabel = ` … +${hiddenCount}`
-    const columns = options.columns()
-    const hiddenLine = columns
-      ? Bun.stringWidth(hiddenLabel) <= columns
-        ? hiddenLabel
-        : '…'
-      : hiddenLabel
-    return [firstLine, hiddenLine, ...visibleTail]
+    const tail = visibleTail(lines, maxRows)
+    const hiddenCount = lines.length - tail.length - 1
+    return [firstLine, hiddenLine(hiddenCount), ...tail]
   }
 
   function clearDynamicRegion(): void {

--- a/packages/mobile/src/agent-device/agent-device-evidence.ts
+++ b/packages/mobile/src/agent-device/agent-device-evidence.ts
@@ -34,6 +34,11 @@ export interface FinishedScenarioEvidence {
   availability: MobileEvidenceAvailability[]
 }
 
+interface CapturedEvidence {
+  artifact?: MobileArtifact
+  availability: MobileEvidenceAvailability
+}
+
 const screenshotResultSchema = z.object({ path: z.string().min(1) })
 
 function errorMessage(error: unknown): string {
@@ -80,6 +85,74 @@ async function capturedArtifact(
     capturedAt,
     sizeBytes,
   }
+}
+
+async function captureEvidence(
+  kind: MobileArtifactKind,
+  capture: () => Promise<MobileArtifact>,
+): Promise<CapturedEvidence> {
+  try {
+    return {
+      artifact: await capture(),
+      availability: { kind, state: 'available' },
+    }
+  } catch (error) {
+    return { availability: unavailableEvidence(kind, error) }
+  }
+}
+
+function appendCapturedEvidence(
+  result: CapturedEvidence,
+  artifacts: MobileArtifact[],
+  availability: MobileEvidenceAvailability[],
+): void {
+  if (result.artifact) artifacts.push(result.artifact)
+  availability.push(result.availability)
+}
+
+async function stopRecording(
+  session: AgentDeviceEvidenceSession,
+  path: string,
+): Promise<MobileArtifact> {
+  await session.client.recording.record({ action: 'stop', path })
+  return capturedArtifact('recording', path, 'video/mp4')
+}
+
+async function stopTrace(
+  session: AgentDeviceEvidenceSession,
+  path: string,
+): Promise<MobileArtifact> {
+  await session.client.recording.trace({ action: 'stop', path })
+  return capturedArtifact('trace', path)
+}
+
+async function captureDeviceLog(
+  session: AgentDeviceEvidenceSession,
+  directory: string,
+): Promise<MobileArtifact> {
+  if (!session.deviceLogPath) {
+    throw new Error('Agent Device did not provide an app log path')
+  }
+  const path = join(directory, 'scenario.log')
+  const log = await readFile(session.deviceLogPath, 'utf8')
+  await writeFile(path, redactText(log, session.redactions), 'utf8')
+  return capturedArtifact('device-log', path, 'text/plain')
+}
+
+async function captureScreenshot(
+  session: AgentDeviceEvidenceSession,
+  directory: string,
+): Promise<MobileArtifact> {
+  const requestedPath = join(directory, 'scenario.png')
+  const screenshot = screenshotResultSchema.parse(
+    await session.client.capture.screenshot({ path: requestedPath }),
+  )
+  if (resolve(screenshot.path) !== resolve(requestedPath)) {
+    throw new Error(
+      'Agent Device returned a screenshot path outside the requested evidence location',
+    )
+  }
+  return capturedArtifact('screenshot', screenshot.path, 'image/png')
 }
 
 export async function startScenarioEvidence(
@@ -141,63 +214,40 @@ export async function finishScenarioEvidence(
   if (!active.directory) return { artifacts, availability }
 
   if (active.recordingPath) {
-    try {
-      await session.client.recording.record({
-        action: 'stop',
-        path: active.recordingPath,
-      })
-      artifacts.push(
-        await capturedArtifact('recording', active.recordingPath, 'video/mp4'),
-      )
-      availability.push({ kind: 'recording', state: 'available' })
-    } catch (error) {
-      availability.push(unavailableEvidence('recording', error))
-    }
+    appendCapturedEvidence(
+      await captureEvidence('recording', () =>
+        stopRecording(session, active.recordingPath!),
+      ),
+      artifacts,
+      availability,
+    )
   }
   if (active.tracePath) {
-    try {
-      await session.client.recording.trace({
-        action: 'stop',
-        path: active.tracePath,
-      })
-      artifacts.push(await capturedArtifact('trace', active.tracePath))
-      availability.push({ kind: 'trace', state: 'available' })
-    } catch (error) {
-      availability.push(unavailableEvidence('trace', error))
-    }
+    appendCapturedEvidence(
+      await captureEvidence('trace', () =>
+        stopTrace(session, active.tracePath!),
+      ),
+      artifacts,
+      availability,
+    )
   }
   if (session.artifacts.has('device-log')) {
-    try {
-      if (!session.deviceLogPath) {
-        throw new Error('Agent Device did not provide an app log path')
-      }
-      const path = join(active.directory, 'scenario.log')
-      const log = await readFile(session.deviceLogPath, 'utf8')
-      await writeFile(path, redactText(log, session.redactions), 'utf8')
-      artifacts.push(await capturedArtifact('device-log', path, 'text/plain'))
-      availability.push({ kind: 'device-log', state: 'available' })
-    } catch (error) {
-      availability.push(unavailableEvidence('device-log', error))
-    }
+    appendCapturedEvidence(
+      await captureEvidence('device-log', () =>
+        captureDeviceLog(session, active.directory!),
+      ),
+      artifacts,
+      availability,
+    )
   }
   if (session.artifacts.has('screenshot')) {
-    try {
-      const requestedPath = join(active.directory, 'scenario.png')
-      const screenshot = screenshotResultSchema.parse(
-        await session.client.capture.screenshot({ path: requestedPath }),
-      )
-      if (resolve(screenshot.path) !== resolve(requestedPath)) {
-        throw new Error(
-          'Agent Device returned a screenshot path outside the requested evidence location',
-        )
-      }
-      artifacts.push(
-        await capturedArtifact('screenshot', screenshot.path, 'image/png'),
-      )
-      availability.push({ kind: 'screenshot', state: 'available' })
-    } catch (error) {
-      availability.push(unavailableEvidence('screenshot', error))
-    }
+    appendCapturedEvidence(
+      await captureEvidence('screenshot', () =>
+        captureScreenshot(session, active.directory!),
+      ),
+      artifacts,
+      availability,
+    )
   }
   return { artifacts, availability }
 }

--- a/packages/mobile/src/agent-device/agent-device-gateway.ts
+++ b/packages/mobile/src/agent-device/agent-device-gateway.ts
@@ -50,6 +50,63 @@ function replayScenarioStepIndex(
   return Math.max(0, payload.stepRanges.length - 1)
 }
 
+function passedScenarioExecution(
+  session: GatewaySession,
+): WorkerScenarioExecution {
+  return {
+    stepExecutions: session.compiled.descriptions.map((description) => ({
+      state: 'passed',
+      resolvedActions: [{ description }],
+    })),
+  }
+}
+
+function divergentScenarioExecution(
+  session: GatewaySession,
+  error: unknown,
+): WorkerScenarioExecution {
+  const failedStep = replayScenarioStepIndex(error, session.compiled.payload)
+  return {
+    stepExecutions: session.compiled.descriptions
+      .slice(0, failedStep + 1)
+      .map((description, index) =>
+        index === failedStep
+          ? {
+              state: 'failed' as const,
+              resolvedActions: [{ description }],
+              replayDiverged: true,
+              message: `Agent Device Replay diverged at Scenario step ${failedStep + 1}`,
+            }
+          : {
+              state: 'passed' as const,
+              resolvedActions: [{ description }],
+            },
+      ),
+    replayDiverged: true,
+  }
+}
+
+function attachFinishedEvidence(
+  session: GatewaySession,
+  finished: Awaited<ReturnType<typeof finishScenarioEvidence>>,
+): void {
+  const finalStep = session.execution?.stepExecutions.at(-1)
+  if (!finalStep) return
+  if (finished.artifacts.length > 0) finalStep.artifacts = finished.artifacts
+  const availability = [
+    ...session.evidenceAvailability,
+    ...finished.availability,
+  ]
+  if (availability.length === 0) return
+  const byKind = new Map(availability.map((item) => [item.kind, item]))
+  finalStep.evidenceAvailability = session.requestedArtifacts.flatMap(
+    (kind) => {
+      const item = byKind.get(kind)
+      return item ? [item] : []
+    },
+  )
+}
+
 export class AgentDeviceGateway {
   private readonly createClient: AgentDeviceClientFactory
   private readonly sessions = new Map<string, GatewaySession>()
@@ -144,60 +201,16 @@ export class AgentDeviceGateway {
         script: session.compiled.payload.script,
         runtimeEnv: session.compiled.runtimeEnv,
       })
-      session.execution = {
-        stepExecutions: session.compiled.descriptions.map((description) => ({
-          state: 'passed',
-          resolvedActions: [{ description }],
-        })),
-      }
+      session.execution = passedScenarioExecution(session)
     } catch (error) {
       if (!isAgentDeviceReplayDivergence(error)) throw error
-      const failedStep = replayScenarioStepIndex(
-        error,
-        session.compiled.payload,
-      )
-      session.execution = {
-        stepExecutions: session.compiled.descriptions
-          .slice(0, failedStep + 1)
-          .map((description, index) =>
-            index === failedStep
-              ? {
-                  state: 'failed' as const,
-                  resolvedActions: [{ description }],
-                  replayDiverged: true,
-                  message: `Agent Device Replay diverged at Scenario step ${failedStep + 1}`,
-                }
-              : {
-                  state: 'passed' as const,
-                  resolvedActions: [{ description }],
-                },
-          ),
-        replayDiverged: true,
-      }
+      session.execution = divergentScenarioExecution(session, error)
     } finally {
       const finishedEvidence = await finishScenarioEvidence(
         session,
         activeEvidence,
       )
-      const finalStep = session.execution?.stepExecutions.at(-1)
-      if (finalStep) {
-        if (finishedEvidence.artifacts.length > 0) {
-          finalStep.artifacts = finishedEvidence.artifacts
-        }
-        const availability = [
-          ...session.evidenceAvailability,
-          ...finishedEvidence.availability,
-        ]
-        if (availability.length > 0) {
-          const byKind = new Map(availability.map((item) => [item.kind, item]))
-          finalStep.evidenceAvailability = session.requestedArtifacts.flatMap(
-            (kind) => {
-              const item = byKind.get(kind)
-              return item ? [item] : []
-            },
-          )
-        }
-      }
+      attachFinishedEvidence(session, finishedEvidence)
     }
     return session.execution
   }

--- a/packages/mobile/src/benchmarking/mobile-benchmark-controlled-driver.ts
+++ b/packages/mobile/src/benchmarking/mobile-benchmark-controlled-driver.ts
@@ -6,6 +6,7 @@ import {
   finalScenarioAttempt,
   openLocalExecutionCache,
   runScenario,
+  type TestResult,
 } from '@pickle-spec/runner'
 import {
   assertNoProviderCredentials,
@@ -69,6 +70,177 @@ const scenario = {
   runtimeBindings,
 }
 
+type OpenSessionRequest = Extract<MobileWorkerRequest, { type: 'open-session' }>
+type ExecuteScenarioRequest = Extract<
+  MobileWorkerRequest,
+  { type: 'execute-scenario' }
+>
+type CompleteSessionRequest = Extract<
+  MobileWorkerRequest,
+  { type: 'complete-session' }
+>
+
+interface ControlledWorkerState {
+  opened: Map<string, OpenSessionRequest>
+  executedAdaptive: Map<string, ReturnType<typeof compileMobileScenario>>
+  modes: Array<'adaptive' | 'replay'>
+  scriptsMatched: boolean
+  adaptiveScriptDigest?: string
+}
+
+function requireControlledSession(
+  state: ControlledWorkerState,
+  sessionId: string,
+): OpenSessionRequest {
+  const session = state.opened.get(sessionId)
+  if (!session) throw new Error('Controlled mobile session is absent')
+  return session
+}
+
+function digestScript(script: unknown): string | undefined {
+  return typeof script === 'string'
+    ? createHash('sha256').update(script).digest('hex')
+    : undefined
+}
+
+function controlledScenarioExecution(
+  state: ControlledWorkerState,
+  request: ExecuteScenarioRequest,
+) {
+  const session = requireControlledSession(state, request.sessionId)
+  const adaptive =
+    session.mode === 'adaptive'
+      ? compileMobileScenario({
+          platform: 'android',
+          applicationId,
+          scenario: session.scenario,
+        })
+      : undefined
+  if (adaptive) state.executedAdaptive.set(request.sessionId, adaptive)
+  const script =
+    adaptive?.payload.script ?? session.executionCache?.adapterPayload.script
+  const digest = digestScript(script)
+  if (session.mode === 'adaptive') state.adaptiveScriptDigest = digest
+  else state.scriptsMatched &&= digest === state.adaptiveScriptDigest
+  if (!state.scriptsMatched) {
+    throw new Error('Controlled modes did not execute the same .ad')
+  }
+  return {
+    version: 3 as const,
+    type: 'scenario-executed' as const,
+    sessionId: request.sessionId,
+    execution: {
+      stepExecutions: templateSteps.map((step) => ({
+        state: 'passed' as const,
+        resolvedActions: [{ description: step.text }],
+      })),
+    },
+  }
+}
+
+function controlledSessionCompletion(
+  state: ControlledWorkerState,
+  request: CompleteSessionRequest,
+) {
+  const session = requireControlledSession(state, request.sessionId)
+  const adaptive = state.executedAdaptive.get(request.sessionId)
+  if (session.mode === 'adaptive' && !adaptive) {
+    throw new Error('Controlled Adaptive representation is absent')
+  }
+  return {
+    version: 3 as const,
+    type: 'session-completed' as const,
+    sessionId: request.sessionId,
+    completion:
+      session.mode === 'adaptive'
+        ? {
+            inferenceCount: 0,
+            replayRepresentation: {
+              cacheable: true as const,
+              adapterPayload: adaptive!.payload,
+              requiredVariables: adaptive!.requiredVariables,
+            },
+          }
+        : { inferenceCount: 0 },
+  }
+}
+
+function closeControlledSession(
+  state: ControlledWorkerState,
+  sessionId: string,
+  type: 'session-closed' | 'session-cancelled',
+) {
+  state.opened.delete(sessionId)
+  state.executedAdaptive.delete(sessionId)
+  return { version: 3 as const, type, sessionId }
+}
+
+function createControlledWorker(
+  state: ControlledWorkerState,
+): MobileWorkerClient {
+  return {
+    async request(request) {
+      switch (request.type) {
+        case 'discover-targets':
+          return { version: 3, type: 'targets-discovered', targets: [] }
+        case 'open-session':
+          state.opened.set(request.sessionId, request)
+          state.modes.push(request.mode)
+          return {
+            version: 3,
+            type: 'session-opened',
+            sessionId: request.sessionId,
+            targetId: 'controlled-emulator',
+          }
+        case 'execute-scenario':
+          return controlledScenarioExecution(state, request)
+        case 'complete-session':
+          return controlledSessionCompletion(state, request)
+        case 'close-session':
+          return closeControlledSession(
+            state,
+            request.sessionId,
+            'session-closed',
+          )
+        case 'cancel-session':
+          return closeControlledSession(
+            state,
+            request.sessionId,
+            'session-cancelled',
+          )
+      }
+    },
+    async dispose() {},
+  }
+}
+
+function expectedAttemptFields(mode: MobileBenchmarkMode) {
+  return mode === 'adaptive'
+    ? { executionMode: 'adaptive', cacheOutcome: 'refresh' }
+    : {
+        executionMode: 'replay',
+        cacheOutcome: 'hit',
+        inferenceCount: 0,
+      }
+}
+
+function assertControlledRun(
+  mode: MobileBenchmarkMode,
+  result: TestResult,
+): void {
+  const attempt = finalScenarioAttempt(result)
+  if (result.state !== 'passed') {
+    throw new Error(
+      `Controlled ${mode} run failed: ${attempt.message ?? result.state}`,
+    )
+  }
+  for (const [field, value] of Object.entries(expectedAttemptFields(mode))) {
+    if (attempt[field as keyof typeof attempt] !== value) {
+      throw new Error(`Controlled ${mode} run reported invalid ${field}`)
+    }
+  }
+}
+
 export async function createControlledMobileBenchmarkDriver(
   environment: ProviderCredentialEnvironment = process.env,
 ): Promise<ControlledMobileBenchmarkDriver> {
@@ -77,112 +249,14 @@ export async function createControlledMobileBenchmarkDriver(
   const cacheRoot = await mkdtemp(
     join(tmpdir(), 'pickle-mobile-benchmark-cache-'),
   )
-  const opened = new Map<
-    string,
-    Extract<MobileWorkerRequest, { type: 'open-session' }>
-  >()
-  const executedAdaptive = new Map<
-    string,
-    ReturnType<typeof compileMobileScenario>
-  >()
-  const modes: Array<'adaptive' | 'replay'> = []
-  let scriptsMatched = true
-  let adaptiveScriptDigest: string | undefined
-  let sourceRun = 0
-  const worker: MobileWorkerClient = {
-    async request(request) {
-      switch (request.type) {
-        case 'discover-targets':
-          return { version: 3, type: 'targets-discovered', targets: [] }
-        case 'open-session':
-          opened.set(request.sessionId, request)
-          modes.push(request.mode)
-          return {
-            version: 3,
-            type: 'session-opened',
-            sessionId: request.sessionId,
-            targetId: 'controlled-emulator',
-          }
-        case 'execute-scenario': {
-          const session = opened.get(request.sessionId)
-          if (!session) throw new Error('Controlled mobile session is absent')
-          const adaptive =
-            session.mode === 'adaptive'
-              ? compileMobileScenario({
-                  platform: 'android',
-                  applicationId,
-                  scenario: session.scenario,
-                })
-              : undefined
-          if (adaptive) executedAdaptive.set(request.sessionId, adaptive)
-          const script =
-            adaptive?.payload.script ??
-            session.executionCache?.adapterPayload.script
-          const digest =
-            typeof script === 'string'
-              ? createHash('sha256').update(script).digest('hex')
-              : undefined
-          if (session.mode === 'adaptive') adaptiveScriptDigest = digest
-          else scriptsMatched &&= digest === adaptiveScriptDigest
-          if (!scriptsMatched) {
-            throw new Error('Controlled modes did not execute the same .ad')
-          }
-          return {
-            version: 3,
-            type: 'scenario-executed',
-            sessionId: request.sessionId,
-            execution: {
-              stepExecutions: templateSteps.map((step) => ({
-                state: 'passed' as const,
-                resolvedActions: [{ description: step.text }],
-              })),
-            },
-          }
-        }
-        case 'complete-session': {
-          const session = opened.get(request.sessionId)
-          if (!session) throw new Error('Controlled mobile session is absent')
-          const adaptive = executedAdaptive.get(request.sessionId)
-          if (session.mode === 'adaptive' && !adaptive) {
-            throw new Error('Controlled Adaptive representation is absent')
-          }
-          return {
-            version: 3,
-            type: 'session-completed',
-            sessionId: request.sessionId,
-            completion:
-              session.mode === 'adaptive'
-                ? {
-                    inferenceCount: 0,
-                    replayRepresentation: {
-                      cacheable: true as const,
-                      adapterPayload: adaptive!.payload,
-                      requiredVariables: adaptive!.requiredVariables,
-                    },
-                  }
-                : { inferenceCount: 0 },
-          }
-        }
-        case 'close-session':
-          opened.delete(request.sessionId)
-          executedAdaptive.delete(request.sessionId)
-          return {
-            version: 3,
-            type: 'session-closed',
-            sessionId: request.sessionId,
-          }
-        case 'cancel-session':
-          opened.delete(request.sessionId)
-          executedAdaptive.delete(request.sessionId)
-          return {
-            version: 3,
-            type: 'session-cancelled',
-            sessionId: request.sessionId,
-          }
-      }
-    },
-    async dispose() {},
+  const state: ControlledWorkerState = {
+    opened: new Map(),
+    executedAdaptive: new Map(),
+    modes: [],
+    scriptsMatched: true,
   }
+  let sourceRun = 0
+  const worker = createControlledWorker(state)
   const adapter = createMobileAdapter(
     {
       application: {
@@ -211,32 +285,14 @@ export async function createControlledMobileBenchmarkDriver(
           sourceRunId: `mobile-benchmark-${++sourceRun}`,
         },
       })
-      const expected =
-        mode === 'adaptive'
-          ? { executionMode: 'adaptive', cacheOutcome: 'refresh' }
-          : {
-              executionMode: 'replay',
-              cacheOutcome: 'hit',
-              inferenceCount: 0,
-            }
-      const attempt = finalScenarioAttempt(run.result)
-      if (run.result.state !== 'passed') {
-        throw new Error(
-          `Controlled ${mode} run failed: ${attempt.message ?? run.result.state}`,
-        )
-      }
-      for (const [field, value] of Object.entries(expected)) {
-        if (attempt[field as keyof typeof attempt] !== value) {
-          throw new Error(`Controlled ${mode} run reported invalid ${field}`)
-        }
-      }
+      assertControlledRun(mode, run.result)
       return performance.now() - startedAt
     },
     async evidence() {
       return {
         cacheEntries: (await cache.inspect()).length,
-        modes: [...modes],
-        scriptsMatched,
+        modes: [...state.modes],
+        scriptsMatched: state.scriptsMatched,
       }
     },
     async dispose() {

--- a/packages/mobile/src/worker/worker-client.ts
+++ b/packages/mobile/src/worker/worker-client.ts
@@ -202,25 +202,25 @@ class NodeWorkerClient implements MobileWorkerClient {
       const { done, value } = await reader.read()
       if (done) return
       buffer += decoder.decode(value, { stream: true })
-      let newline = buffer.indexOf('\n')
-      while (newline !== -1) {
-        const line = buffer.slice(0, newline)
-        buffer = buffer.slice(newline + 1)
-        try {
-          if (!this.ready) {
-            const message = workerReadyMessageSchema.parse(JSON.parse(line))
-            assertSupportedNodeVersion(message.nodeVersion)
-            onReady()
-          } else {
-            this.handleResponse(line)
-          }
-        } catch (error) {
-          throw new Error(
-            `Invalid mobile worker message: ${errorMessage(error)}`,
-          )
-        }
-        newline = buffer.indexOf('\n')
+      const lines = buffer.split('\n')
+      buffer = lines.pop() ?? ''
+      for (const line of lines) {
+        this.handleMessage(line, onReady)
       }
+    }
+  }
+
+  private handleMessage(line: string, onReady: () => void): void {
+    try {
+      if (this.ready) {
+        this.handleResponse(line)
+        return
+      }
+      const message = workerReadyMessageSchema.parse(JSON.parse(line))
+      assertSupportedNodeVersion(message.nodeVersion)
+      onReady()
+    } catch (error) {
+      throw new Error(`Invalid mobile worker message: ${errorMessage(error)}`)
     }
   }
 

--- a/packages/mobile/src/worker/worker-runtime.ts
+++ b/packages/mobile/src/worker/worker-runtime.ts
@@ -54,102 +54,128 @@ export class MobileWorkerRuntime {
   async handle(request: MobileWorkerRequest): Promise<MobileWorkerResponse> {
     switch (request.type) {
       case 'discover-targets':
-        return {
-          version: mobileWorkerProtocolVersion,
-          type: 'targets-discovered',
-          targets: await this.gateway.discoverTargets(
-            request.platform ?? 'android',
-          ),
-        }
-      case 'open-session': {
-        if (
-          this.sessions.has(request.sessionId) ||
-          this.cancelling.has(request.sessionId)
-        ) {
-          throw new Error(
-            `Mobile logical session "${request.sessionId}" is already active`,
-          )
-        }
-        const opened = await this.gateway.openSession({
-          sessionId: request.sessionId,
-          platform: request.platform ?? 'android',
-          targetId: request.targetId,
-          application: request.application,
-          artifactDirectory: request.artifactDirectory,
-          artifacts: request.artifacts,
-          redactions: request.redactions,
-          requiredCapabilities: request.requiredCapabilities,
-          mode: request.mode,
-          scenario: request.scenario,
-          executionCache: request.executionCache,
-        })
-        this.sessions.add(request.sessionId)
-        return {
-          version: mobileWorkerProtocolVersion,
-          type: 'session-opened',
-          sessionId: request.sessionId,
-          targetId: opened.targetId,
-        }
-      }
-      case 'execute-scenario': {
-        if (!this.sessions.has(request.sessionId)) {
-          throw new Error(
-            `Mobile logical session "${request.sessionId}" is not open`,
-          )
-        }
-        const execution = await this.serialize(request.sessionId, () =>
-          this.gateway.executeScenario(request.sessionId),
-        )
-        return {
-          version: mobileWorkerProtocolVersion,
-          type: 'scenario-executed',
-          sessionId: request.sessionId,
-          execution,
-        }
-      }
-      case 'complete-session': {
-        if (!this.sessions.has(request.sessionId)) {
-          throw new Error(
-            `Mobile logical session "${request.sessionId}" is not open`,
-          )
-        }
-        const completion = await this.serialize(request.sessionId, () =>
-          this.gateway.completeSession(request.sessionId),
-        )
-        return {
-          version: mobileWorkerProtocolVersion,
-          type: 'session-completed',
-          sessionId: request.sessionId,
-          completion,
-        }
-      }
+        return this.discoverTargets(request)
+      case 'open-session':
+        return this.openSession(request)
+      case 'execute-scenario':
+        return this.executeScenario(request)
+      case 'complete-session':
+        return this.completeSession(request)
       case 'close-session':
-        await this.serialize(request.sessionId, () =>
-          this.gateway.closeSession(request.sessionId),
-        )
-        this.sessions.delete(request.sessionId)
-        return {
-          version: mobileWorkerProtocolVersion,
-          type: 'session-closed',
-          sessionId: request.sessionId,
-        }
-      case 'cancel-session': {
-        this.cancelling.add(request.sessionId)
-        this.sessions.delete(request.sessionId)
-        try {
-          await (this.gateway.cancelSession?.(request.sessionId) ??
-            this.gateway.closeSession(request.sessionId))
-          await this.queues.get(request.sessionId)?.catch(() => {})
-        } finally {
-          this.queues.delete(request.sessionId)
-          this.cancelling.delete(request.sessionId)
-        }
-        return {
-          version: mobileWorkerProtocolVersion,
-          type: 'session-cancelled',
-          sessionId: request.sessionId,
-        }
-      }
+        return this.closeSession(request.sessionId)
+      case 'cancel-session':
+        return this.cancelSession(request.sessionId)
+    }
+  }
+
+  private async discoverTargets(
+    request: Extract<MobileWorkerRequest, { type: 'discover-targets' }>,
+  ): Promise<MobileWorkerResponse> {
+    return {
+      version: mobileWorkerProtocolVersion,
+      type: 'targets-discovered',
+      targets: await this.gateway.discoverTargets(
+        request.platform ?? 'android',
+      ),
+    }
+  }
+
+  private async openSession(
+    request: Extract<MobileWorkerRequest, { type: 'open-session' }>,
+  ): Promise<MobileWorkerResponse> {
+    if (
+      this.sessions.has(request.sessionId) ||
+      this.cancelling.has(request.sessionId)
+    ) {
+      throw new Error(
+        `Mobile logical session "${request.sessionId}" is already active`,
+      )
+    }
+    const opened = await this.gateway.openSession({
+      sessionId: request.sessionId,
+      platform: request.platform ?? 'android',
+      targetId: request.targetId,
+      application: request.application,
+      artifactDirectory: request.artifactDirectory,
+      artifacts: request.artifacts,
+      redactions: request.redactions,
+      requiredCapabilities: request.requiredCapabilities,
+      mode: request.mode,
+      scenario: request.scenario,
+      executionCache: request.executionCache,
+    })
+    this.sessions.add(request.sessionId)
+    return {
+      version: mobileWorkerProtocolVersion,
+      type: 'session-opened',
+      sessionId: request.sessionId,
+      targetId: opened.targetId,
+    }
+  }
+
+  private requireSession(sessionId: string): void {
+    if (!this.sessions.has(sessionId)) {
+      throw new Error(`Mobile logical session "${sessionId}" is not open`)
+    }
+  }
+
+  private async executeScenario(
+    request: Extract<MobileWorkerRequest, { type: 'execute-scenario' }>,
+  ): Promise<MobileWorkerResponse> {
+    this.requireSession(request.sessionId)
+    const execution = await this.serialize(request.sessionId, () =>
+      this.gateway.executeScenario(request.sessionId),
+    )
+    return {
+      version: mobileWorkerProtocolVersion,
+      type: 'scenario-executed',
+      sessionId: request.sessionId,
+      execution,
+    }
+  }
+
+  private async completeSession(
+    request: Extract<MobileWorkerRequest, { type: 'complete-session' }>,
+  ): Promise<MobileWorkerResponse> {
+    this.requireSession(request.sessionId)
+    const completion = await this.serialize(request.sessionId, () =>
+      this.gateway.completeSession(request.sessionId),
+    )
+    return {
+      version: mobileWorkerProtocolVersion,
+      type: 'session-completed',
+      sessionId: request.sessionId,
+      completion,
+    }
+  }
+
+  private async closeSession(sessionId: string): Promise<MobileWorkerResponse> {
+    await this.serialize(sessionId, () => this.gateway.closeSession(sessionId))
+    this.sessions.delete(sessionId)
+    return {
+      version: mobileWorkerProtocolVersion,
+      type: 'session-closed',
+      sessionId,
+    }
+  }
+
+  private async cancelSession(
+    sessionId: string,
+  ): Promise<MobileWorkerResponse> {
+    this.cancelling.add(sessionId)
+    this.sessions.delete(sessionId)
+    try {
+      await (this.gateway.cancelSession?.(sessionId) ??
+        this.gateway.closeSession(sessionId))
+      await this.queues.get(sessionId)?.catch(() => {})
+    } finally {
+      this.queues.delete(sessionId)
+      this.cancelling.delete(sessionId)
+    }
+    return {
+      version: mobileWorkerProtocolVersion,
+      type: 'session-cancelled',
+      sessionId,
     }
   }
 

--- a/packages/runner/src/execution-cache/local-execution-cache-coordination.ts
+++ b/packages/runner/src/execution-cache/local-execution-cache-coordination.ts
@@ -4,6 +4,7 @@ import type {
   ExecutionCacheCoordination,
   ExecutionCacheKey,
   ExecutionCacheLease,
+  ExecutionCacheLeaseAcquisition,
   ExecutionCacheLeasePublicationResult,
   ExecutionCacheLeaseWaitResult,
   ExecutionCacheWriteMetadata,
@@ -258,6 +259,77 @@ function publishLeaseEntry(
   return { published: true, stored, evictedEntries }
 }
 
+function acquireLease(
+  db: Database,
+  key: ExecutionCacheKey,
+  projectKey: string,
+  timing: ExecutionCacheLeaseTiming,
+  now: () => Date,
+): ExecutionCacheLeaseAcquisition {
+  const digestKey = executionCacheKeyDigest(key)
+  const timestamp = now().getTime()
+  db.run('DELETE FROM lease_outcomes WHERE completed_at <= ?', [
+    timestamp - timing.waitTimeoutMs,
+  ])
+  const existing = db
+    .query(
+      `SELECT owner_token AS ownerToken, expires_at AS expiresAt,
+              baseline_revision AS baselineRevision
+       FROM leases WHERE key_digest = ?`,
+    )
+    .get(digestKey) as LeaseRow | null
+  if (existing && existing.expiresAt > timestamp) {
+    return {
+      acquired: false,
+      ownerToken: existing.ownerToken,
+      baselineRevision: existing.baselineRevision ?? undefined,
+    }
+  }
+
+  const ownerToken = randomUUID()
+  const baselineRevision = readExecutionCacheEntrySnapshot(
+    db,
+    digestKey,
+  )?.revision
+  db.run(
+    `INSERT INTO leases (
+       key_digest, project_key, owner_token, expires_at, baseline_revision
+     ) VALUES (?, ?, ?, ?, ?)
+     ON CONFLICT(key_digest) DO UPDATE SET
+       project_key = excluded.project_key,
+       owner_token = excluded.owner_token,
+       expires_at = excluded.expires_at,
+       baseline_revision = excluded.baseline_revision
+     WHERE leases.expires_at <= ?`,
+    [
+      digestKey,
+      projectKey,
+      ownerToken,
+      timestamp + timing.ttlMs,
+      baselineRevision ?? null,
+      timestamp,
+    ],
+  )
+  const acquired = db
+    .query(
+      `SELECT owner_token AS ownerToken, expires_at AS expiresAt,
+              baseline_revision AS baselineRevision
+       FROM leases WHERE key_digest = ?`,
+    )
+    .get(digestKey) as LeaseRow
+  if (acquired.ownerToken !== ownerToken) {
+    return {
+      acquired: false,
+      ownerToken: acquired.ownerToken,
+      baselineRevision: acquired.baselineRevision ?? undefined,
+    }
+  }
+  return {
+    acquired: true,
+    lease: leaseFromRow(key, acquired, timing.heartbeatMs),
+  }
+}
+
 export function createLocalExecutionCacheCoordination(
   options: LocalExecutionCacheCoordinationOptions,
 ): ExecutionCacheCoordination {
@@ -274,70 +346,7 @@ export function createLocalExecutionCacheCoordination(
       assertExecutionCacheProjectKey(projectKey, key)
       return database.use((db) =>
         db
-          .transaction(() => {
-            const digestKey = executionCacheKeyDigest(key)
-            const timestamp = now().getTime()
-            db.run('DELETE FROM lease_outcomes WHERE completed_at <= ?', [
-              timestamp - timing.waitTimeoutMs,
-            ])
-            const existing = db
-              .query(
-                `SELECT owner_token AS ownerToken, expires_at AS expiresAt,
-                      baseline_revision AS baselineRevision
-               FROM leases WHERE key_digest = ?`,
-              )
-              .get(digestKey) as LeaseRow | null
-            if (existing && existing.expiresAt > timestamp) {
-              return {
-                acquired: false as const,
-                ownerToken: existing.ownerToken,
-                baselineRevision: existing.baselineRevision ?? undefined,
-              }
-            }
-            const ownerToken = randomUUID()
-            const baselineRevision = readExecutionCacheEntrySnapshot(
-              db,
-              digestKey,
-            )?.revision
-            db.run(
-              `INSERT INTO leases (
-               key_digest, project_key, owner_token, expires_at,
-               baseline_revision
-             ) VALUES (?, ?, ?, ?, ?)
-             ON CONFLICT(key_digest) DO UPDATE SET
-               project_key = excluded.project_key,
-               owner_token = excluded.owner_token,
-               expires_at = excluded.expires_at,
-               baseline_revision = excluded.baseline_revision
-             WHERE leases.expires_at <= ?`,
-              [
-                digestKey,
-                projectKey,
-                ownerToken,
-                timestamp + timing.ttlMs,
-                baselineRevision ?? null,
-                timestamp,
-              ],
-            )
-            const acquired = db
-              .query(
-                `SELECT owner_token AS ownerToken, expires_at AS expiresAt,
-                      baseline_revision AS baselineRevision
-               FROM leases WHERE key_digest = ?`,
-              )
-              .get(digestKey) as LeaseRow
-            if (acquired.ownerToken !== ownerToken) {
-              return {
-                acquired: false as const,
-                ownerToken: acquired.ownerToken,
-                baselineRevision: acquired.baselineRevision ?? undefined,
-              }
-            }
-            return {
-              acquired: true as const,
-              lease: leaseFromRow(key, acquired, timing.heartbeatMs),
-            }
-          })
+          .transaction(() => acquireLease(db, key, projectKey, timing, now))
           .immediate(),
       )
     },

--- a/packages/runner/src/execution-cache/local-execution-cache-database.ts
+++ b/packages/runner/src/execution-cache/local-execution-cache-database.ts
@@ -26,6 +26,41 @@ function hasColumn(db: Database, table: string, column: string): boolean {
   )
 }
 
+function addMissingColumn(
+  db: Database,
+  table: string,
+  column: string,
+  definition: string,
+): void {
+  if (!hasColumn(db, table, column)) {
+    db.run(`ALTER TABLE ${table} ADD COLUMN ${column} ${definition}`)
+  }
+}
+
+function migrateLegacyEntries(db: Database, version: number): void {
+  if (version > 0 && version < 3) {
+    db.run('ALTER TABLE entries ADD COLUMN revision INTEGER NOT NULL DEFAULT 1')
+  }
+  addMissingColumn(db, 'leases', 'baseline_revision', 'INTEGER')
+  addMissingColumn(db, 'leases', 'project_key', 'TEXT')
+  addMissingColumn(db, 'lease_outcomes', 'project_key', 'TEXT')
+  if (version === 0 || version >= 5) return
+  db.run(`
+    UPDATE leases SET project_key = (
+      SELECT project_key FROM entries
+      WHERE entries.key_digest = leases.key_digest
+    )
+  `)
+  db.run(`
+    UPDATE lease_outcomes SET project_key = (
+      SELECT project_key FROM entries
+      WHERE entries.key_digest = lease_outcomes.key_digest
+    )
+  `)
+  db.run('DELETE FROM leases WHERE project_key IS NULL')
+  db.run('DELETE FROM lease_outcomes WHERE project_key IS NULL')
+}
+
 function migrate(db: Database): void {
   const version = db.query('PRAGMA user_version').get() as CacheSchemaVersion
   if (version.user_version > cacheSchemaVersion) {
@@ -89,36 +124,7 @@ function migrate(db: Database): void {
       CREATE INDEX IF NOT EXISTS lease_outcomes_completed
       ON lease_outcomes(completed_at)
     `)
-    if (version.user_version > 0 && version.user_version < 3) {
-      db.run(
-        'ALTER TABLE entries ADD COLUMN revision INTEGER NOT NULL DEFAULT 1',
-      )
-    }
-    if (!hasColumn(db, 'leases', 'baseline_revision')) {
-      db.run('ALTER TABLE leases ADD COLUMN baseline_revision INTEGER')
-    }
-    if (!hasColumn(db, 'leases', 'project_key')) {
-      db.run('ALTER TABLE leases ADD COLUMN project_key TEXT')
-    }
-    if (!hasColumn(db, 'lease_outcomes', 'project_key')) {
-      db.run('ALTER TABLE lease_outcomes ADD COLUMN project_key TEXT')
-    }
-    if (version.user_version > 0 && version.user_version < 5) {
-      db.run(`
-        UPDATE leases SET project_key = (
-          SELECT project_key FROM entries
-          WHERE entries.key_digest = leases.key_digest
-        )
-      `)
-      db.run(`
-        UPDATE lease_outcomes SET project_key = (
-          SELECT project_key FROM entries
-          WHERE entries.key_digest = lease_outcomes.key_digest
-        )
-      `)
-      db.run('DELETE FROM leases WHERE project_key IS NULL')
-      db.run('DELETE FROM lease_outcomes WHERE project_key IS NULL')
-    }
+    migrateLegacyEntries(db, version.user_version)
     db.run(`PRAGMA user_version = ${cacheSchemaVersion}`)
   }).immediate()
 }

--- a/packages/runner/src/execution-cache/run-scenario-cache.ts
+++ b/packages/runner/src/execution-cache/run-scenario-cache.ts
@@ -884,22 +884,39 @@ export async function runScenarioWithExecutionCache(
   }
 
   if (cachePolicy === 'refresh') {
-    await appendEvent(events, input, {
-      type: 'cache-refresh',
-      cacheKey,
-      scope: nextAttemptScope(input),
-    })
-    const observedSnapshot =
-      await input.executionCache!.store.coordination?.readCurrent(cacheKey)
-    return runCoordinatedAdaptive({
-      input,
-      events,
-      cacheKey,
-      cacheOutcome: 'refresh',
-      observedRevision: observedSnapshot?.revision,
-    })
+    return runCacheRefresh(input, events, cacheKey)
   }
 
+  return runCachedScenario(input, events, cachePolicy, cacheKey)
+}
+
+async function runCacheRefresh(
+  input: RunScenarioInput,
+  events: RunEvent[],
+  cacheKey: ExecutionCacheKey,
+): Promise<ScenarioRun> {
+  await appendEvent(events, input, {
+    type: 'cache-refresh',
+    cacheKey,
+    scope: nextAttemptScope(input),
+  })
+  const observedSnapshot =
+    await input.executionCache!.store.coordination?.readCurrent(cacheKey)
+  return runCoordinatedAdaptive({
+    input,
+    events,
+    cacheKey,
+    cacheOutcome: 'refresh',
+    observedRevision: observedSnapshot?.revision,
+  })
+}
+
+async function runCachedScenario(
+  input: RunScenarioInput,
+  events: RunEvent[],
+  cachePolicy: ExecutionCachePolicy,
+  cacheKey: ExecutionCacheKey,
+): Promise<ScenarioRun> {
   const observedSnapshot =
     await input.executionCache!.store.coordination?.readCurrent(cacheKey)
   const source = await input.executionCache!.store.read(cacheKey)

--- a/packages/runner/src/execution/run-scenario.ts
+++ b/packages/runner/src/execution/run-scenario.ts
@@ -381,6 +381,199 @@ interface SessionExecutionContext {
   recordStep: RecordStep
 }
 
+interface FinishAttemptInput {
+  input: ScenarioAttemptInput
+  now: () => Date
+  scenarioStartedAt: string
+  events: RunEvent[]
+  completion: TargetSessionCompletion | undefined
+  progress: AttemptProgress
+  emit: EmitAttemptEvent
+  state: TestResultState
+  steps: TestStepResult[]
+  message?: string
+}
+
+async function finishAttempt(
+  context: FinishAttemptInput,
+): Promise<AttemptScenarioRun> {
+  const finishedAt = context.now().toISOString()
+  const attempt: ScenarioAttempt = {
+    attempt: context.input.attempt,
+    startedAt: context.scenarioStartedAt,
+    finishedAt,
+    durationMs: durationMs(context.scenarioStartedAt, finishedAt),
+    state: context.state,
+    steps: context.steps,
+    executionMode: context.input.mode,
+    inferenceCount: context.completion?.inferenceCount ?? 0,
+    ...(context.input.adapter.fidelityPolicy
+      ? { fidelityPolicy: context.input.adapter.fidelityPolicy }
+      : {}),
+    ...(context.message !== undefined ? { message: context.message } : {}),
+    ...(context.progress.diagnostics.length > 0
+      ? { diagnostics: context.progress.diagnostics }
+      : {}),
+    evidenceAvailability: attemptEvidence(
+      context.input,
+      context.steps,
+      context.progress.evidenceAvailability,
+      context.progress.diagnostics,
+    ),
+  }
+  const result = createTestResult(context.input, [attempt])
+  await context.emit(scenarioFinishedPayload(result), finishedAt)
+  return {
+    events: context.events,
+    result,
+    attempt,
+    completion: context.completion,
+    replayDiverged: context.progress.replayDiverged,
+    runtimeValueExposed: context.progress.runtimeValueExposed,
+  }
+}
+
+interface RecordExecutionInput {
+  input: ScenarioAttemptInput
+  bindings: readonly ScenarioVariableBinding[]
+  progress: AttemptProgress
+  recordStep: RecordStep
+}
+
+async function recordStepExecution(
+  context: RecordExecutionInput,
+  stepIndex: number,
+  startedAt: string,
+  execution: StepExecution,
+): Promise<boolean> {
+  const templateStep = templateStepAt(context.input.scenario, stepIndex)
+  const projected = publicStepExecution(execution, context.bindings)
+  context.progress.runtimeValueExposed ||= projected.runtimeValueExposed
+  context.progress.evidenceAvailability.push(
+    ...(projected.execution.evidenceAvailability ?? []),
+  )
+  if (context.input.signal?.aborted) {
+    context.progress.state = 'cancelled'
+    context.progress.message = 'Scenario cancelled during step execution'
+    await context.recordStep(stepIndex, startedAt, {
+      step: templateStep,
+      state: context.progress.state,
+      resolvedActions: projected.execution.resolvedActions,
+      message: context.progress.message,
+    })
+    return false
+  }
+  await context.recordStep(stepIndex, startedAt, {
+    step: templateStep,
+    state: projected.execution.state,
+    resolvedActions: projected.execution.resolvedActions,
+    message: projected.execution.message,
+    artifacts: projected.execution.artifacts?.length
+      ? projected.execution.artifacts
+      : undefined,
+    diagnostics: projected.execution.diagnostics?.length
+      ? projected.execution.diagnostics.map((entry) =>
+          stampDiagnostic(entry, context.input, stepIndex, templateStep),
+        )
+      : undefined,
+    trace: projected.execution.trace?.length
+      ? projected.execution.trace
+      : undefined,
+  })
+  if (execution.replayDiverged) {
+    context.progress.replayDiverged = true
+    context.progress.state = 'failed'
+    context.progress.message = projected.execution.message
+    return false
+  }
+  if (execution.state === 'passed') return true
+  context.progress.state = execution.state
+  context.progress.message = projected.execution.message
+  return false
+}
+
+async function executeTargetSessionSteps(
+  session: TargetSession,
+  scenarioWallStartedAt: number,
+  context: SessionExecutionContext,
+): Promise<void> {
+  if (Boolean(session.executeScenario) === Boolean(session.executeStep)) {
+    recordExecutionError(
+      context.progress,
+      new Error(
+        'Target session must provide exactly one of executeStep or executeScenario',
+      ),
+      context.bindings,
+      context.input,
+      context.latestOccurredAt(),
+      undefined,
+    )
+    return
+  }
+  if (session.executeScenario) {
+    await executeScenarioSession(session, context)
+    return
+  }
+  await executeStepSession(session, scenarioWallStartedAt, context)
+}
+
+async function completeTargetSession(
+  session: TargetSession,
+  context: SessionExecutionContext,
+): Promise<TargetSessionCompletion | undefined> {
+  if (
+    context.progress.state !== 'passed' ||
+    context.input.signal?.aborted ||
+    !session.complete
+  ) {
+    return undefined
+  }
+  try {
+    return validateCompletion(await session.complete())
+  } catch (error) {
+    recordExecutionError(
+      context.progress,
+      error,
+      context.bindings,
+      context.input,
+      context.latestOccurredAt(),
+      undefined,
+    )
+    return undefined
+  }
+}
+
+async function closeTargetSession(
+  session: TargetSession,
+  context: SessionExecutionContext,
+): Promise<void> {
+  try {
+    await session.close()
+  } catch (error) {
+    recordExecutionError(
+      context.progress,
+      error,
+      context.bindings,
+      context.input,
+      context.latestOccurredAt(),
+      undefined,
+    )
+  }
+}
+
+async function executeTargetSession(
+  session: TargetSession,
+  scenarioWallStartedAt: number,
+  context: SessionExecutionContext,
+): Promise<TargetSessionCompletion | undefined> {
+  try {
+    await executeTargetSessionSteps(session, scenarioWallStartedAt, context)
+    return await completeTargetSession(session, context)
+  } finally {
+    await closeTargetSession(session, context)
+  }
+}
+
 function recordExecutionError(
   progress: AttemptProgress,
   error: unknown,
@@ -556,42 +749,19 @@ export async function runScenarioAttempt(
     state: TestResultState,
     steps: TestStepResult[],
     message?: string,
-  ): Promise<AttemptScenarioRun> => {
-    const finishedAt = now().toISOString()
-    const attempt: ScenarioAttempt = {
-      attempt: input.attempt,
-      startedAt: scenarioStartedAt,
-      finishedAt,
-      durationMs: durationMs(scenarioStartedAt, finishedAt),
+  ): Promise<AttemptScenarioRun> =>
+    finishAttempt({
+      input,
+      now,
+      scenarioStartedAt,
+      events,
+      completion,
+      progress,
+      emit,
       state,
       steps,
-      executionMode: input.mode,
-      inferenceCount: completion?.inferenceCount ?? 0,
-      ...(input.adapter.fidelityPolicy
-        ? { fidelityPolicy: input.adapter.fidelityPolicy }
-        : {}),
-      ...(message !== undefined ? { message } : {}),
-      ...(progress.diagnostics.length > 0
-        ? { diagnostics: progress.diagnostics }
-        : {}),
-      evidenceAvailability: attemptEvidence(
-        input,
-        steps,
-        progress.evidenceAvailability,
-        progress.diagnostics,
-      ),
-    }
-    const result = createTestResult(input, [attempt])
-    await emit(scenarioFinishedPayload(result), finishedAt)
-    return {
-      events,
-      result,
-      attempt,
-      completion,
-      replayDiverged: progress.replayDiverged,
-      runtimeValueExposed: progress.runtimeValueExposed,
-    }
-  }
+      message,
+    })
 
   const initialOutcome = initialAttemptOutcome(input)
   if (initialOutcome)
@@ -657,55 +827,13 @@ export async function runScenarioAttempt(
     stepIndex: number,
     startedAt: string,
     execution: StepExecution,
-  ): Promise<boolean> => {
-    const templateStep = templateStepAt(input.scenario, stepIndex)
-    const projected = publicStepExecution(execution, bindings)
-    progress.runtimeValueExposed ||= projected.runtimeValueExposed
-    progress.evidenceAvailability.push(
-      ...(projected.execution.evidenceAvailability ?? []),
+  ): Promise<boolean> =>
+    recordStepExecution(
+      { input, bindings, progress, recordStep },
+      stepIndex,
+      startedAt,
+      execution,
     )
-    if (input.signal?.aborted) {
-      progress.state = 'cancelled'
-      progress.message = 'Scenario cancelled during step execution'
-      await recordStep(stepIndex, startedAt, {
-        step: templateStep,
-        state: progress.state,
-        resolvedActions: projected.execution.resolvedActions,
-        message: progress.message,
-      })
-      return false
-    }
-    await recordStep(stepIndex, startedAt, {
-      step: templateStep,
-      state: projected.execution.state,
-      resolvedActions: projected.execution.resolvedActions,
-      message: projected.execution.message,
-      artifacts: projected.execution.artifacts?.length
-        ? projected.execution.artifacts
-        : undefined,
-      diagnostics: projected.execution.diagnostics?.length
-        ? projected.execution.diagnostics.map((entry) =>
-            stampDiagnostic(entry, input, stepIndex, templateStep),
-          )
-        : undefined,
-      trace: projected.execution.trace?.length
-        ? projected.execution.trace
-        : undefined,
-    })
-
-    if (execution.replayDiverged) {
-      progress.replayDiverged = true
-      progress.state = 'failed'
-      progress.message = projected.execution.message
-      return false
-    }
-    if (execution.state !== 'passed') {
-      progress.state = execution.state
-      progress.message = projected.execution.message
-      return false
-    }
-    return true
-  }
 
   const executionContext: SessionExecutionContext = {
     input,
@@ -717,55 +845,11 @@ export async function runScenarioAttempt(
     recordStep,
   }
 
-  try {
-    if (Boolean(session.executeScenario) === Boolean(session.executeStep)) {
-      recordExecutionError(
-        progress,
-        new Error(
-          'Target session must provide exactly one of executeStep or executeScenario',
-        ),
-        bindings,
-        input,
-        executionContext.latestOccurredAt(),
-        undefined,
-      )
-    } else if (session.executeScenario) {
-      await executeScenarioSession(session, executionContext)
-    } else {
-      await executeStepSession(session, scenarioWallStartedAt, executionContext)
-    }
-    if (
-      progress.state === 'passed' &&
-      !input.signal?.aborted &&
-      session.complete
-    ) {
-      try {
-        completion = validateCompletion(await session.complete())
-      } catch (error) {
-        recordExecutionError(
-          progress,
-          error,
-          bindings,
-          input,
-          executionContext.latestOccurredAt(),
-          undefined,
-        )
-      }
-    }
-  } finally {
-    try {
-      await session.close()
-    } catch (error) {
-      recordExecutionError(
-        progress,
-        error,
-        bindings,
-        input,
-        executionContext.latestOccurredAt(),
-        undefined,
-      )
-    }
-  }
+  completion = await executeTargetSession(
+    session,
+    scenarioWallStartedAt,
+    executionContext,
+  )
 
   return finish(progress.state, steps, progress.message)
 }

--- a/packages/runner/src/exports/archive.ts
+++ b/packages/runner/src/exports/archive.ts
@@ -255,9 +255,20 @@ export async function readRunArchive(path: string): Promise<RunArchive> {
   return archive
 }
 
-export async function importRunArchive(
+type ImportedArtifact = RunArchive['artifacts'][number] & { target: string }
+
+interface PreparedArchiveImport {
+  archive: RunArchive
+  originalBytes: Uint8Array
+  artifacts: ImportedArtifact[]
+  archivesDirectory: string
+  runDirectory: string
+  preservedArchivePath: string
+}
+
+async function prepareArchiveImport(
   input: ImportRunArchiveInput,
-): Promise<ImportedRunArchive> {
+): Promise<PreparedArchiveImport> {
   const originalBytes = new Uint8Array(
     await Bun.file(input.archivePath).arrayBuffer(),
   )
@@ -289,37 +300,73 @@ export async function importRunArchive(
   }
   validateArchiveArtifactReferences(archive, runDirectory)
   assertArchiveArtifactPayloads(archive)
-  await mkdir(archivesDirectory, { recursive: true })
-  await mkdir(dirname(runDirectory), { recursive: true })
+  return {
+    archive,
+    originalBytes,
+    artifacts,
+    archivesDirectory,
+    runDirectory,
+    preservedArchivePath,
+  }
+}
+
+async function createImportedRunDirectory(
+  runDirectory: string,
+  runId: string,
+): Promise<void> {
   try {
     await mkdir(runDirectory)
   } catch (error) {
     if (isAlreadyExists(error)) {
-      throw new Error(`Test run "${archive.manifest.id}" already exists`)
+      throw new Error(`Test run "${runId}" already exists`)
     }
     throw error
   }
+}
+
+async function writePreservedArchive(
+  path: string,
+  originalBytes: Uint8Array,
+): Promise<void> {
+  const archiveFile = await open(path, 'wx')
+  try {
+    await archiveFile.writeFile(originalBytes)
+  } finally {
+    await archiveFile.close()
+  }
+}
+
+async function writeImportedArtifacts(
+  artifacts: readonly ImportedArtifact[],
+): Promise<Map<string, string>> {
+  const pathMap = new Map<string, string>()
+  for (const artifact of artifacts) {
+    await mkdir(dirname(artifact.target), { recursive: true })
+    await Bun.write(
+      artifact.target,
+      decodeBase64(artifact.content, artifact.path),
+    )
+    pathMap.set(artifact.path, artifact.target)
+  }
+  return pathMap
+}
+
+export async function importRunArchive(
+  input: ImportRunArchiveInput,
+): Promise<ImportedRunArchive> {
+  const prepared = await prepareArchiveImport(input)
+  const { archive, originalBytes, artifacts } = prepared
+  const { archivesDirectory, runDirectory, preservedArchivePath } = prepared
+  await mkdir(archivesDirectory, { recursive: true })
+  await mkdir(dirname(runDirectory), { recursive: true })
+  await createImportedRunDirectory(runDirectory, archive.manifest.id)
 
   let preservedArchive = false
   try {
-    const archiveFile = await open(preservedArchivePath, 'wx')
+    await writePreservedArchive(preservedArchivePath, originalBytes)
     preservedArchive = true
-    try {
-      await archiveFile.writeFile(originalBytes)
-    } finally {
-      await archiveFile.close()
-    }
     await mkdir(join(runDirectory, 'artifacts'))
-
-    const pathMap = new Map<string, string>()
-    for (const artifact of artifacts) {
-      await mkdir(dirname(artifact.target), { recursive: true })
-      await Bun.write(
-        artifact.target,
-        decodeBase64(artifact.content, artifact.path),
-      )
-      pathMap.set(artifact.path, artifact.target)
-    }
+    const pathMap = await writeImportedArtifacts(artifacts)
     const mapPath: MapArtifactPath = (path) =>
       pathMap.get(path) ?? importedArtifactPath(runDirectory, path)
     const events = archive.events.map((event) =>

--- a/packages/runner/src/results/rerun.ts
+++ b/packages/runner/src/results/rerun.ts
@@ -13,6 +13,28 @@ const failureStates = new Set<TestResultState>([
   'infrastructure-error',
 ])
 
+function matchesOptionalSet(
+  value: string | undefined,
+  accepted: ReadonlySet<string> | undefined,
+): boolean {
+  return !accepted || (value !== undefined && accepted.has(value))
+}
+
+function matchesRerunFilter(
+  result: TestResult,
+  hasStateFilter: boolean,
+  scenarioIds: ReadonlySet<string> | undefined,
+  scenarioNames: ReadonlySet<string> | undefined,
+  profileIds: ReadonlySet<string> | undefined,
+): boolean {
+  if (hasStateFilter && !failureStates.has(result.state)) return false
+  return (
+    matchesOptionalSet(result.scenario.id, scenarioIds) &&
+    matchesOptionalSet(result.scenario.name, scenarioNames) &&
+    matchesOptionalSet(result.executionTargetProfile.id, profileIds)
+  )
+}
+
 export function selectRerunResults(
   manifest: TestRunManifest,
   filter: RerunFilter,
@@ -26,22 +48,13 @@ export function selectRerunResults(
     : undefined
   const profileIds = filter.profileIds ? new Set(filter.profileIds) : undefined
 
-  return manifest.results.filter((result) => {
-    if (hasStateFilter) {
-      if (!failureStates.has(result.state)) return false
-    }
-    if (
-      scenarioIds &&
-      (!result.scenario.id || !scenarioIds.has(result.scenario.id))
-    ) {
-      return false
-    }
-    if (scenarioNames && !scenarioNames.has(result.scenario.name)) {
-      return false
-    }
-    if (profileIds && !profileIds.has(result.executionTargetProfile.id)) {
-      return false
-    }
-    return true
-  })
+  return manifest.results.filter((result) =>
+    matchesRerunFilter(
+      result,
+      hasStateFilter,
+      scenarioIds,
+      scenarioNames,
+      profileIds,
+    ),
+  )
 }

--- a/packages/runner/src/results/test-run-schema.ts
+++ b/packages/runner/src/results/test-run-schema.ts
@@ -161,36 +161,54 @@ function validateEvidenceAvailability(
     }
     availabilityByKind.set(availability.kind, availability)
   }
-  for (const kind of evidenceKinds) {
-    if (!availabilityByKind.has(kind)) {
-      context.addIssue({
-        code: 'custom',
-        path: ['evidenceAvailability'],
-        message: `Evidence availability must include "${kind}"`,
-      })
-    }
-  }
+  validateRequiredEvidenceKinds(availabilityByKind, context)
 
   const availableKinds = persistedEvidenceKinds(
     attempt.steps,
     attempt.diagnostics,
   )
   for (const [kind, availability] of availabilityByKind) {
-    const hasPersistedEvidence = availableKinds.has(kind)
-    if (hasPersistedEvidence && availability.state !== 'available') {
-      context.addIssue({
-        code: 'custom',
-        path: ['evidenceAvailability'],
-        message: `Evidence availability for "${kind}" must be available when persisted evidence exists`,
-      })
-    }
-    if (!hasPersistedEvidence && availability.state === 'available') {
-      context.addIssue({
-        code: 'custom',
-        path: ['evidenceAvailability'],
-        message: `Available evidence for "${kind}" requires persisted evidence`,
-      })
-    }
+    validatePersistedEvidenceKind(kind, availability, availableKinds, context)
+  }
+}
+
+type EvidenceKind = ScenarioAttempt['evidenceAvailability'][number]['kind']
+type EvidenceAvailability = ScenarioAttempt['evidenceAvailability'][number]
+
+function validateRequiredEvidenceKinds(
+  availabilityByKind: ReadonlyMap<EvidenceKind, EvidenceAvailability>,
+  context: z.RefinementCtx,
+): void {
+  for (const kind of evidenceKinds) {
+    if (availabilityByKind.has(kind)) continue
+    context.addIssue({
+      code: 'custom',
+      path: ['evidenceAvailability'],
+      message: `Evidence availability must include "${kind}"`,
+    })
+  }
+}
+
+function validatePersistedEvidenceKind(
+  kind: EvidenceKind,
+  availability: EvidenceAvailability,
+  availableKinds: ReadonlySet<EvidenceKind>,
+  context: z.RefinementCtx,
+): void {
+  const hasPersistedEvidence = availableKinds.has(kind)
+  if (hasPersistedEvidence && availability.state !== 'available') {
+    context.addIssue({
+      code: 'custom',
+      path: ['evidenceAvailability'],
+      message: `Evidence availability for "${kind}" must be available when persisted evidence exists`,
+    })
+  }
+  if (!hasPersistedEvidence && availability.state === 'available') {
+    context.addIssue({
+      code: 'custom',
+      path: ['evidenceAvailability'],
+      message: `Available evidence for "${kind}" requires persisted evidence`,
+    })
   }
 }
 

--- a/packages/runner/src/results/test-run-store.ts
+++ b/packages/runner/src/results/test-run-store.ts
@@ -121,6 +121,28 @@ const indexSchemaVersion = 5
 export const defaultRetention: Readonly<RetentionPolicy> = {}
 export const defaultRunStorageWarningBytes = 5 * 1024 * 1024 * 1024
 
+function runStartedEvent(
+  id: string,
+  startedAt: string,
+  options: CreateTestRunOptions,
+): RunEventPayload {
+  return {
+    type: 'run-started',
+    run: {
+      id,
+      startedAt,
+      ...(options.sourceRunId ? { sourceRunId: options.sourceRunId } : {}),
+      ...(options.suite ? { suite: options.suite } : {}),
+      ...(options.applicationRevision
+        ? { applicationRevision: options.applicationRevision }
+        : {}),
+      ...(options.evidencePersistence
+        ? { evidencePersistence: options.evidencePersistence }
+        : {}),
+    },
+  }
+}
+
 const stateRank: Record<TestResultState, number> = {
   skipped: 0,
   passed: 1,
@@ -400,23 +422,7 @@ export function openTestRunStore(options: TestRunStoreOptions): TestRunStore {
       }
       const run = persistedRunFor(id, startedAt, options)
       try {
-        await run.append({
-          type: 'run-started',
-          run: {
-            id,
-            startedAt,
-            ...(options.sourceRunId
-              ? { sourceRunId: options.sourceRunId }
-              : {}),
-            ...(options.suite ? { suite: options.suite } : {}),
-            ...(options.applicationRevision
-              ? { applicationRevision: options.applicationRevision }
-              : {}),
-            ...(options.evidencePersistence
-              ? { evidencePersistence: options.evidencePersistence }
-              : {}),
-          },
-        })
+        await run.append(runStartedEvent(id, startedAt, options))
         return run
       } catch (error) {
         await rm(runDirectory, { recursive: true, force: true })
@@ -487,47 +493,73 @@ function persistedTestRun(
     return manifest.finishedAt ? manifest : undefined
   }
 
+  async function appendEvent(
+    event: RunEvent | RunEventPayload,
+  ): Promise<RunEvent> {
+    if (await finalizedManifest()) {
+      throw new Error(`Test run "${id}" is finalized and cannot be changed`)
+    }
+    const current = await readEvents(eventsPath, incompatibleSchema)
+    const recordable = recordableRunEventPayloadData(eventPayload(event))
+    const policy =
+      'scope' in recordable
+        ? evidencePersistenceFor(recordable.scope.executionTargetProfileId)
+        : evidencePersistenceFor('')
+    const envelope = {
+      schemaVersion: testRunSchemaVersion,
+      sequence: current.length + 1,
+      occurredAt:
+        'occurredAt' in event ? event.occurredAt : now().toISOString(),
+    } as const
+    const persisted = await persistEventArtifacts(
+      recordable,
+      current,
+      policy,
+      artifactsDirectory,
+    )
+    const versioned = { ...persisted.event, ...envelope } as RunEvent
+    try {
+      await appendFile(eventsPath, `${JSON.stringify(versioned)}\n`)
+    } catch (error) {
+      await Promise.all(
+        persisted.publishedPaths.map((path) => rm(path, { force: true })),
+      )
+      throw error
+    }
+    return !shouldPersistEventEvidence(recordable, policy)
+      ? ({ ...recordable, ...envelope } as RunEvent)
+      : versioned
+  }
+
+  async function materializeRun(input?: {
+    finished?: boolean
+  }): Promise<TestRunManifest> {
+    const finalized = await finalizedManifest()
+    if (finalized) return finalized
+    const recorded = await readEvents(eventsPath, incompatibleSchema)
+    const results = materializeTestResults(recorded)
+    const manifest: TestRunManifest = {
+      schemaVersion: testRunSchemaVersion,
+      id,
+      startedAt: startedAtFrom(recorded, startedAt),
+      ...(input?.finished === false ? {} : { finishedAt: now().toISOString() }),
+      ...(metadata.sourceRunId ? { sourceRunId: metadata.sourceRunId } : {}),
+      ...(metadata.suite ? { suite: metadata.suite } : {}),
+      ...(metadata.applicationRevision
+        ? { applicationRevision: metadata.applicationRevision }
+        : {}),
+      state: aggregateTestResultState(results),
+      results,
+    }
+    await Bun.write(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`)
+    await onMaterialize(manifest)
+    return manifest
+  }
+
   return {
     id,
     async append(event) {
-      return serializeOperation(async () => {
-        if (await finalizedManifest()) {
-          throw new Error(`Test run "${id}" is finalized and cannot be changed`)
-        }
-        const current = await readEvents(eventsPath, incompatibleSchema)
-        const recordable = recordableRunEventPayloadData(eventPayload(event))
-        const policy =
-          'scope' in recordable
-            ? evidencePersistenceFor(recordable.scope.executionTargetProfileId)
-            : evidencePersistenceFor('')
-        const envelope = {
-          schemaVersion: testRunSchemaVersion,
-          sequence: current.length + 1,
-          occurredAt:
-            'occurredAt' in event ? event.occurredAt : now().toISOString(),
-        } as const
-        const persisted = await persistEventArtifacts(
-          recordable,
-          current,
-          policy,
-          artifactsDirectory,
-        )
-        const versioned = {
-          ...persisted.event,
-          ...envelope,
-        } as RunEvent
-        try {
-          await appendFile(eventsPath, `${JSON.stringify(versioned)}\n`)
-        } catch (error) {
-          await Promise.all(
-            persisted.publishedPaths.map((path) => rm(path, { force: true })),
-          )
-          throw error
-        }
-        return !shouldPersistEventEvidence(recordable, policy)
-          ? ({ ...recordable, ...envelope } as RunEvent)
-          : versioned
-      })
+      return serializeOperation(() => appendEvent(event))
     },
     async events() {
       return serializeOperation(() =>
@@ -535,32 +567,7 @@ function persistedTestRun(
       )
     },
     async materialize(input) {
-      return serializeOperation(async () => {
-        const finalized = await finalizedManifest()
-        if (finalized) return finalized
-        const recorded = await readEvents(eventsPath, incompatibleSchema)
-        const results = materializeTestResults(recorded)
-        const manifest: TestRunManifest = {
-          schemaVersion: testRunSchemaVersion,
-          id,
-          startedAt: startedAtFrom(recorded, startedAt),
-          ...(input?.finished === false
-            ? {}
-            : { finishedAt: now().toISOString() }),
-          ...(metadata.sourceRunId
-            ? { sourceRunId: metadata.sourceRunId }
-            : {}),
-          ...(metadata.suite ? { suite: metadata.suite } : {}),
-          ...(metadata.applicationRevision
-            ? { applicationRevision: metadata.applicationRevision }
-            : {}),
-          state: aggregateTestResultState(results),
-          results,
-        }
-        await Bun.write(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`)
-        await onMaterialize(manifest)
-        return manifest
-      })
+      return serializeOperation(() => materializeRun(input))
     },
   }
 }
@@ -580,6 +587,32 @@ interface IndexedRun {
   executionModes: string
   cacheOutcomes: string
   inferenceCount: number | null
+}
+
+function testRunSummaryFrom(row: unknown): TestRunSummary {
+  const indexed = row as IndexedRun
+  const executionModes = JSON.parse(indexed.executionModes) as ExecutionMode[]
+  const cacheOutcomes = JSON.parse(indexed.cacheOutcomes) as CacheOutcome[]
+  return {
+    id: indexed.id,
+    startedAt: indexed.startedAt,
+    ...(indexed.finishedAt ? { finishedAt: indexed.finishedAt } : {}),
+    ...(indexed.sourceRunId ? { sourceRunId: indexed.sourceRunId } : {}),
+    ...(indexed.suite ? { suite: indexed.suite } : {}),
+    executionTargetProfileIds: JSON.parse(
+      indexed.executionTargetProfileIds,
+    ) as string[],
+    specificationUris: JSON.parse(indexed.specificationUris) as string[],
+    ...(indexed.applicationRevision
+      ? { applicationRevision: indexed.applicationRevision }
+      : {}),
+    ...(indexed.durationMs !== null ? { durationMs: indexed.durationMs } : {}),
+    state: indexed.state,
+    resultCount: indexed.resultCount,
+    executionModes: executionModes.length > 0 ? executionModes : undefined,
+    cacheOutcomes: cacheOutcomes.length > 0 ? cacheOutcomes : undefined,
+    inferenceCount: indexed.inferenceCount ?? undefined,
+  }
 }
 
 type IndexColumn = { name: string }
@@ -827,35 +860,7 @@ function listRuns(db: Database): TestRunSummary[] {
        FROM runs ORDER BY id`,
     )
     .all()
-    .map((row) => {
-      const indexed = row as IndexedRun
-      const executionModes = JSON.parse(
-        indexed.executionModes,
-      ) as ExecutionMode[]
-      const cacheOutcomes = JSON.parse(indexed.cacheOutcomes) as CacheOutcome[]
-      return {
-        id: indexed.id,
-        startedAt: indexed.startedAt,
-        ...(indexed.finishedAt ? { finishedAt: indexed.finishedAt } : {}),
-        ...(indexed.sourceRunId ? { sourceRunId: indexed.sourceRunId } : {}),
-        ...(indexed.suite ? { suite: indexed.suite } : {}),
-        executionTargetProfileIds: JSON.parse(
-          indexed.executionTargetProfileIds,
-        ) as string[],
-        specificationUris: JSON.parse(indexed.specificationUris) as string[],
-        ...(indexed.applicationRevision
-          ? { applicationRevision: indexed.applicationRevision }
-          : {}),
-        ...(indexed.durationMs !== null
-          ? { durationMs: indexed.durationMs }
-          : {}),
-        state: indexed.state,
-        resultCount: indexed.resultCount,
-        executionModes: executionModes.length > 0 ? executionModes : undefined,
-        cacheOutcomes: cacheOutcomes.length > 0 ? cacheOutcomes : undefined,
-        inferenceCount: indexed.inferenceCount ?? undefined,
-      }
-    })
+    .map(testRunSummaryFrom)
 }
 
 function listRunIds(db: Database): string[] {
@@ -1148,32 +1153,19 @@ async function copyStepArtifacts(
   const artifacts: TestArtifact[] = []
   try {
     for (const [index, artifact] of step.artifacts.entries()) {
-      const path = artifactDestination(
+      const copied = await copyStepArtifact(
         artifact,
         index,
         artifactsDirectory,
+        stagingDirectory,
         name,
       )
-      const filename = basename(path)
-      if (artifact.path === path) {
-        artifacts.push(artifact)
-        continue
-      }
-      const stagedPath = join(stagingDirectory, filename)
-      try {
-        await copyFile(artifact.path, stagedPath)
-        if (await pathExists(path)) {
-          throw new Error(`Test artifact destination already exists: ${path}`)
-        }
-        await rename(stagedPath, path)
-        publishedPaths.push(path)
-        artifacts.push({ ...artifact, path })
-      } catch (error) {
-        captureFailures.push({
-          kind: artifact.kind,
-          message: `${artifact.path}: ${errorMessage(error)}`,
-        })
-      }
+      appendCopiedStepArtifact(
+        copied,
+        artifacts,
+        publishedPaths,
+        captureFailures,
+      )
     }
   } finally {
     await rm(stagingDirectory, { recursive: true, force: true })
@@ -1186,6 +1178,50 @@ async function copyStepArtifacts(
     },
     publishedPaths,
     captureFailures,
+  }
+}
+
+interface CopiedStepArtifact {
+  artifact?: TestArtifact
+  publishedPath?: string
+  captureFailure?: EvidenceCaptureFailure
+}
+
+function appendCopiedStepArtifact(
+  copied: CopiedStepArtifact,
+  artifacts: TestArtifact[],
+  publishedPaths: string[],
+  captureFailures: EvidenceCaptureFailure[],
+): void {
+  if (copied.artifact) artifacts.push(copied.artifact)
+  if (copied.publishedPath) publishedPaths.push(copied.publishedPath)
+  if (copied.captureFailure) captureFailures.push(copied.captureFailure)
+}
+
+async function copyStepArtifact(
+  artifact: TestArtifact,
+  index: number,
+  artifactsDirectory: string,
+  stagingDirectory: string,
+  name: string,
+): Promise<CopiedStepArtifact> {
+  const path = artifactDestination(artifact, index, artifactsDirectory, name)
+  if (artifact.path === path) return { artifact }
+  const stagedPath = join(stagingDirectory, basename(path))
+  try {
+    await copyFile(artifact.path, stagedPath)
+    if (await pathExists(path)) {
+      throw new Error(`Test artifact destination already exists: ${path}`)
+    }
+    await rename(stagedPath, path)
+    return { artifact: { ...artifact, path }, publishedPath: path }
+  } catch (error) {
+    return {
+      captureFailure: {
+        kind: artifact.kind,
+        message: `${artifact.path}: ${errorMessage(error)}`,
+      },
+    }
   }
 }
 

--- a/packages/spec/src/authoring/editor.ts
+++ b/packages/spec/src/authoring/editor.ts
@@ -69,11 +69,10 @@ function stepEndLine(step: Step): number {
   return step.location.line
 }
 
-function stepReplacements(
+function sharedStepReplacements(
   source: string,
   steps: readonly Step[],
   nextSteps: readonly StructuredStep[],
-  fallbackLocation: SourceLocation | undefined,
 ): Replacement[] {
   const replacements: Replacement[] = []
   const shared = Math.min(steps.length, nextSteps.length)
@@ -97,33 +96,61 @@ function stepReplacements(
       })
     }
   }
-  if (nextSteps.length > steps.length) {
-    const last = steps[steps.length - 1]
-    const indent = Math.max(
-      (last?.location.column ?? fallbackLocation?.column ?? 5) - 1,
-      0,
-    )
-    const afterLine = last ? stepEndLine(last) : (fallbackLocation?.line ?? 1)
-    const insertAt = offsetAt(source, { line: afterLine + 1, column: 1 })
-    const newline = newlineFor(source)
-    const added = nextSteps
-      .slice(steps.length)
-      .map((step) => `${' '.repeat(indent)}${step.keyword} ${step.text}`)
-      .join(newline)
-    replacements.push({
-      start: insertAt,
-      end: insertAt,
-      text: `${added}${newline}`,
-    })
+  return replacements
+}
+
+function addedStepsReplacement(
+  source: string,
+  steps: readonly Step[],
+  nextSteps: readonly StructuredStep[],
+  fallbackLocation: SourceLocation | undefined,
+): Replacement | undefined {
+  if (nextSteps.length <= steps.length) return undefined
+  const last = steps[steps.length - 1]
+  const indent = Math.max(
+    (last?.location.column ?? fallbackLocation?.column ?? 5) - 1,
+    0,
+  )
+  const afterLine = last ? stepEndLine(last) : (fallbackLocation?.line ?? 1)
+  const insertAt = offsetAt(source, { line: afterLine + 1, column: 1 })
+  const newline = newlineFor(source)
+  const added = nextSteps
+    .slice(steps.length)
+    .map((step) => `${' '.repeat(indent)}${step.keyword} ${step.text}`)
+    .join(newline)
+  return { start: insertAt, end: insertAt, text: `${added}${newline}` }
+}
+
+function removedStepReplacements(
+  source: string,
+  steps: readonly Step[],
+  nextStepCount: number,
+): Replacement[] {
+  const replacements: Replacement[] = []
+  for (let index = steps.length - 1; index >= nextStepCount; index--) {
+    const step = steps[index]!
+    const start = offsetAt(source, { line: step.location.line, column: 1 })
+    const end = offsetAt(source, { line: stepEndLine(step) + 1, column: 1 })
+    replacements.push({ start, end, text: '' })
   }
-  if (steps.length > nextSteps.length) {
-    for (let index = steps.length - 1; index >= nextSteps.length; index--) {
-      const step = steps[index]!
-      const start = offsetAt(source, { line: step.location.line, column: 1 })
-      const end = offsetAt(source, { line: stepEndLine(step) + 1, column: 1 })
-      replacements.push({ start, end, text: '' })
-    }
-  }
+  return replacements
+}
+
+function stepReplacements(
+  source: string,
+  steps: readonly Step[],
+  nextSteps: readonly StructuredStep[],
+  fallbackLocation: SourceLocation | undefined,
+): Replacement[] {
+  const replacements = sharedStepReplacements(source, steps, nextSteps)
+  const addition = addedStepsReplacement(
+    source,
+    steps,
+    nextSteps,
+    fallbackLocation,
+  )
+  if (addition) replacements.push(addition)
+  replacements.push(...removedStepReplacements(source, steps, nextSteps.length))
   return replacements
 }
 

--- a/packages/spec/src/identity/identity-management.ts
+++ b/packages/spec/src/identity/identity-management.ts
@@ -190,36 +190,37 @@ function recordIdentifier(
 }
 
 function resolvedNodeId(node: IdentityNode, uri: string): string {
-  if (node.kind === 'examples-row') {
-    const explicit = node.pickleIdValue?.trim()
-    if (explicit) return explicit
-    return identifierDigest([
-      'examples-row',
-      uri,
-      node.specificationName,
-      node.scenarioName ?? '',
-      node.examplesName ?? '',
-      ...(node.rowValues ?? []),
-    ])
+  switch (node.kind) {
+    case 'examples-row': {
+      const explicit = node.pickleIdValue?.trim()
+      if (explicit) return explicit
+      return identifierDigest([
+        'examples-row',
+        uri,
+        node.specificationName,
+        node.scenarioName ?? '',
+        node.examplesName ?? '',
+        ...(node.rowValues ?? []),
+      ])
+    }
+    case 'feature':
+      return resolveSpecificationId(uri, node.specificationName, node.tags)
+    case 'scenario':
+      return resolveScenarioId(
+        uri,
+        node.specificationName,
+        node.scenarioName ?? '',
+        node.tags,
+      )
+    case 'examples':
+      return resolveExamplesId(
+        uri,
+        node.specificationName,
+        node.scenarioName ?? '',
+        node.examplesName ?? '',
+        node.tags,
+      )
   }
-  if (node.kind === 'feature') {
-    return resolveSpecificationId(uri, node.specificationName, node.tags)
-  }
-  if (node.kind === 'scenario') {
-    return resolveScenarioId(
-      uri,
-      node.specificationName,
-      node.scenarioName ?? '',
-      node.tags,
-    )
-  }
-  return resolveExamplesId(
-    uri,
-    node.specificationName,
-    node.scenarioName ?? '',
-    node.examplesName ?? '',
-    node.tags,
-  )
 }
 
 function validateExamplesRow(

--- a/packages/spec/src/parsing/specification.ts
+++ b/packages/spec/src/parsing/specification.ts
@@ -128,32 +128,41 @@ function mapSourceArgument(step: Step): ScenarioStep['argument'] {
   return undefined
 }
 
+function addStepInfo(
+  result: Map<string, ScenarioStep>,
+  steps: readonly Step[],
+): void {
+  let previous: ScenarioStepType = 'context'
+  for (const step of steps) {
+    previous = stepType(step.keywordType, previous)
+    const argument = mapSourceArgument(step)
+    result.set(step.id, {
+      keyword: step.keyword.trim(),
+      text: step.text,
+      type: previous,
+      argument,
+    })
+  }
+}
+
+function addChildStepInfo(
+  result: Map<string, ScenarioStep>,
+  child: FeatureChild | RuleChild,
+): void {
+  if (child.background) addStepInfo(result, child.background.steps)
+  if (child.scenario) addStepInfo(result, child.scenario.steps)
+  if ('rule' in child && child.rule) {
+    for (const ruleChild of child.rule.children) {
+      addChildStepInfo(result, ruleChild)
+    }
+  }
+}
+
 function collectStepInfo(document: GherkinDocument): Map<string, ScenarioStep> {
   const result = new Map<string, ScenarioStep>()
-
-  function addSteps(steps: readonly Step[]): void {
-    let previous: ScenarioStepType = 'context'
-    for (const step of steps) {
-      previous = stepType(step.keywordType, previous)
-      const argument = mapSourceArgument(step)
-      result.set(step.id, {
-        keyword: step.keyword.trim(),
-        text: step.text,
-        type: previous,
-        argument,
-      })
-    }
-  }
-
   for (const child of document.feature?.children ?? []) {
-    if (child.background) addSteps(child.background.steps)
-    if (child.scenario) addSteps(child.scenario.steps)
-    for (const ruleChild of child.rule?.children ?? []) {
-      if (ruleChild.background) addSteps(ruleChild.background.steps)
-      if (ruleChild.scenario) addSteps(ruleChild.scenario.steps)
-    }
+    addChildStepInfo(result, child)
   }
-
   return result
 }
 
@@ -340,46 +349,57 @@ function mapScenario(
   }
 }
 
+function collectExamplesRows(
+  scenarioName: string,
+  examples: Examples,
+  rowsById: Map<string, OutlineRow>,
+): void {
+  const header = examples.tableHeader?.cells.map((cell) => cell.value) ?? []
+  const duplicate = header.find((name, index) => header.indexOf(name) !== index)
+  if (duplicate) {
+    throw new Error(
+      `Scenario Outline Examples contain duplicate variable name "${duplicate}"`,
+    )
+  }
+  const examplesTags = examples.tags.map((tag) => tag.name)
+  for (const row of examples.tableBody) {
+    rowsById.set(row.id, {
+      header,
+      cells: row.cells.map((cell) => cell.value),
+      examplesTags,
+      examplesName: examples.name,
+      scenarioName,
+    })
+  }
+}
+
+function collectChildIdentity(
+  child: FeatureChild | RuleChild,
+  scenariosById: Map<string, { tags: string[]; name: string }>,
+  rowsById: Map<string, OutlineRow>,
+): void {
+  if (child.scenario) {
+    scenariosById.set(child.scenario.id, {
+      tags: child.scenario.tags.map((tag) => tag.name),
+      name: child.scenario.name,
+    })
+    for (const examples of child.scenario.examples) {
+      collectExamplesRows(child.scenario.name, examples, rowsById)
+    }
+  }
+  if ('rule' in child && child.rule) {
+    for (const ruleChild of child.rule.children) {
+      collectChildIdentity(ruleChild, scenariosById, rowsById)
+    }
+  }
+}
+
 function collectIdentityNodes(
   document: GherkinDocument,
   scenariosById: Map<string, { tags: string[]; name: string }>,
   rowsById: Map<string, OutlineRow>,
 ): void {
-  function visitExamples(scenarioName: string, examples: Examples): void {
-    const header = examples.tableHeader?.cells.map((cell) => cell.value) ?? []
-    const duplicate = header.find(
-      (name, index) => header.indexOf(name) !== index,
-    )
-    if (duplicate) {
-      throw new Error(
-        `Scenario Outline Examples contain duplicate variable name "${duplicate}"`,
-      )
-    }
-    const examplesTags = examples.tags.map((tag) => tag.name)
-    for (const row of examples.tableBody) {
-      rowsById.set(row.id, {
-        header,
-        cells: row.cells.map((cell) => cell.value),
-        examplesTags,
-        examplesName: examples.name,
-        scenarioName,
-      })
-    }
+  for (const child of document.feature?.children ?? []) {
+    collectChildIdentity(child, scenariosById, rowsById)
   }
-
-  function visitChild(child: FeatureChild | RuleChild): void {
-    if (child.scenario) {
-      scenariosById.set(child.scenario.id, {
-        tags: child.scenario.tags.map((tag) => tag.name),
-        name: child.scenario.name,
-      })
-      for (const examples of child.scenario.examples)
-        visitExamples(child.scenario.name, examples)
-    }
-    if ('rule' in child && child.rule) {
-      for (const ruleChild of child.rule.children) visitChild(ruleChild)
-    }
-  }
-
-  for (const child of document.feature?.children ?? []) visitChild(child)
 }

--- a/packages/studio/src/authoring/documents.ts
+++ b/packages/studio/src/authoring/documents.ts
@@ -136,6 +136,48 @@ export function createSpecificationWorkspace(
     }
   }
 
+  async function validateWriteTarget(input: {
+    uri: string
+    expectedRevision?: string
+    create?: boolean
+  }): Promise<string> {
+    const path = resolveUri(input.uri)
+    const file = Bun.file(path)
+    const exists = await file.exists()
+    if (!exists) {
+      if (!input.create)
+        throw new Error(`Specification ${input.uri} was not found`)
+      return path
+    }
+    const diskSource = await file.text()
+    const revision = revisionFor(diskSource)
+    if (
+      input.create ||
+      (input.expectedRevision !== undefined &&
+        revision !== input.expectedRevision)
+    ) {
+      throw new DocumentConflictError({ uri: input.uri, diskSource, revision })
+    }
+    return path
+  }
+
+  async function collectCompletions(
+    pattern: string,
+    tags: Set<string>,
+    steps: Set<string>,
+  ): Promise<void> {
+    for await (const path of new Bun.Glob(pattern).scan({
+      cwd: root,
+      onlyFiles: true,
+    })) {
+      const catalog = catalogFromSource(
+        await Bun.file(resolve(root, path)).text(),
+      )
+      for (const tag of catalog.tags) tags.add(tag)
+      for (const step of catalog.steps) steps.add(step)
+    }
+  }
+
   return {
     async read(uri) {
       const path = resolveUri(uri)
@@ -168,34 +210,7 @@ export function createSpecificationWorkspace(
     },
 
     async write(input) {
-      const path = resolveUri(input.uri)
-      const file = Bun.file(path)
-      const exists = await file.exists()
-      if (input.create && exists) {
-        const diskSource = await file.text()
-        throw new DocumentConflictError({
-          uri: input.uri,
-          diskSource,
-          revision: revisionFor(diskSource),
-        })
-      }
-      if (!input.create && !exists) {
-        throw new Error(`Specification ${input.uri} was not found`)
-      }
-      if (!input.create && exists) {
-        const diskSource = await file.text()
-        const revision = revisionFor(diskSource)
-        if (
-          input.expectedRevision !== undefined &&
-          revision !== input.expectedRevision
-        ) {
-          throw new DocumentConflictError({
-            uri: input.uri,
-            diskSource,
-            revision,
-          })
-        }
-      }
+      const path = await validateWriteTarget(input)
       const source = applySpecificationSource({
         uri: input.uri,
         source: input.source,
@@ -229,16 +244,7 @@ export function createSpecificationWorkspace(
       const tags = new Set<string>()
       const steps = new Set<string>()
       for (const pattern of globs) {
-        for await (const path of new Bun.Glob(pattern).scan({
-          cwd: root,
-          onlyFiles: true,
-        })) {
-          const catalog = catalogFromSource(
-            await Bun.file(resolve(root, path)).text(),
-          )
-          for (const tag of catalog.tags) tags.add(tag)
-          for (const step of catalog.steps) steps.add(step)
-        }
+        await collectCompletions(pattern, tags, steps)
       }
       return {
         tags: [...tags].sort((left, right) => left.localeCompare(right)),

--- a/packages/studio/src/authoring/specification-editor.tsx
+++ b/packages/studio/src/authoring/specification-editor.tsx
@@ -231,7 +231,15 @@ export function SpecificationEditor(props: {
       setConflict(nextConflict)
       return
     }
-    if (options.create && options.uri && options.uri !== buffer.uri) {
+    await acceptWrittenSpecification(written, options, buffer.uri)
+  }
+
+  async function acceptWrittenSpecification(
+    written: SpecificationBuffer,
+    options: { create?: boolean; uri?: string },
+    currentUri: string,
+  ) {
+    if (options.create && options.uri && options.uri !== currentUri) {
       setReview(undefined)
       setConflict(undefined)
       await props.onCatalogChange()

--- a/packages/studio/src/components/ui/scroll-area.tsx
+++ b/packages/studio/src/components/ui/scroll-area.tsx
@@ -7,6 +7,17 @@ type ScrollAreaProps = ScrollAreaPrimitive.Root.Props & {
   viewportProps?: ScrollAreaPrimitive.Viewport.Props
 }
 
+function horizontalScrollLeft(
+  viewport: HTMLDivElement,
+  key: string,
+): number | undefined {
+  if (key === 'ArrowRight') return viewport.scrollLeft + 44
+  if (key === 'ArrowLeft') return viewport.scrollLeft - 44
+  if (key === 'Home') return 0
+  if (key === 'End') return viewport.scrollWidth
+  return undefined
+}
+
 function ScrollArea({
   className,
   children,
@@ -25,16 +36,7 @@ function ScrollArea({
       return
     }
     const viewport = event.currentTarget
-    const nextScrollLeft =
-      event.key === 'ArrowRight'
-        ? viewport.scrollLeft + 44
-        : event.key === 'ArrowLeft'
-          ? viewport.scrollLeft - 44
-          : event.key === 'Home'
-            ? 0
-            : event.key === 'End'
-              ? viewport.scrollWidth
-              : undefined
+    const nextScrollLeft = horizontalScrollLeft(viewport, event.key)
     if (nextScrollLeft === undefined) return
     event.preventDefault()
     viewport.scrollLeft = nextScrollLeft

--- a/packages/studio/src/runs/result/artifact-viewer.tsx
+++ b/packages/studio/src/runs/result/artifact-viewer.tsx
@@ -1,5 +1,5 @@
 import type { TestArtifact, TestResultState } from '@pickle-spec/runner'
-import { useEffect, useRef, useState } from 'react'
+import { type ChangeEvent, useEffect, useRef, useState } from 'react'
 import { Button, ButtonLink } from '../../components/ui/button'
 import { Input } from '../../components/ui/input'
 import { Label } from '../../components/ui/label'
@@ -25,9 +25,50 @@ type TextLoadState =
 
 const maximumInlineLogBytes = 10 * 1024 * 1024
 const maximumRenderedLogLines = 1_000
+const oversizedLogDetail =
+  'This log is larger than the 10 MiB inline-view limit. Download it to inspect the complete file.'
 
 function errorMessage(reason: unknown): string {
   return reason instanceof Error ? reason.message : String(reason)
+}
+
+function failedResponse(response: Response): TextLoadState {
+  return {
+    kind: 'error',
+    failure: response.status === 404 ? 'missing' : 'load-failed',
+    detail: `Artifact request returned ${response.status}.`,
+  }
+}
+
+function oversizedLog(
+  sizeBytes: number | undefined,
+): TextLoadState | undefined {
+  return sizeBytes !== undefined && sizeBytes > maximumInlineLogBytes
+    ? { kind: 'error', failure: 'load-failed', detail: oversizedLogDetail }
+    : undefined
+}
+
+async function fetchTextArtifact(
+  href: string,
+  signal: AbortSignal,
+): Promise<TextLoadState> {
+  const metadata = await fetch(href, { method: 'HEAD', signal })
+  if (!metadata.ok) return failedResponse(metadata)
+  const contentLength = Number(metadata.headers.get('content-length'))
+  if (Number.isFinite(contentLength) && contentLength > maximumInlineLogBytes) {
+    return { kind: 'error', failure: 'load-failed', detail: oversizedLogDetail }
+  }
+  const response = await fetch(href, { signal })
+  if (!response.ok) return failedResponse(response)
+  const bytes = await response.arrayBuffer()
+  try {
+    return {
+      kind: 'loaded',
+      text: new TextDecoder('utf-8', { fatal: true }).decode(bytes),
+    }
+  } catch {
+    return { kind: 'error', failure: 'corrupt' }
+  }
 }
 
 async function classifyMediaFailure(
@@ -137,16 +178,9 @@ function TextArtifact(props: ArtifactViewerProps) {
   )
 
   async function loadText() {
-    if (
-      props.artifact.sizeBytes !== undefined &&
-      props.artifact.sizeBytes > maximumInlineLogBytes
-    ) {
-      setLoadState({
-        kind: 'error',
-        failure: 'load-failed',
-        detail:
-          'This log is larger than the 10 MiB inline-view limit. Download it to inspect the complete file.',
-      })
+    const sizeFailure = oversizedLog(props.artifact.sizeBytes)
+    if (sizeFailure) {
+      setLoadState(sizeFailure)
       return
     }
     request.current?.abort()
@@ -154,52 +188,12 @@ function TextArtifact(props: ArtifactViewerProps) {
     request.current = controller
     setLoadState({ kind: 'loading' })
     try {
-      const href = artifactUrl(props.artifact.path)
-      const metadata = await fetch(href, {
-        method: 'HEAD',
-        signal: controller.signal,
-      })
-      if (!metadata.ok) {
-        setLoadState({
-          kind: 'error',
-          failure: metadata.status === 404 ? 'missing' : 'load-failed',
-          detail: `Artifact request returned ${metadata.status}.`,
-        })
-        return
-      }
-      const contentLength = Number(metadata.headers.get('content-length'))
-      if (
-        Number.isFinite(contentLength) &&
-        contentLength > maximumInlineLogBytes
-      ) {
-        setLoadState({
-          kind: 'error',
-          failure: 'load-failed',
-          detail:
-            'This log is larger than the 10 MiB inline-view limit. Download it to inspect the complete file.',
-        })
-        return
-      }
-      const response = await fetch(href, {
-        signal: controller.signal,
-      })
-      if (!response.ok) {
-        setLoadState({
-          kind: 'error',
-          failure: response.status === 404 ? 'missing' : 'load-failed',
-          detail: `Artifact request returned ${response.status}.`,
-        })
-        return
-      }
-      const bytes = await response.arrayBuffer()
-      try {
-        setLoadState({
-          kind: 'loaded',
-          text: new TextDecoder('utf-8', { fatal: true }).decode(bytes),
-        })
-      } catch {
-        setLoadState({ kind: 'error', failure: 'corrupt' })
-      }
+      setLoadState(
+        await fetchTextArtifact(
+          artifactUrl(props.artifact.path),
+          controller.signal,
+        ),
+      )
     } catch (reason) {
       if (controller.signal.aborted) return
       setLoadState({
@@ -211,34 +205,63 @@ function TextArtifact(props: ArtifactViewerProps) {
   }
 
   if (loadState.kind !== 'loaded') {
-    return (
-      <div className="flex min-h-32 flex-col items-center justify-center gap-3 rounded-md border border-dashed border-border px-4 text-center text-muted-foreground">
-        <p>
-          {loadState.kind === 'error'
-            ? artifactLoadFailureGuidance(loadState.failure)
-            : 'The device log stays unloaded until you need to search it.'}
-        </p>
-        {loadState.kind === 'error' && loadState.detail ? (
-          <p className="break-words text-xs">{loadState.detail}</p>
-        ) : null}
-        <Button
-          type="button"
-          variant="outline"
-          disabled={loadState.kind === 'loading'}
-          onClick={() => void loadText()}
-        >
-          {loadState.kind === 'loading'
-            ? 'Loading device log…'
-            : loadState.kind === 'error'
-              ? 'Retry loading device log'
-              : 'Load device log'}
-        </Button>
-      </div>
-    )
+    return <UnloadedTextArtifact state={loadState} onLoad={loadText} />
   }
 
-  const normalizedQuery = query.toLocaleLowerCase()
-  const matchingLines = loadState.text
+  return (
+    <LoadedTextArtifact
+      artifactPath={props.artifact.path}
+      text={loadState.text}
+      query={query}
+      onQueryChange={setQuery}
+    />
+  )
+}
+
+function UnloadedTextArtifact(props: {
+  state: Exclude<TextLoadState, { kind: 'loaded' }>
+  onLoad: () => Promise<void>
+}) {
+  const guidance =
+    props.state.kind === 'error'
+      ? artifactLoadFailureGuidance(props.state.failure)
+      : 'The device log stays unloaded until you need to search it.'
+  const label =
+    props.state.kind === 'loading'
+      ? 'Loading device log…'
+      : props.state.kind === 'error'
+        ? 'Retry loading device log'
+        : 'Load device log'
+  return (
+    <div className="flex min-h-32 flex-col items-center justify-center gap-3 rounded-md border border-dashed border-border px-4 text-center text-muted-foreground">
+      <p>{guidance}</p>
+      {props.state.kind === 'error' && props.state.detail ? (
+        <p className="break-words text-xs">{props.state.detail}</p>
+      ) : null}
+      <Button
+        type="button"
+        variant="outline"
+        disabled={props.state.kind === 'loading'}
+        onClick={() => void props.onLoad()}
+      >
+        {label}
+      </Button>
+    </div>
+  )
+}
+
+function LoadedTextArtifact(props: {
+  artifactPath: string
+  text: string
+  query: string
+  onQueryChange: (query: string) => void
+}) {
+  function handleQueryChange(event: ChangeEvent<HTMLInputElement>) {
+    props.onQueryChange(event.target.value)
+  }
+
+  const normalizedQuery = props.query.toLocaleLowerCase()
+  const matchingLines = props.text
     .split('\n')
     .filter(
       (line) =>
@@ -248,14 +271,14 @@ function TextArtifact(props: ArtifactViewerProps) {
   return (
     <div className="min-w-0 space-y-3">
       <div className="space-y-1">
-        <Label htmlFor={`device-log-search-${props.artifact.path}`}>
+        <Label htmlFor={`device-log-search-${props.artifactPath}`}>
           Search device log
         </Label>
         <Input
-          id={`device-log-search-${props.artifact.path}`}
+          id={`device-log-search-${props.artifactPath}`}
           type="search"
-          value={query}
-          onChange={(event) => setQuery(event.target.value)}
+          value={props.query}
+          onChange={handleQueryChange}
           placeholder="Find text in the complete log"
         />
       </div>

--- a/packages/studio/src/runs/result/live-result-projection.ts
+++ b/packages/studio/src/runs/result/live-result-projection.ts
@@ -160,26 +160,24 @@ function projectResults(input: ProjectLiveSnapshotInput): TestResult[] {
   for (const event of input.events) {
     if (event.type !== 'scenario-finished') continue
     finishedKeys.add(attemptKey(event.scope))
-    const identity = resultIdentityKey(event.scope)
-    const existing = finished.get(identity)
-    if (existing) {
-      const attempts = [...existing.attempts, event.attempt].sort(
-        (left, right) => left.attempt - right.attempt,
-      )
-      const final = attempts.at(-1)
-      if (!final) continue
-      finished.set(identity, {
-        ...existing,
-        attempts,
-        state: final.state,
-        finishedAt: final.finishedAt,
-        durationMs: Math.max(
-          0,
-          Date.parse(final.finishedAt) - Date.parse(existing.startedAt),
-        ),
-      })
-      continue
-    }
+    appendFinishedResult(finished, event)
+  }
+  const inProgress: TestResult[] = []
+  for (const event of input.events) {
+    if (event.type !== 'scenario-started') continue
+    if (finishedKeys.has(attemptKey(event.scope))) continue
+    inProgress.push(projectInProgressResult(input, event, liveDiagnostics))
+  }
+  return [...finished.values(), ...inProgress]
+}
+
+function appendFinishedResult(
+  finished: Map<string, TestResult>,
+  event: Extract<RunEvent, { type: 'scenario-finished' }>,
+): void {
+  const identity = resultIdentityKey(event.scope)
+  const existing = finished.get(identity)
+  if (!existing) {
     finished.set(identity, {
       schemaVersion: 2,
       specification: event.specification,
@@ -191,55 +189,69 @@ function projectResults(input: ProjectLiveSnapshotInput): TestResult[] {
       durationMs: event.attempt.durationMs,
       attempts: [event.attempt],
     })
+    return
   }
-  const inProgress: TestResult[] = []
-  for (const event of input.events) {
-    if (event.type !== 'scenario-started') continue
-    if (finishedKeys.has(attemptKey(event.scope))) continue
-    const steps = inProgressSteps(input.events, event, liveDiagnostics)
-    const latest = steps.at(-1)
-    const durationMs = latest
-      ? Math.max(
-          0,
-          Date.parse(latest.finishedAt) - Date.parse(event.occurredAt),
-        )
-      : 0
-    const finishedAt = latest?.finishedAt ?? event.occurredAt
-    const scheduled = scheduledResultFor(input.schedule, event)
-    inProgress.push({
-      schemaVersion: 2,
-      specification: scheduled?.specification ?? {
-        name: input.specificationUri,
-        uri: input.specificationUri,
+  const attempts = [...existing.attempts, event.attempt].sort(
+    (left, right) => left.attempt - right.attempt,
+  )
+  const final = attempts.at(-1)
+  if (!final) return
+  finished.set(identity, {
+    ...existing,
+    attempts,
+    state: final.state,
+    finishedAt: final.finishedAt,
+    durationMs: Math.max(
+      0,
+      Date.parse(final.finishedAt) - Date.parse(existing.startedAt),
+    ),
+  })
+}
+
+function projectInProgressResult(
+  input: ProjectLiveSnapshotInput,
+  event: Extract<RunEvent, { type: 'scenario-started' }>,
+  liveDiagnostics: NonNullable<ProjectLiveSnapshotInput['liveDiagnostics']>,
+): TestResult {
+  const steps = inProgressSteps(input.events, event, liveDiagnostics)
+  const latest = steps.at(-1)
+  const finishedAt = latest?.finishedAt ?? event.occurredAt
+  const durationMs = latest
+    ? Math.max(0, Date.parse(finishedAt) - Date.parse(event.occurredAt))
+    : 0
+  const scheduled = scheduledResultFor(input.schedule, event)
+  return {
+    schemaVersion: 2,
+    specification: scheduled?.specification ?? {
+      name: input.specificationUri,
+      uri: input.specificationUri,
+    },
+    scenario: event.scenario,
+    executionTargetProfile: event.executionTargetProfile,
+    state: latest?.state ?? 'passed',
+    startedAt: event.occurredAt,
+    finishedAt,
+    durationMs,
+    attempts: [
+      {
+        attempt: event.scope.attempt,
+        startedAt: event.occurredAt,
+        finishedAt,
+        durationMs,
+        state: latest?.state ?? 'passed',
+        steps,
+        evidenceAvailability: liveEvidenceAvailability(steps),
+        diagnostics: liveDiagnostics
+          .filter(
+            (entry) =>
+              entry.scope &&
+              sameAttemptScope(entry.scope, event.scope) &&
+              entry.diagnostic.stepIndex === undefined,
+          )
+          .map((entry) => entry.diagnostic),
       },
-      scenario: event.scenario,
-      executionTargetProfile: event.executionTargetProfile,
-      state: latest?.state ?? 'passed',
-      startedAt: event.occurredAt,
-      finishedAt,
-      durationMs,
-      attempts: [
-        {
-          attempt: event.scope.attempt,
-          startedAt: event.occurredAt,
-          finishedAt,
-          durationMs,
-          state: latest?.state ?? 'passed',
-          steps,
-          evidenceAvailability: liveEvidenceAvailability(steps),
-          diagnostics: liveDiagnostics
-            .filter(
-              (entry) =>
-                entry.scope &&
-                sameAttemptScope(entry.scope, event.scope) &&
-                entry.diagnostic.stepIndex === undefined,
-            )
-            .map((entry) => entry.diagnostic),
-        },
-      ],
-    })
+    ],
   }
-  return [...finished.values(), ...inProgress]
 }
 
 function scheduledResultFor(

--- a/packages/studio/src/runs/result/result-evidence-panels.tsx
+++ b/packages/studio/src/runs/result/result-evidence-panels.tsx
@@ -41,6 +41,24 @@ const diagnosticOrigins = [
   'application',
 ] as const satisfies readonly DiagnosticOrigin[]
 
+function hasDiagnosticFilters(filters: readonly unknown[]): boolean {
+  return filters.some(Boolean)
+}
+
+function diagnosticAvailability(
+  availability: readonly EvidenceAvailability[],
+): { description: string; recovery?: string } {
+  const diagnostics = availability.find((item) => item.kind === 'diagnostics')
+  const description = diagnostics?.message
+    ? `${diagnostics.state} · ${diagnostics.message}`
+    : (diagnostics?.state ?? 'Not recorded')
+  const recovery =
+    diagnostics && diagnostics.state !== 'available'
+      ? recoveryGuidance(diagnostics.state)
+      : undefined
+  return { description, recovery }
+}
+
 type MetadataProps = {
   label: string
   value: string
@@ -289,16 +307,7 @@ export function ResultDiagnostics(props: ResultDiagnosticsProps) {
   const [scenarioId, setScenarioId] = useState('')
   const [stepIndex, setStepIndex] = useState('')
   const [executionTargetProfileId, setExecutionTargetProfileId] = useState('')
-  const diagnosticsAvailability = props.availability.find(
-    (item) => item.kind === 'diagnostics',
-  )
-  const availabilityDescription = diagnosticsAvailability?.message
-    ? `${diagnosticsAvailability.state} · ${diagnosticsAvailability.message}`
-    : (diagnosticsAvailability?.state ?? 'Not recorded')
-  const availabilityRecovery =
-    diagnosticsAvailability && diagnosticsAvailability.state !== 'available'
-      ? recoveryGuidance(diagnosticsAvailability.state)
-      : undefined
+  const availability = diagnosticAvailability(props.availability)
   const parsedStepIndex = stepIndex === '' ? undefined : Number(stepIndex)
   const diagnostics = useMemo(
     () =>
@@ -330,14 +339,14 @@ export function ResultDiagnostics(props: ResultDiagnosticsProps) {
     stepIndex,
     executionTargetProfileId,
   ].join(':')
-  const hasFilters = Boolean(
-    query ||
-      level ||
-      origin ||
-      scenarioId ||
-      stepIndex ||
-      executionTargetProfileId,
-  )
+  const hasFilters = hasDiagnosticFilters([
+    query,
+    level,
+    origin,
+    scenarioId,
+    stepIndex,
+    executionTargetProfileId,
+  ])
 
   function clearFilters() {
     setQuery('')
@@ -353,9 +362,9 @@ export function ResultDiagnostics(props: ResultDiagnosticsProps) {
         <CardHeader>
           <CardTitle>Diagnostics availability</CardTitle>
           <CardDescription>
-            <span>{availabilityDescription}</span>
-            {availabilityRecovery ? (
-              <span className="block">{availabilityRecovery}</span>
+            <span>{availability.description}</span>
+            {availability.recovery ? (
+              <span className="block">{availability.recovery}</span>
             ) : null}
           </CardDescription>
         </CardHeader>

--- a/packages/studio/src/runs/result/result-evidence-timeline.tsx
+++ b/packages/studio/src/runs/result/result-evidence-timeline.tsx
@@ -23,6 +23,18 @@ type ResultEvidenceTimelineProps = {
   onPauseFollowing?: () => void
 }
 
+function selectedTimelineEntry(
+  entries: readonly TimelineEntry[],
+  activeEntryId: string | undefined,
+  causalEntry: TimelineEntry | undefined,
+): TimelineEntry | undefined {
+  return (
+    entries.find((entry) => entry.id === activeEntryId) ??
+    causalEntry ??
+    entries.at(-1)
+  )
+}
+
 export function ResultEvidenceTimeline(props: ResultEvidenceTimelineProps) {
   const [selectedEntryId, setSelectedEntryId] = useState<string>()
   const causalEntry = causalTimelineEntry(props.entries)
@@ -32,10 +44,11 @@ export function ResultEvidenceTimeline(props: ResultEvidenceTimelineProps) {
     props.follow === true
       ? followedEntryId
       : (selectedEntryId ?? followedEntryId)
-  const selectedEntry =
-    props.entries.find((entry) => entry.id === activeEntryId) ??
-    causalEntry ??
-    props.entries.at(-1)
+  const selectedEntry = selectedTimelineEntry(
+    props.entries,
+    activeEntryId,
+    causalEntry,
+  )
   const causalPointUnavailable =
     !props.entries.some((entry) => entry.causalAt) &&
     (props.state === 'failed' || props.state === 'infrastructure-error')

--- a/packages/studio/src/runs/result/result-evidence.ts
+++ b/packages/studio/src/runs/result/result-evidence.ts
@@ -345,6 +345,75 @@ export function artifactLoadFailureGuidance(
   return artifactLoadGuidance[failure]
 }
 
+function diagnosticTimelineEntry(
+  diagnostic: DiagnosticEvidence,
+  causalAt: string | undefined,
+  entryId: (suffix: string) => string,
+): TimelineEntry {
+  return {
+    id: entryId(`diagnostic-${diagnostic.id}`),
+    startedAt: diagnostic.occurredAt,
+    timingPrecision: diagnostic.timingPrecision,
+    kind: 'Diagnostic entry',
+    title: diagnostic.message,
+    context: diagnostic.stepText ?? diagnostic.source,
+    state: diagnostic.level,
+    causalAt: diagnostic.causalAt,
+    causal: Boolean(causalAt && diagnostic.causalAt === causalAt),
+    attributes: [
+      { label: 'Origin', value: diagnostic.origin },
+      { label: 'Source', value: diagnostic.source },
+      ...(diagnostic.stream
+        ? [{ label: 'Stream', value: diagnostic.stream }]
+        : []),
+      ...(diagnostic.scenarioId
+        ? [{ label: 'Scenario ID', value: diagnostic.scenarioId }]
+        : []),
+      ...(diagnostic.scenarioName
+        ? [{ label: 'Scenario', value: diagnostic.scenarioName }]
+        : []),
+      ...(diagnostic.stepIndex === undefined
+        ? []
+        : [{ label: 'Step index', value: String(diagnostic.stepIndex) }]),
+      ...(diagnostic.executionTargetProfileId
+        ? [
+            {
+              label: 'Execution target',
+              value: diagnostic.executionTargetProfileId,
+            },
+          ]
+        : []),
+    ],
+  }
+}
+
+function artifactTimelineEntry(
+  step: ScenarioAttempt['steps'][number],
+  artifact: TestArtifact,
+  index: number,
+  entryId: (suffix: string) => string,
+): TimelineEntry {
+  return {
+    id: entryId(`artifact-${step.index}-${index}`),
+    startedAt: artifact.capturedAt ?? step.finishedAt,
+    timingPrecision: artifact.capturedAt ? 'exact' : 'step-finish',
+    kind: 'Test artifact',
+    title: artifact.kind,
+    context: `${step.step.keyword.trim()} ${step.step.text}`,
+    attributes: [
+      { label: 'Artifact kind', value: artifact.kind },
+      { label: 'Step index', value: String(step.index) },
+      ...(artifact.name ? [{ label: 'Name', value: artifact.name }] : []),
+      ...(artifact.mediaType
+        ? [{ label: 'Media type', value: artifact.mediaType }]
+        : []),
+      ...(artifact.sizeBytes === undefined
+        ? []
+        : [{ label: 'Size', value: `${artifact.sizeBytes} bytes` }]),
+    ],
+  }
+}
+
 export function timelineFor(
   events: readonly RunEvent[],
   attempt: ScenarioAttempt,
@@ -434,62 +503,12 @@ export function timelineFor(
     }))
   })
   const diagnosticEntries: TimelineEntry[] = diagnosticsFor(attempt).map(
-    (diagnostic) => ({
-      id: entryId(`diagnostic-${diagnostic.id}`),
-      startedAt: diagnostic.occurredAt,
-      timingPrecision: diagnostic.timingPrecision,
-      kind: 'Diagnostic entry',
-      title: diagnostic.message,
-      context: diagnostic.stepText ?? diagnostic.source,
-      state: diagnostic.level,
-      causalAt: diagnostic.causalAt,
-      causal: Boolean(causalAt && diagnostic.causalAt === causalAt),
-      attributes: [
-        { label: 'Origin', value: diagnostic.origin },
-        { label: 'Source', value: diagnostic.source },
-        ...(diagnostic.stream
-          ? [{ label: 'Stream', value: diagnostic.stream }]
-          : []),
-        ...(diagnostic.scenarioId
-          ? [{ label: 'Scenario ID', value: diagnostic.scenarioId }]
-          : []),
-        ...(diagnostic.scenarioName
-          ? [{ label: 'Scenario', value: diagnostic.scenarioName }]
-          : []),
-        ...(diagnostic.stepIndex === undefined
-          ? []
-          : [{ label: 'Step index', value: String(diagnostic.stepIndex) }]),
-        ...(diagnostic.executionTargetProfileId
-          ? [
-              {
-                label: 'Execution target',
-                value: diagnostic.executionTargetProfileId,
-              },
-            ]
-          : []),
-      ],
-    }),
+    (diagnostic) => diagnosticTimelineEntry(diagnostic, causalAt, entryId),
   )
   const artifactEntries: TimelineEntry[] = attempt.steps.flatMap((step) =>
-    (step.artifacts ?? []).map((artifact, index) => ({
-      id: entryId(`artifact-${step.index}-${index}`),
-      startedAt: artifact.capturedAt ?? step.finishedAt,
-      timingPrecision: artifact.capturedAt ? 'exact' : 'step-finish',
-      kind: 'Test artifact',
-      title: artifact.kind,
-      context: `${step.step.keyword.trim()} ${step.step.text}`,
-      attributes: [
-        { label: 'Artifact kind', value: artifact.kind },
-        { label: 'Step index', value: String(step.index) },
-        ...(artifact.name ? [{ label: 'Name', value: artifact.name }] : []),
-        ...(artifact.mediaType
-          ? [{ label: 'Media type', value: artifact.mediaType }]
-          : []),
-        ...(artifact.sizeBytes === undefined
-          ? []
-          : [{ label: 'Size', value: `${artifact.sizeBytes} bytes` }]),
-      ],
-    })),
+    (step.artifacts ?? []).map((artifact, index) =>
+      artifactTimelineEntry(step, artifact, index, entryId),
+    ),
   )
   const kindOrder: Record<TimelineEntry['kind'], number> = {
     Step: 0,

--- a/packages/studio/src/runs/result/result-inspector.tsx
+++ b/packages/studio/src/runs/result/result-inspector.tsx
@@ -48,22 +48,21 @@ type ResultInspectorProps = {
   onPauseFollowing?: () => void
 }
 
-export function ResultInspector(props: ResultInspectorProps) {
-  const [fetched, setFetched] = useState<StudioRunSnapshot>()
+function useFetchedRunSnapshot(props: ResultInspectorProps) {
+  const [snapshot, setSnapshot] = useState<StudioRunSnapshot>()
   const [error, setError] = useState<string>()
-
   useEffect(() => {
     if (props.snapshot) return
     let cancelled = false
-    setFetched(undefined)
+    setSnapshot(undefined)
     setError(undefined)
-    props
+    void props
       .api<StudioRunSnapshot>(
         `/api/runs/${encodeURIComponent(props.location.runId)}`,
       )
       .then(
         (value) => {
-          if (!cancelled) setFetched(value)
+          if (!cancelled) setSnapshot(value)
         },
         (reason: unknown) => {
           if (!cancelled) setError(reasonMessage(reason))
@@ -73,17 +72,21 @@ export function ResultInspector(props: ResultInspectorProps) {
       cancelled = true
     }
   }, [props.api, props.location.runId, props.snapshot])
+  return { snapshot, error }
+}
 
-  const snapshot = props.snapshot ?? fetched
+export function ResultInspector(props: ResultInspectorProps) {
+  const fetched = useFetchedRunSnapshot(props)
+  const snapshot = props.snapshot ?? fetched.snapshot
   const inspected = snapshot
     ? findInspectedResult(snapshot, props.location)
     : undefined
 
-  if (error) {
+  if (fetched.error) {
     return (
       <div className="p-4">
         <p role="alert" className="text-sm text-destructive">
-          {error}
+          {fetched.error}
         </p>
       </div>
     )
@@ -109,7 +112,18 @@ export function ResultInspector(props: ResultInspectorProps) {
       </div>
     )
   }
+  return (
+    <InspectedResultView {...props} snapshot={snapshot} inspected={inspected} />
+  )
+}
 
+function InspectedResultView(
+  props: ResultInspectorProps & {
+    snapshot: StudioRunSnapshot
+    inspected: NonNullable<ReturnType<typeof findInspectedResult>>
+  },
+) {
+  const { snapshot, inspected } = props
   const displayState = displayedAttemptState(inspected.attempt)
   const inProgress = isAttemptInProgress(inspected.attempt)
   const activeTab =

--- a/packages/studio/src/runs/result/timeline-waterfall.tsx
+++ b/packages/studio/src/runs/result/timeline-waterfall.tsx
@@ -1,4 +1,10 @@
-import { type KeyboardEvent, useEffect, useRef, useState } from 'react'
+import {
+  type KeyboardEvent,
+  type RefObject,
+  useEffect,
+  useRef,
+  useState,
+} from 'react'
 import { Button } from '../../components/ui/button'
 import { ScrollArea } from '../../components/ui/scroll-area'
 import { cn } from '../../lib/utils'
@@ -81,6 +87,82 @@ type TimelineLabelsProps = TimelineWaterfallProps & {
   onMoveFocus: (event: KeyboardEvent, index: number) => void
 }
 
+function TimelineLabelEntry(
+  props: TimelineWaterfallProps & {
+    entry: TimelineEntry
+    entryIndex: number
+    totalEntries: number
+    followedRef: RefObject<HTMLLIElement | null>
+    onMoveFocus: (event: KeyboardEvent, index: number) => void
+  },
+) {
+  const selected = props.entry.id === props.selectedEntryId
+  function handleClick() {
+    props.onSelect(props.entry.id)
+  }
+  function handleKeyDown(event: KeyboardEvent) {
+    props.onMoveFocus(event, props.entryIndex)
+  }
+  return (
+    <li
+      ref={
+        props.entry.id === props.followedEntryId ? props.followedRef : undefined
+      }
+      aria-posinset={props.entryIndex + 1}
+      aria-setsize={props.totalEntries}
+      className="h-11 border-b border-border last:border-b-0"
+    >
+      <Button
+        type="button"
+        variant="ghost"
+        aria-label={`${props.entry.kind} ${props.entry.title}, ${relativeTimeLabel(props.entry.startedAt, props.attemptStartedAt)}`}
+        aria-pressed={selected}
+        data-timeline-index={props.entryIndex}
+        tabIndex={selected ? 0 : -1}
+        onClick={handleClick}
+        onKeyDown={handleKeyDown}
+        className={cn(
+          'h-full w-full min-w-0 justify-start rounded-none px-3 text-left',
+          selected && 'bg-secondary text-foreground',
+          props.entry.causal && 'text-destructive',
+        )}
+      >
+        <span
+          className={cn(
+            'flex size-6 shrink-0 items-center justify-center rounded-md',
+            timelineKindSolidClassName(props.entry.kind),
+          )}
+        >
+          <TimelineKindIcon kind={props.entry.kind} className="size-3.5" />
+        </span>
+        <span className="min-w-0 flex-1">
+          <span className="block truncate text-xs font-medium text-current">
+            {props.entry.title}
+          </span>
+          <span className="mt-0.5 flex items-center gap-1.5 text-[0.625rem] text-muted-foreground">
+            <span className="truncate">{props.entry.kind}</span>
+            <span aria-hidden="true">·</span>
+            <span className="shrink-0 font-mono tabular-nums">
+              {relativeTimeLabel(props.entry.startedAt, props.attemptStartedAt)}
+            </span>
+          </span>
+        </span>
+        {props.entry.causal ? (
+          <>
+            <span className="sr-only">
+              {props.entry.causalAt ? 'Causal point' : 'Failure context'}
+            </span>
+            <span
+              aria-hidden="true"
+              className="size-1.5 shrink-0 rounded-full bg-destructive"
+            />
+          </>
+        ) : null}
+      </Button>
+    </li>
+  )
+}
+
 function TimelineLabels(props: TimelineLabelsProps) {
   const followedRef = useRef<HTMLLIElement>(null)
   useEffect(() => {
@@ -93,70 +175,15 @@ function TimelineLabels(props: TimelineLabelsProps) {
         Evidence
       </div>
       <ol aria-label="Execution timeline">
-        {props.entries.map((entry, visibleIndex) => {
-          const entryIndex = props.entryOffset + visibleIndex
-          return (
-            <li
-              key={entry.id}
-              ref={entry.id === props.followedEntryId ? followedRef : undefined}
-              aria-posinset={entryIndex + 1}
-              aria-setsize={props.totalEntries}
-              className="h-11 border-b border-border last:border-b-0"
-            >
-              <Button
-                type="button"
-                variant="ghost"
-                aria-label={`${entry.kind} ${entry.title}, ${relativeTimeLabel(entry.startedAt, props.attemptStartedAt)}`}
-                aria-pressed={entry.id === props.selectedEntryId}
-                data-timeline-index={entryIndex}
-                tabIndex={entry.id === props.selectedEntryId ? 0 : -1}
-                onClick={() => props.onSelect(entry.id)}
-                onKeyDown={(event) => props.onMoveFocus(event, entryIndex)}
-                className={cn(
-                  'h-full w-full min-w-0 justify-start rounded-none px-3 text-left',
-                  entry.id === props.selectedEntryId &&
-                    'bg-secondary text-foreground',
-                  entry.causal && 'text-destructive',
-                )}
-              >
-                <span
-                  className={cn(
-                    'flex size-6 shrink-0 items-center justify-center rounded-md',
-                    timelineKindSolidClassName(entry.kind),
-                  )}
-                >
-                  <TimelineKindIcon kind={entry.kind} className="size-3.5" />
-                </span>
-                <span className="min-w-0 flex-1">
-                  <span className="block truncate text-xs font-medium text-current">
-                    {entry.title}
-                  </span>
-                  <span className="mt-0.5 flex items-center gap-1.5 text-[0.625rem] text-muted-foreground">
-                    <span className="truncate">{entry.kind}</span>
-                    <span aria-hidden="true">·</span>
-                    <span className="shrink-0 font-mono tabular-nums">
-                      {relativeTimeLabel(
-                        entry.startedAt,
-                        props.attemptStartedAt,
-                      )}
-                    </span>
-                  </span>
-                </span>
-                {entry.causal ? (
-                  <>
-                    <span className="sr-only">
-                      {entry.causalAt ? 'Causal point' : 'Failure context'}
-                    </span>
-                    <span
-                      aria-hidden="true"
-                      className="size-1.5 shrink-0 rounded-full bg-destructive"
-                    />
-                  </>
-                ) : null}
-              </Button>
-            </li>
-          )
-        })}
+        {props.entries.map((entry, visibleIndex) => (
+          <TimelineLabelEntry
+            {...props}
+            key={entry.id}
+            entry={entry}
+            entryIndex={props.entryOffset + visibleIndex}
+            followedRef={followedRef}
+          />
+        ))}
       </ol>
     </div>
   )

--- a/packages/studio/src/runs/run-detail.tsx
+++ b/packages/studio/src/runs/run-detail.tsx
@@ -44,21 +44,19 @@ type RunDetailProps = {
 
 const resultRowHeight = 56
 
-export function RunDetail(props: RunDetailProps) {
-  const [fetched, setFetched] = useState<StudioRunSnapshot>()
+function useFetchedRunSnapshot(props: RunDetailProps) {
+  const [snapshot, setSnapshot] = useState<StudioRunSnapshot>()
   const [error, setError] = useState<string>()
-  const [includeAllArtifacts, setIncludeAllArtifacts] = useState(false)
-
   useEffect(() => {
     if (props.live?.snapshot) return
     let cancelled = false
-    setFetched(undefined)
+    setSnapshot(undefined)
     setError(undefined)
-    props
+    void props
       .api<StudioRunSnapshot>(`/api/runs/${encodeURIComponent(props.runId)}`)
       .then(
-        (snapshot) => {
-          if (!cancelled) setFetched(snapshot)
+        (value) => {
+          if (!cancelled) setSnapshot(value)
         },
         (reason: unknown) => {
           if (!cancelled) setError(reasonMessage(reason))
@@ -68,25 +66,19 @@ export function RunDetail(props: RunDetailProps) {
       cancelled = true
     }
   }, [props.api, props.live?.snapshot, props.runId])
+  return { snapshot, error }
+}
 
-  const snapshot = props.live?.snapshot ?? fetched
-  const attempts = useMemo(
-    () =>
-      (snapshot?.manifest?.results ?? []).flatMap((result) =>
-        result.attempts.map((attempt) => ({ result, attempt })),
-      ),
-    [snapshot?.manifest?.results],
-  )
-  const resultWindow = useVirtualWindow<HTMLDivElement>({
-    count: attempts.length,
-    itemSize: resultRowHeight,
-  })
+export function RunDetail(props: RunDetailProps) {
+  const fetched = useFetchedRunSnapshot(props)
+  const [includeAllArtifacts, setIncludeAllArtifacts] = useState(false)
+  const snapshot = props.live?.snapshot ?? fetched.snapshot
 
-  if (error) {
+  if (fetched.error) {
     return (
       <RunDetailMessage onBack={props.onBack}>
         <p role="alert" className="text-sm text-destructive">
-          {error}
+          {fetched.error}
         </p>
       </RunDetailMessage>
     )
@@ -98,79 +90,126 @@ export function RunDetail(props: RunDetailProps) {
       </section>
     )
   }
+  return (
+    <LoadedRunDetail
+      {...props}
+      manifest={snapshot.manifest}
+      includeAllArtifacts={includeAllArtifacts}
+      onIncludeAllArtifacts={setIncludeAllArtifacts}
+    />
+  )
+}
 
-  const manifest = snapshot.manifest
+function RunDetailHeader(
+  props: RunDetailProps & {
+    manifest: TestRunManifest
+    running: boolean
+    artifactMode: 'all' | 'failures'
+    includeAllArtifacts: boolean
+    onIncludeAllArtifacts: (include: boolean) => void
+  },
+) {
+  const displayState = props.running ? 'running' : props.manifest.state
+  const rerunDisabled =
+    props.runsBlocked ||
+    (props.manifest.state !== 'failed' &&
+      props.manifest.state !== 'infrastructure-error')
+  function cancelRun() {
+    props.onCancel(props.manifest.id)
+  }
+  function rerunFailures() {
+    void props.onRerun({ rerunId: props.manifest.id, failures: true })
+  }
+  return (
+    <header className="flex flex-wrap items-start justify-between gap-3 border-b border-border pb-4">
+      <div className="min-w-0 space-y-2">
+        <Button type="button" variant="ghost" size="sm" onClick={props.onBack}>
+          Back to Runs
+        </Button>
+        <div className="flex flex-wrap items-center gap-2">
+          <h1 className="studio-display text-lg sm:text-xl">
+            Test run {props.manifest.id}
+          </h1>
+          <Badge
+            variant={
+              displayState === 'running'
+                ? 'running'
+                : resultBadgeVariant(displayState)
+            }
+          >
+            <ResultMark state={displayState} />
+            {displayState}
+          </Badge>
+        </div>
+        <p className="text-xs text-muted-foreground">
+          {props.manifest.sourceRunId
+            ? `Rerun of ${props.manifest.sourceRunId}`
+            : 'Original Test run'}
+        </p>
+        {props.live?.connection.kind === 'disconnected' ? (
+          <p role="status" className="text-sm text-destructive">
+            {props.live.connection.message}
+          </p>
+        ) : null}
+      </div>
+      <div className="flex flex-wrap items-center gap-2">
+        {props.running ? (
+          <Button type="button" variant="destructive" onClick={cancelRun}>
+            Cancel Test run
+          </Button>
+        ) : (
+          <ExportMenu
+            runId={props.manifest.id}
+            artifactMode={props.artifactMode}
+            includeAllArtifacts={props.includeAllArtifacts}
+            onIncludeAllArtifacts={props.onIncludeAllArtifacts}
+          />
+        )}
+        <Button
+          type="button"
+          variant="outline"
+          disabled={rerunDisabled}
+          onClick={rerunFailures}
+        >
+          Rerun failures
+        </Button>
+      </div>
+    </header>
+  )
+}
+
+function LoadedRunDetail(
+  props: RunDetailProps & {
+    manifest: TestRunManifest
+    includeAllArtifacts: boolean
+    onIncludeAllArtifacts: (include: boolean) => void
+  },
+) {
+  const manifest = props.manifest
+  const includeAllArtifacts = props.includeAllArtifacts
+  const attempts = useMemo(
+    () =>
+      manifest.results.flatMap((result) =>
+        result.attempts.map((attempt) => ({ result, attempt })),
+      ),
+    [manifest.results],
+  )
+  const resultWindow = useVirtualWindow<HTMLDivElement>({
+    count: attempts.length,
+    itemSize: resultRowHeight,
+  })
   const running = props.live?.phase === 'running'
   const artifactMode = includeAllArtifacts ? 'all' : 'failures'
   const visibleAttempts = attempts.slice(resultWindow.start, resultWindow.end)
 
   return (
     <section className="min-h-0 flex-1 space-y-5 overflow-auto px-3 py-4 sm:px-5">
-      <header className="flex flex-wrap items-start justify-between gap-3 border-b border-border pb-4">
-        <div className="min-w-0 space-y-2">
-          <Button
-            type="button"
-            variant="ghost"
-            size="sm"
-            onClick={props.onBack}
-          >
-            Back to Runs
-          </Button>
-          <div className="flex flex-wrap items-center gap-2">
-            <h1 className="studio-display text-lg sm:text-xl">
-              Test run {manifest.id}
-            </h1>
-            <Badge
-              variant={running ? 'running' : resultBadgeVariant(manifest.state)}
-            >
-              <ResultMark state={running ? 'running' : manifest.state} />
-              {running ? 'running' : manifest.state}
-            </Badge>
-          </div>
-          <p className="text-xs text-muted-foreground">
-            {manifest.sourceRunId
-              ? `Rerun of ${manifest.sourceRunId}`
-              : 'Original Test run'}
-          </p>
-          {props.live?.connection.kind === 'disconnected' ? (
-            <p role="status" className="text-sm text-destructive">
-              {props.live.connection.message}
-            </p>
-          ) : null}
-        </div>
-        <div className="flex flex-wrap items-center gap-2">
-          {running ? (
-            <Button
-              type="button"
-              variant="destructive"
-              onClick={() => props.onCancel(manifest.id)}
-            >
-              Cancel Test run
-            </Button>
-          ) : (
-            <ExportMenu
-              runId={manifest.id}
-              artifactMode={artifactMode}
-              includeAllArtifacts={includeAllArtifacts}
-              onIncludeAllArtifacts={setIncludeAllArtifacts}
-            />
-          )}
-          <Button
-            type="button"
-            variant="outline"
-            disabled={
-              props.runsBlocked ||
-              (manifest.state !== 'failed' &&
-                manifest.state !== 'infrastructure-error')
-            }
-            onClick={() =>
-              void props.onRerun({ rerunId: manifest.id, failures: true })
-            }
-          >
-            Rerun failures
-          </Button>
-        </div>
-      </header>
+      <RunDetailHeader
+        {...props}
+        manifest={manifest}
+        running={running}
+        artifactMode={artifactMode}
+      />
 
       <RunMetadata manifest={manifest} />
 

--- a/packages/studio/src/runs/runs-model.ts
+++ b/packages/studio/src/runs/runs-model.ts
@@ -82,24 +82,32 @@ export function filterRuns(
   specificationNames: ReadonlyMap<string, string>,
 ): RunListItem[] {
   const query = filters.q?.trim().toLocaleLowerCase()
-  return items.filter(({ summary, state }) => {
-    if (filters.state && filters.state !== state) return false
-    if (
-      filters.specification &&
-      !summary.specificationUris.includes(filters.specification)
-    ) {
-      return false
-    }
-    if (
-      filters.profile &&
-      !summary.executionTargetProfileIds.includes(filters.profile)
-    ) {
-      return false
-    }
-    if (filters.suite && summary.suite !== filters.suite) return false
-    if (!query) return true
-    return searchableRunText(summary, specificationNames).includes(query)
-  })
+  return items.filter((item) =>
+    runMatchesFilters(item, filters, query, specificationNames),
+  )
+}
+
+function runMatchesFilters(
+  { summary, state }: RunListItem,
+  filters: RunsFilters,
+  query: string | undefined,
+  specificationNames: ReadonlyMap<string, string>,
+): boolean {
+  if (filters.state && filters.state !== state) return false
+  if (
+    filters.specification &&
+    !summary.specificationUris.includes(filters.specification)
+  )
+    return false
+  if (
+    filters.profile &&
+    !summary.executionTargetProfileIds.includes(filters.profile)
+  )
+    return false
+  if (filters.suite && summary.suite !== filters.suite) return false
+  return (
+    !query || searchableRunText(summary, specificationNames).includes(query)
+  )
 }
 
 export function runProgress(inspection: LiveResultInspection): RunProgress {

--- a/packages/studio/src/runs/runs.tsx
+++ b/packages/studio/src/runs/runs.tsx
@@ -510,6 +510,117 @@ type RunTableProps = {
   onSelect: React.Dispatch<React.SetStateAction<string[]>>
 }
 
+function RunTableRow(
+  props: Omit<RunTableProps, 'items' | 'window'> & RunListItem,
+) {
+  const { summary, state } = props
+  const selected = props.selectedRunIds.includes(summary.id)
+  const pinned = props.pinnedRunIds.has(summary.id)
+  const rerunDisabled =
+    props.runsBlocked ||
+    (summary.state !== 'failed' && summary.state !== 'infrastructure-error')
+
+  function handleSelectionChange(checked: boolean) {
+    props.onSelect((current) =>
+      checked
+        ? [...current, summary.id]
+        : current.filter((id) => id !== summary.id),
+    )
+  }
+
+  function handlePin() {
+    props.onPin(summary.id, !pinned)
+  }
+
+  function handleOpen() {
+    props.onOpen(summary.id)
+  }
+
+  function handleRerun() {
+    void props.onRerun({ rerunId: summary.id, failures: true })
+  }
+
+  return (
+    <TableRow style={{ height: runRowHeight }}>
+      <TableCell>
+        <Checkbox
+          aria-label={`Select ${summary.id} for comparison`}
+          checked={selected}
+          disabled={!selected && props.selectedRunIds.length === 2}
+          onCheckedChange={handleSelectionChange}
+        />
+      </TableCell>
+      <TableCell>
+        <Tooltip>
+          <TooltipTrigger
+            type="button"
+            className={buttonVariants({ variant: 'outline', size: 'sm' })}
+            aria-pressed={pinned}
+            onClick={handlePin}
+          >
+            {pinned ? 'Unpin' : 'Pin'}
+          </TooltipTrigger>
+          <TooltipContent side="right">
+            {pinned
+              ? 'Allow retention to delete this Test run.'
+              : 'Protect this Test run from retention deletion.'}
+          </TooltipContent>
+        </Tooltip>
+      </TableCell>
+      <TableCell>
+        <span className="block">
+          {new Date(summary.startedAt).toLocaleString()}
+        </span>
+        <span className="font-mono text-muted-foreground">{summary.id}</span>
+      </TableCell>
+      <TableCell>
+        {summary.specificationUris
+          .map((uri) => props.specificationNames.get(uri) ?? uri)
+          .join(', ') || 'None'}
+      </TableCell>
+      <TableCell>{summary.suite ?? 'Ad hoc selection'}</TableCell>
+      <TableCell>
+        {summary.executionTargetProfileIds.join(', ') || 'None'}
+      </TableCell>
+      <TableCell>{durationLabel(summary.durationMs)}</TableCell>
+      <TableCell>
+        <Badge
+          variant={state === 'running' ? 'running' : resultBadgeVariant(state)}
+        >
+          <ResultMark state={state} /> {state}
+        </Badge>
+      </TableCell>
+      <TableCell>{resultCountLabel(summary.resultCount)}</TableCell>
+      <TableCell>
+        <div className="flex items-center gap-2">
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            onClick={handleOpen}
+          >
+            Review run
+          </Button>
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            disabled={rerunDisabled}
+            onClick={handleRerun}
+          >
+            Rerun failures
+          </Button>
+        </div>
+        {summary.sourceRunId ? (
+          <span className="mt-1 block text-muted-foreground">
+            Rerun of {summary.sourceRunId}
+          </span>
+        ) : null}
+      </TableCell>
+    </TableRow>
+  )
+}
+
 function RunTable(props: RunTableProps) {
   const visibleItems = props.items.slice(props.window.start, props.window.end)
   return (
@@ -537,114 +648,8 @@ function RunTable(props: RunTableProps) {
         </TableHeader>
         <TableBody>
           <VirtualTableSpacer height={props.window.before} colSpan={10} />
-          {visibleItems.map(({ summary, state }) => (
-            <TableRow key={summary.id} style={{ height: runRowHeight }}>
-              <TableCell>
-                <Checkbox
-                  aria-label={`Select ${summary.id} for comparison`}
-                  checked={props.selectedRunIds.includes(summary.id)}
-                  disabled={
-                    !props.selectedRunIds.includes(summary.id) &&
-                    props.selectedRunIds.length === 2
-                  }
-                  onCheckedChange={(checked) =>
-                    props.onSelect((current) =>
-                      checked
-                        ? [...current, summary.id]
-                        : current.filter((id) => id !== summary.id),
-                    )
-                  }
-                />
-              </TableCell>
-              <TableCell>
-                <Tooltip>
-                  <TooltipTrigger
-                    type="button"
-                    className={buttonVariants({
-                      variant: 'outline',
-                      size: 'sm',
-                    })}
-                    aria-pressed={props.pinnedRunIds.has(summary.id)}
-                    onClick={() =>
-                      props.onPin(
-                        summary.id,
-                        !props.pinnedRunIds.has(summary.id),
-                      )
-                    }
-                  >
-                    {props.pinnedRunIds.has(summary.id) ? 'Unpin' : 'Pin'}
-                  </TooltipTrigger>
-                  <TooltipContent side="right">
-                    {props.pinnedRunIds.has(summary.id)
-                      ? 'Allow retention to delete this Test run.'
-                      : 'Protect this Test run from retention deletion.'}
-                  </TooltipContent>
-                </Tooltip>
-              </TableCell>
-              <TableCell>
-                <span className="block">
-                  {new Date(summary.startedAt).toLocaleString()}
-                </span>
-                <span className="font-mono text-muted-foreground">
-                  {summary.id}
-                </span>
-              </TableCell>
-              <TableCell>
-                {summary.specificationUris
-                  .map((uri) => props.specificationNames.get(uri) ?? uri)
-                  .join(', ') || 'None'}
-              </TableCell>
-              <TableCell>{summary.suite ?? 'Ad hoc selection'}</TableCell>
-              <TableCell>
-                {summary.executionTargetProfileIds.join(', ') || 'None'}
-              </TableCell>
-              <TableCell>{durationLabel(summary.durationMs)}</TableCell>
-              <TableCell>
-                <Badge
-                  variant={
-                    state === 'running' ? 'running' : resultBadgeVariant(state)
-                  }
-                >
-                  <ResultMark state={state} /> {state}
-                </Badge>
-              </TableCell>
-              <TableCell>{resultCountLabel(summary.resultCount)}</TableCell>
-              <TableCell>
-                <div className="flex items-center gap-2">
-                  <Button
-                    type="button"
-                    variant="outline"
-                    size="sm"
-                    onClick={() => props.onOpen(summary.id)}
-                  >
-                    Review run
-                  </Button>
-                  <Button
-                    type="button"
-                    variant="outline"
-                    size="sm"
-                    disabled={
-                      props.runsBlocked ||
-                      (summary.state !== 'failed' &&
-                        summary.state !== 'infrastructure-error')
-                    }
-                    onClick={() =>
-                      void props.onRerun({
-                        rerunId: summary.id,
-                        failures: true,
-                      })
-                    }
-                  >
-                    Rerun failures
-                  </Button>
-                </div>
-                {summary.sourceRunId ? (
-                  <span className="mt-1 block text-muted-foreground">
-                    Rerun of {summary.sourceRunId}
-                  </span>
-                ) : null}
-              </TableCell>
-            </TableRow>
+          {visibleItems.map((item) => (
+            <RunTableRow {...props} {...item} key={item.summary.id} />
           ))}
           <VirtualTableSpacer height={props.window.after} colSpan={10} />
         </TableBody>

--- a/packages/studio/src/runs/use-active-runs.ts
+++ b/packages/studio/src/runs/use-active-runs.ts
@@ -34,56 +34,64 @@ export function useActiveRuns(options: ActiveRunsOptions) {
       void connect(runId)
     }
 
+    function inspectionFrom(snapshot: StudioRunSnapshot, runId: string) {
+      let inspection = startLiveInspection({ runId, specificationUri: '' })
+      for (const event of snapshot.events) {
+        inspection = receiveLiveStreamEvent(inspection, event)
+      }
+      return inspection
+    }
+
+    async function finishRun(runId: string): Promise<void> {
+      try {
+        const snapshot = await options.api<StudioRunSnapshot>(
+          `/api/runs/${encodeURIComponent(runId)}`,
+        )
+        updateInspection(runId, (current) =>
+          hydrateLiveInspection(current, snapshot),
+        )
+        onFinished.current(runId)
+      } catch (reason) {
+        onError.current(messageFrom(reason))
+      }
+    }
+
+    function openRunSocket(runId: string): void {
+      const protocol = location.protocol === 'https:' ? 'wss:' : 'ws:'
+      const socket = new WebSocket(
+        `${protocol}//${location.host}/api/runs/${encodeURIComponent(runId)}/events`,
+      )
+      sockets.push(socket)
+      socket.onmessage = (message) => {
+        const event = JSON.parse(String(message.data)) as LiveStreamEvent
+        updateInspection(runId, (current) =>
+          receiveLiveStreamEvent(current, event),
+        )
+        if (event.type === 'run-finished') void finishRun(runId)
+      }
+      socket.onclose = () => disconnectRun(runId)
+    }
+
+    function disconnectRun(runId: string): void {
+      if (cancelled) return
+      updateInspection(runId, (current) =>
+        current.phase === 'running'
+          ? disconnectLiveInspection(
+              current,
+              'The live event stream closed. Reopen the Test run to reconnect.',
+            )
+          : current,
+      )
+    }
+
     async function connect(runId: string) {
       try {
         const snapshot = await options.api<StudioRunSnapshot>(
           `/api/runs/${encodeURIComponent(runId)}`,
         )
         if (cancelled) return
-        let inspection = startLiveInspection({
-          runId,
-          specificationUri: '',
-        })
-        for (const event of snapshot.events) {
-          inspection = receiveLiveStreamEvent(inspection, event)
-        }
-        updateInspection(runId, inspection)
-
-        const protocol = location.protocol === 'https:' ? 'wss:' : 'ws:'
-        const socket = new WebSocket(
-          `${protocol}//${location.host}/api/runs/${encodeURIComponent(runId)}/events`,
-        )
-        sockets.push(socket)
-        socket.onmessage = (message) => {
-          const event = JSON.parse(String(message.data)) as LiveStreamEvent
-          updateInspection(runId, (current) =>
-            receiveLiveStreamEvent(current, event),
-          )
-          if (event.type === 'run-finished') {
-            void options
-              .api<StudioRunSnapshot>(`/api/runs/${encodeURIComponent(runId)}`)
-              .then(
-                (finalSnapshot) => {
-                  updateInspection(runId, (current) =>
-                    hydrateLiveInspection(current, finalSnapshot),
-                  )
-                  onFinished.current(runId)
-                },
-                (reason: unknown) => onError.current(messageFrom(reason)),
-              )
-          }
-        }
-        socket.onclose = () => {
-          if (cancelled) return
-          updateInspection(runId, (current) =>
-            current.phase === 'running'
-              ? disconnectLiveInspection(
-                  current,
-                  'The live event stream closed. Reopen the Test run to reconnect.',
-                )
-              : current,
-          )
-        }
+        updateInspection(runId, inspectionFrom(snapshot, runId))
+        openRunSocket(runId)
       } catch (reason) {
         if (!cancelled) onError.current(messageFrom(reason))
       }

--- a/packages/studio/src/server/git.ts
+++ b/packages/studio/src/server/git.ts
@@ -114,6 +114,50 @@ async function pullRequestAvailability(root: string): Promise<{
   return { available: true }
 }
 
+function statusPath(line: string): string | undefined {
+  return line
+    .slice(3)
+    .replace(/^"(.*)"$/, '$1')
+    .split(' -> ')
+    .at(-1)
+}
+
+function statusLabel(line: string, staged: boolean, unstaged: boolean): string {
+  if (line.startsWith('??')) return 'untracked'
+  if (line.includes('D')) return 'deleted'
+  if (staged && !unstaged && line[0] === 'A') return 'added'
+  return 'modified'
+}
+
+async function gitFileFromStatus(
+  root: string,
+  line: string,
+): Promise<StudioGitFile | undefined> {
+  const path = statusPath(line)
+  if (!path) return undefined
+  const untracked = line.startsWith('??')
+  const staged = fileStaged(line)
+  const unstaged = fileUnstaged(line)
+  return {
+    path,
+    status: statusLabel(line, staged, unstaged),
+    staged: staged && !unstaged,
+    diff: await diffFor(root, path, unstaged ? false : staged, untracked),
+  }
+}
+
+async function statusFiles(
+  root: string,
+  output: string,
+): Promise<StudioGitFile[]> {
+  const files: StudioGitFile[] = []
+  for (const line of output.split('\n').filter(Boolean)) {
+    const file = await gitFileFromStatus(root, line)
+    if (file) files.push(file)
+  }
+  return files
+}
+
 export function createGitWorkspace(root: string): GitWorkspace {
   async function status(): Promise<StudioGitStatus> {
     const repo = git(root, ['rev-parse', '--is-inside-work-tree'])
@@ -127,34 +171,7 @@ export function createGitWorkspace(root: string): GitWorkspace {
     const branch = git(root, ['branch', '--show-current']).stdout.trim()
     const porcelain = git(root, ['status', '--porcelain', '-uall'])
     assertGitSuccess(porcelain, 'read repository status')
-    const files: StudioGitFile[] = []
-    for (const line of porcelain.stdout.split('\n').filter(Boolean)) {
-      const path = line
-        .slice(3)
-        .replace(/^"(.*)"$/, '$1')
-        .split(' -> ')
-        .at(-1)
-      if (!path) continue
-      const untracked = line.startsWith('??')
-      const staged = fileStaged(line)
-      const unstaged = fileUnstaged(line)
-      const statusLabel = untracked
-        ? 'untracked'
-        : line.includes('D')
-          ? 'deleted'
-          : staged && !unstaged && line[0] === 'A'
-            ? 'added'
-            : 'modified'
-      const diff = unstaged
-        ? await diffFor(root, path, false, untracked)
-        : await diffFor(root, path, staged, untracked)
-      files.push({
-        path,
-        status: statusLabel,
-        staged: staged && !unstaged,
-        diff,
-      })
-    }
+    const files = await statusFiles(root, porcelain.stdout)
     const pullRequest = await pullRequestAvailability(root)
     return {
       ...(branch ? { branch } : {}),

--- a/packages/studio/src/server/server.ts
+++ b/packages/studio/src/server/server.ts
@@ -531,504 +531,546 @@ export async function startStudio(
     async fetch(request, server) {
       const url = new URL(request.url)
       const origin = `http://${browserHostname(hostname)}:${server.port}`
-      async function routeHistory(): Promise<Response | null> {
-        if (
-          (url.pathname === '/api/history' || url.pathname === '/api/runs') &&
-          request.method === 'GET'
-        ) {
-          if (!options.history) {
-            return new Response('Test run history is unavailable', {
-              status: 501,
-            })
-          }
-          return Response.json({
-            ...(await options.history.list()),
-            activeRunIds: [...activeRuns].sort(),
-          } satisfies StudioRunsIndex)
+      const requestKey = `${request.method} ${url.pathname}`
+
+      function historyUnavailable(): Response {
+        return new Response('Test run history is unavailable', { status: 501 })
+      }
+
+      function requestError(error: unknown, status = 400): Response {
+        const message = error instanceof Error ? error.message : String(error)
+        return new Response(message, { status })
+      }
+
+      async function historyIndex(): Promise<Response> {
+        if (!options.history) return historyUnavailable()
+        return Response.json({
+          ...(await options.history.list()),
+          activeRunIds: [...activeRuns].sort(),
+        } satisfies StudioRunsIndex)
+      }
+
+      async function compareHistory(): Promise<Response> {
+        if (!options.history) return historyUnavailable()
+        const body = (await request.json()) as HistoryComparisonRequest
+        if (!body.baselineRunId || !body.candidateRunId) {
+          return new Response('Select two test runs to compare', {
+            status: 400,
+          })
         }
-        if (
-          url.pathname === '/api/history/compare' &&
-          request.method === 'POST'
-        ) {
-          if (!options.history) {
-            return new Response('Test run history is unavailable', {
-              status: 501,
-            })
-          }
-          const body = (await request.json()) as HistoryComparisonRequest
-          if (!body.baselineRunId || !body.candidateRunId) {
-            return new Response('Select two test runs to compare', {
-              status: 400,
-            })
-          }
-          return Response.json(
-            await options.history.compare(
-              body.baselineRunId,
-              body.candidateRunId,
-            ),
-          )
-        }
-        if (
-          url.pathname === '/api/history/import' &&
-          request.method === 'POST'
-        ) {
-          if (!options.history) {
-            return new Response('Test run history is unavailable', {
-              status: 501,
-            })
-          }
-          try {
-            return Response.json(
-              await options.history.importArchive(
-                new Uint8Array(await request.arrayBuffer()),
-              ),
-            )
-          } catch (error) {
-            const message =
-              error instanceof Error ? error.message : String(error)
-            return new Response(message, { status: 400 })
-          }
-        }
-        if (
-          url.pathname === '/api/history/retention' &&
-          request.method === 'POST'
-        ) {
-          if (!options.history) {
-            return new Response('Test run history is unavailable', {
-              status: 501,
-            })
-          }
-          return Response.json(await options.history.deleteEligible())
-        }
-        const historyPinMatch = url.pathname.match(
-          /^\/api\/history\/([^/]+)\/pin$/,
+        return Response.json(
+          await options.history.compare(
+            body.baselineRunId,
+            body.candidateRunId,
+          ),
         )
-        if (
-          historyPinMatch &&
-          (request.method === 'POST' || request.method === 'DELETE')
-        ) {
-          if (!options.history) {
-            return new Response('Test run history is unavailable', {
-              status: 501,
-            })
-          }
-          const runId = decodeURIComponent(historyPinMatch[1]!)
-          if (request.method === 'POST') await options.history.pin(runId)
-          else await options.history.unpin(runId)
-          return Response.json({ runId, pinned: request.method === 'POST' })
+      }
+
+      async function importHistory(): Promise<Response> {
+        if (!options.history) return historyUnavailable()
+        try {
+          const archive = new Uint8Array(await request.arrayBuffer())
+          return Response.json(await options.history.importArchive(archive))
+        } catch (error) {
+          return requestError(error)
         }
-        const historyExportMatch = url.pathname.match(
-          /^\/api\/history\/([^/]+)\/(html|archive|allure)$/,
-        )
-        if (historyExportMatch && request.method === 'GET') {
-          if (!options.history) {
-            return new Response('Test run history is unavailable', {
-              status: 501,
-            })
-          }
-          const runId = decodeURIComponent(historyExportMatch[1]!)
-          const kind = historyExportMatch[2]
-          if (kind === 'archive') {
-            return new Response(await options.history.exportArchive(runId), {
+      }
+
+      async function deleteHistoryEligible(): Promise<Response> {
+        return options.history
+          ? Response.json(await options.history.deleteEligible())
+          : historyUnavailable()
+      }
+
+      async function pinHistory(match: RegExpMatchArray): Promise<Response> {
+        if (!options.history) return historyUnavailable()
+        const runId = decodeURIComponent(match[1]!)
+        if (request.method === 'POST') await options.history.pin(runId)
+        else await options.history.unpin(runId)
+        return Response.json({ runId, pinned: request.method === 'POST' })
+      }
+
+      async function exportHistory(match: RegExpMatchArray): Promise<Response> {
+        if (!options.history) return historyUnavailable()
+        const runId = decodeURIComponent(match[1]!)
+        const kind = match[2]
+        const exporters: Record<string, () => Promise<Response>> = {
+          archive: async () =>
+            new Response(await options.history!.exportArchive(runId), {
               headers: {
                 'content-type': 'application/json; charset=utf-8',
                 'content-disposition': `attachment; filename="${runId}.pickle-run.json"`,
               },
-            })
-          }
-          if (kind === 'allure') {
-            const bytes = await options.history.exportAllure(runId)
+            }),
+          allure: async () => {
+            const bytes = await options.history!.exportAllure(runId)
             return new Response(bytes.buffer as ArrayBuffer, {
               headers: {
                 'content-type': 'application/zip',
                 'content-disposition': `attachment; filename="${runId}-allure-results.zip"`,
               },
             })
-          }
-          const artifacts =
-            url.searchParams.get('artifacts') === 'all' ? 'all' : 'failures'
-          return new Response(
-            await options.history.exportHtml(runId, artifacts),
-            {
-              headers: {
-                'content-type': 'text/html; charset=utf-8',
-                'content-disposition': `attachment; filename="${runId}.html"`,
+          },
+          html: async () => {
+            const artifacts =
+              url.searchParams.get('artifacts') === 'all' ? 'all' : 'failures'
+            return new Response(
+              await options.history!.exportHtml(runId, artifacts),
+              {
+                headers: {
+                  'content-type': 'text/html; charset=utf-8',
+                  'content-disposition': `attachment; filename="${runId}.html"`,
+                },
               },
-            },
-          )
+            )
+          },
         }
-        return null
+        const exporter = kind ? exporters[kind] : undefined
+        return exporter?.() ?? new Response('Not found', { status: 404 })
+      }
+
+      async function dynamicHistoryRoute(): Promise<Response | null> {
+        const pinMatch = url.pathname.match(/^\/api\/history\/([^/]+)\/pin$/)
+        if (pinMatch && ['POST', 'DELETE'].includes(request.method)) {
+          return pinHistory(pinMatch)
+        }
+        const exportMatch = url.pathname.match(
+          /^\/api\/history\/([^/]+)\/(html|archive|allure)$/,
+        )
+        return exportMatch && request.method === 'GET'
+          ? exportHistory(exportMatch)
+          : null
+      }
+
+      async function routeHistory(): Promise<Response | null> {
+        const exactRoutes: Record<string, () => Promise<Response>> = {
+          'GET /api/history': historyIndex,
+          'GET /api/runs': historyIndex,
+          'POST /api/history/compare': compareHistory,
+          'POST /api/history/import': importHistory,
+          'POST /api/history/retention': deleteHistoryEligible,
+        }
+        const exact = exactRoutes[requestKey]
+        return exact ? exact() : dynamicHistoryRoute()
+      }
+
+      async function executeCacheAction(
+        action: () => Promise<unknown>,
+      ): Promise<Response> {
+        try {
+          return Response.json(await action())
+        } catch (error) {
+          return requestError(error, 500)
+        }
       }
 
       async function routeExecutionCache(): Promise<Response | null> {
         if (url.pathname !== '/api/execution-cache') return null
         if (!options.executionCache) {
-          return new Response('Execution cache is unavailable', {
+          return new Response('Execution cache is unavailable', { status: 501 })
+        }
+        const actions: Record<string, () => Promise<unknown>> = {
+          GET: () => options.executionCache!.inspect(),
+          DELETE: () => options.executionCache!.clear(),
+        }
+        const action = actions[request.method]
+        return action ? executeCacheAction(action) : null
+      }
+
+      async function saveProjectConfig(): Promise<Response> {
+        if (!options.management) {
+          return new Response('Project configuration is unavailable', {
             status: 501,
           })
         }
         try {
-          if (request.method === 'GET') {
-            return Response.json(await options.executionCache.inspect())
-          }
-          if (request.method === 'DELETE') {
-            return Response.json(await options.executionCache.clear())
-          }
+          const patch = (await request.json()) as StudioConfigPatch
+          return Response.json(await options.management.saveConfig(patch))
         } catch (error) {
-          const message = error instanceof Error ? error.message : String(error)
-          return new Response(message, { status: 500 })
+          return requestError(error)
         }
-        return null
+      }
+
+      async function saveCredential(): Promise<Response> {
+        if (!options.management) {
+          return new Response('Credentials are unavailable', { status: 501 })
+        }
+        try {
+          const body = (await request.json()) as CredentialWriteRequest
+          return Response.json(
+            await options.management.saveCredential({
+              name: body.name ?? '',
+              secret: body.secret ?? '',
+            }),
+          )
+        } catch (error) {
+          return requestError(error)
+        }
+      }
+
+      async function runReadiness(): Promise<Response> {
+        if (!options.management) {
+          return Response.json(
+            (await currentProject()).readiness ?? { ready: true, reasons: [] },
+          )
+        }
+        const body = (await request
+          .json()
+          .catch(() => ({}))) as StudioRunRequest
+        return Response.json(await options.management.readiness(body))
+      }
+
+      async function mobileTargets(): Promise<Response> {
+        if (!options.management?.discoverMobileTargets) {
+          return new Response('Mobile target discovery is unavailable', {
+            status: 501,
+          })
+        }
+        return Response.json(await options.management.discoverMobileTargets())
+      }
+
+      async function stageGit(): Promise<Response> {
+        const body = (await request.json()) as GitPathsRequest
+        try {
+          return Response.json(await git.stage(body.paths ?? []))
+        } catch (error) {
+          return requestError(error)
+        }
+      }
+
+      async function commitGit(): Promise<Response> {
+        const body = (await request.json()) as GitCommitRequest
+        try {
+          return Response.json(
+            await git.commit({
+              message: body.message ?? '',
+              confirmed: Boolean(body.confirmed),
+              paths: body.paths ?? [],
+            }),
+          )
+        } catch (error) {
+          return requestError(error)
+        }
+      }
+
+      async function createPullRequest(): Promise<Response> {
+        try {
+          return Response.json(await git.pullRequest())
+        } catch (error) {
+          return requestError(error)
+        }
       }
 
       async function routeManagement(): Promise<Response | null> {
-        if (url.pathname === '/api/config' && request.method === 'PUT') {
-          if (!options.management) {
-            return new Response('Project configuration is unavailable', {
-              status: 501,
-            })
-          }
-          try {
-            const patch = (await request.json()) as StudioConfigPatch
-            return Response.json(await options.management.saveConfig(patch))
-          } catch (error) {
-            const message =
-              error instanceof Error ? error.message : String(error)
-            return new Response(message, { status: 400 })
-          }
+        const routes: Record<string, () => Promise<Response>> = {
+          'PUT /api/config': saveProjectConfig,
+          'PUT /api/credentials': saveCredential,
+          'POST /api/run-readiness': runReadiness,
+          'GET /api/mobile-targets': mobileTargets,
+          'GET /api/git': async () => Response.json(await git.status()),
+          'POST /api/git/stage': stageGit,
+          'POST /api/git/commit': commitGit,
+          'POST /api/git/pull-request': createPullRequest,
         }
-        if (url.pathname === '/api/credentials' && request.method === 'PUT') {
-          if (!options.management) {
-            return new Response('Credentials are unavailable', { status: 501 })
-          }
-          try {
-            const body = (await request.json()) as CredentialWriteRequest
-            return Response.json(
-              await options.management.saveCredential({
-                name: body.name ?? '',
-                secret: body.secret ?? '',
-              }),
-            )
-          } catch (error) {
-            const message =
-              error instanceof Error ? error.message : String(error)
-            return new Response(message, { status: 400 })
-          }
+        return routes[requestKey]?.() ?? null
+      }
+
+      async function readDocument(): Promise<Response> {
+        const uri = url.searchParams.get('uri')
+        if (!uri) return new Response('Missing uri', { status: 400 })
+        try {
+          return Response.json(await documents.read(uri))
+        } catch (error) {
+          return requestError(error, 404)
         }
-        if (
-          url.pathname === '/api/run-readiness' &&
-          request.method === 'POST'
-        ) {
-          if (!options.management) {
-            return Response.json(
-              (await currentProject()).readiness ?? {
-                ready: true,
-                reasons: [],
-              },
-            )
-          }
-          const body = (await request
-            .json()
-            .catch(() => ({}))) as StudioRunRequest
-          return Response.json(await options.management.readiness(body))
+      }
+
+      async function previewDocument(): Promise<Response> {
+        const body = (await request.json()) as DocumentPreviewRequest
+        try {
+          return Response.json(
+            documents.preview({
+              uri: body.uri,
+              source: body.source,
+              specification: body.specification,
+              metadata: body.metadata,
+              diffAgainst: body.diffAgainst,
+            }),
+          )
+        } catch (error) {
+          return requestError(error)
         }
-        if (
-          url.pathname === '/api/mobile-targets' &&
-          request.method === 'GET'
-        ) {
-          if (!options.management?.discoverMobileTargets) {
-            return new Response('Mobile target discovery is unavailable', {
-              status: 501,
-            })
-          }
-          return Response.json(await options.management.discoverMobileTargets())
+      }
+
+      async function writeDocument(): Promise<Response> {
+        const body = (await request.json()) as DocumentWriteRequest
+        try {
+          return Response.json(
+            await documents.write({
+              uri: body.uri,
+              source: body.source,
+              expectedRevision: body.expectedRevision,
+              create: body.create,
+            }),
+          )
+        } catch (error) {
+          return error instanceof DocumentConflictError
+            ? conflictResponse(error, body.source)
+            : requestError(error)
         }
-        if (url.pathname === '/api/git' && request.method === 'GET') {
-          return Response.json(await git.status())
+      }
+
+      async function proposeDocument(): Promise<Response> {
+        if (!options.authoring?.propose) {
+          return new Response('AI assistance is unavailable', { status: 501 })
         }
-        if (url.pathname === '/api/git/stage' && request.method === 'POST') {
-          const body = (await request.json()) as GitPathsRequest
-          try {
-            return Response.json(await git.stage(body.paths ?? []))
-          } catch (error) {
-            const message =
-              error instanceof Error ? error.message : String(error)
-            return new Response(message, { status: 400 })
-          }
+        const body = (await request.json()) as DocumentProposeRequest
+        try {
+          return Response.json(
+            await documents.propose({
+              prompt: body.prompt,
+              uri: body.uri,
+              currentSource: body.currentSource,
+              author: options.authoring.propose,
+            }),
+          )
+        } catch (error) {
+          return requestError(error)
         }
-        if (url.pathname === '/api/git/commit' && request.method === 'POST') {
-          const body = (await request.json()) as GitCommitRequest
-          try {
-            return Response.json(
-              await git.commit({
-                message: body.message ?? '',
-                confirmed: Boolean(body.confirmed),
-                paths: body.paths ?? [],
-              }),
-            )
-          } catch (error) {
-            const message =
-              error instanceof Error ? error.message : String(error)
-            return new Response(message, { status: 400 })
-          }
-        }
-        if (
-          url.pathname === '/api/git/pull-request' &&
-          request.method === 'POST'
-        ) {
-          try {
-            return Response.json(await git.pullRequest())
-          } catch (error) {
-            const message =
-              error instanceof Error ? error.message : String(error)
-            return new Response(message, { status: 400 })
-          }
-        }
-        return null
       }
 
       async function routeDocuments(): Promise<Response | null> {
-        if (url.pathname === '/api/documents' && request.method === 'GET') {
-          const uri = url.searchParams.get('uri')
-          if (!uri) return new Response('Missing uri', { status: 400 })
-          try {
-            return Response.json(await documents.read(uri))
-          } catch (error) {
-            const message =
-              error instanceof Error ? error.message : String(error)
-            return new Response(message, { status: 404 })
-          }
+        const routes: Record<string, () => Promise<Response>> = {
+          'GET /api/documents': readDocument,
+          'GET /api/documents/completions': async () =>
+            Response.json(await documents.completions()),
+          'POST /api/documents/preview': previewDocument,
+          'PUT /api/documents': writeDocument,
+          'POST /api/documents/propose': proposeDocument,
         }
-        if (
-          url.pathname === '/api/documents/completions' &&
-          request.method === 'GET'
-        ) {
-          return Response.json(await documents.completions())
+        return routes[requestKey]?.() ?? null
+      }
+
+      function upgradeWorkspaceEvents(): Response | undefined {
+        const upgraded = server.upgrade(request, {
+          data: { kind: 'workspace' },
+        })
+        return upgraded
+          ? undefined
+          : new Response('WebSocket upgrade failed', { status: 400 })
+      }
+
+      function publishRunEvent(
+        state: { runId: string; pending: StudioStreamEvent[] },
+        event: StudioStreamEvent,
+      ): void {
+        if (event.type === 'run-started') state.runId = event.run.id
+        if (!state.runId) {
+          state.pending.push(event)
+          return
         }
-        if (
-          url.pathname === '/api/documents/preview' &&
-          request.method === 'POST'
-        ) {
-          const body = (await request.json()) as DocumentPreviewRequest
-          try {
-            return Response.json(
-              documents.preview({
-                uri: body.uri,
-                source: body.source,
-                specification: body.specification,
-                metadata: body.metadata,
-                diffAgainst: body.diffAgainst,
-              }),
-            )
-          } catch (error) {
-            const message =
-              error instanceof Error ? error.message : String(error)
-            return new Response(message, { status: 400 })
-          }
+        for (const pendingEvent of state.pending.splice(0)) {
+          publish(state.runId, pendingEvent)
         }
-        if (url.pathname === '/api/documents' && request.method === 'PUT') {
-          const body = (await request.json()) as DocumentWriteRequest
-          try {
-            return Response.json(
-              await documents.write({
-                uri: body.uri,
-                source: body.source,
-                expectedRevision: body.expectedRevision,
-                create: body.create,
-              }),
-            )
-          } catch (error) {
-            if (error instanceof DocumentConflictError) {
-              return conflictResponse(error, body.source)
-            }
-            const message =
-              error instanceof Error ? error.message : String(error)
-            return new Response(message, { status: 400 })
-          }
+        publish(state.runId, event)
+      }
+
+      async function startRun(): Promise<Response> {
+        if (!options.gateway) {
+          return new Response('Test runs are unavailable', { status: 501 })
         }
-        if (
-          url.pathname === '/api/documents/propose' &&
-          request.method === 'POST'
-        ) {
-          if (!options.authoring?.propose) {
-            return new Response('AI assistance is unavailable', { status: 501 })
+        const body = (await request
+          .json()
+          .catch(() => ({}))) as StudioRunRequest
+        const state = { runId: '', pending: [] as StudioStreamEvent[] }
+        try {
+          const started = await options.gateway.start(body, (event) =>
+            publishRunEvent(state, event),
+          )
+          state.runId = started.id
+          for (const event of state.pending.splice(0))
+            publish(state.runId, event)
+          activeRuns.add(started.id)
+          const finishRun = () => {
+            publish(state.runId, {
+              type: 'run-finished',
+              run: { id: state.runId },
+            })
           }
-          const body = (await request.json()) as DocumentProposeRequest
-          try {
-            return Response.json(
-              await documents.propose({
-                prompt: body.prompt,
-                uri: body.uri,
-                currentSource: body.currentSource,
-                author: options.authoring.propose,
-              }),
-            )
-          } catch (error) {
-            const message =
-              error instanceof Error ? error.message : String(error)
-            return new Response(message, { status: 400 })
-          }
+          void started.done
+            .then(finishRun, finishRun)
+            .finally(() => activeRuns.delete(started.id))
+          return Response.json({ id: started.id })
+        } catch (error) {
+          return requestError(error, 500)
         }
-        return null
+      }
+
+      function artifactPath(): string | Response {
+        const filePath = url.searchParams.get('path')
+        if (!filePath) return new Response('Missing path', { status: 400 })
+        const resolved = resolve(filePath)
+        const allowed = resolveLocalProjectStorage(
+          options.project.root,
+        ).runsDirectory
+        return resolved === allowed || resolved.startsWith(`${allowed}${sep}`)
+          ? resolved
+          : new Response('Forbidden', { status: 403 })
+      }
+
+      function artifactResponse(
+        path: string,
+        file: ReturnType<typeof Bun.file>,
+      ): Response {
+        const headers = {
+          'content-type': file.type || 'application/octet-stream',
+          'content-length': String(file.size),
+        }
+        if (request.method === 'HEAD') return new Response(null, { headers })
+        if (url.searchParams.get('download') !== 'true') {
+          return new Response(file, { headers })
+        }
+        const requestedName = url.searchParams.get('name')
+        const downloadName = basename(requestedName || path).replace(
+          /["\r\n]/g,
+          '_',
+        )
+        return new Response(file, {
+          headers: {
+            'content-disposition': `attachment; filename="${downloadName}"`,
+          },
+        })
+      }
+
+      async function readArtifact(): Promise<Response> {
+        const path = artifactPath()
+        if (path instanceof Response) return path
+        const file = Bun.file(path)
+        if (!(await file.exists()))
+          return new Response('Not found', { status: 404 })
+        return artifactResponse(path, file)
+      }
+
+      async function cancelRun(match: RegExpMatchArray): Promise<Response> {
+        if (!options.gateway) {
+          return new Response('Test runs are unavailable', { status: 501 })
+        }
+        await options.gateway.cancel(decodeURIComponent(match[1]!))
+        return new Response(null, { status: 204 })
+      }
+
+      function upgradeRunEvents(match: RegExpMatchArray): Response | undefined {
+        const runId = decodeURIComponent(match[1]!)
+        const upgraded = server.upgrade(request, {
+          data: { kind: 'run', runId },
+        })
+        return upgraded
+          ? undefined
+          : new Response('WebSocket upgrade failed', { status: 400 })
+      }
+
+      async function runSnapshot(match: RegExpMatchArray): Promise<Response> {
+        if (!options.gateway) {
+          return new Response('Test runs are unavailable', { status: 501 })
+        }
+        return Response.json(
+          await options.gateway.snapshot(decodeURIComponent(match[1]!)),
+        )
       }
 
       async function routeExecution(): Promise<Response | undefined> {
-        if (
-          url.pathname === '/api/workspace/events' &&
-          request.method === 'GET'
-        ) {
-          const upgraded = server.upgrade(request, {
-            data: { kind: 'workspace' },
-          })
-          if (upgraded) return
-          return new Response('WebSocket upgrade failed', { status: 400 })
+        const exactRoutes: Record<
+          string,
+          () => Response | undefined | Promise<Response>
+        > = {
+          'GET /api/workspace/events': upgradeWorkspaceEvents,
+          'POST /api/runs': startRun,
+          'GET /api/artifact': readArtifact,
+          'HEAD /api/artifact': readArtifact,
         }
-        if (url.pathname === '/api/runs' && request.method === 'POST') {
-          if (!options.gateway) {
-            return new Response('Test runs are unavailable', { status: 501 })
-          }
-          const body = (await request
-            .json()
-            .catch(() => ({}))) as StudioRunRequest
-          let runId = ''
-          const pendingEvents: StudioStreamEvent[] = []
-          try {
-            const started = await options.gateway.start(body, (event) => {
-              if (event.type === 'run-started') runId = event.run.id
-              if (!runId) {
-                pendingEvents.push(event)
-                return
-              }
-              for (const pendingEvent of pendingEvents.splice(0)) {
-                publish(runId, pendingEvent)
-              }
-              publish(runId, event)
-            })
-            runId = started.id
-            for (const pendingEvent of pendingEvents.splice(0)) {
-              publish(runId, pendingEvent)
-            }
-            activeRuns.add(started.id)
-            const finishRun = () => {
-              publish(runId, { type: 'run-finished', run: { id: runId } })
-            }
-            void started.done
-              .then(finishRun, finishRun)
-              .finally(() => activeRuns.delete(started.id))
-            return Response.json({ id: started.id })
-          } catch (error) {
-            const message =
-              error instanceof Error ? error.message : String(error)
-            return new Response(message, { status: 500 })
-          }
+        const exact = exactRoutes[requestKey]
+        if (exact) return exact()
+        return routeRunResource()
+      }
+
+      async function routeRunResource(): Promise<Response | undefined> {
+        const routes: Record<string, () => Promise<Response | undefined>> = {
+          POST: postRunResource,
+          GET: getRunResource,
         }
-        if (
-          url.pathname === '/api/artifact' &&
-          (request.method === 'GET' || request.method === 'HEAD')
-        ) {
-          const filePath = url.searchParams.get('path')
-          if (!filePath) return new Response('Missing path', { status: 400 })
-          const resolved = resolve(filePath)
-          const allowed = resolveLocalProjectStorage(
-            options.project.root,
-          ).runsDirectory
-          if (
-            resolved !== allowed &&
-            !resolved.startsWith(`${allowed}${sep}`)
-          ) {
-            return new Response('Forbidden', { status: 403 })
-          }
-          const file = Bun.file(resolved)
-          if (!(await file.exists()))
-            return new Response('Not found', { status: 404 })
-          const headers = {
-            'content-type': file.type || 'application/octet-stream',
-            'content-length': String(file.size),
-          }
-          if (request.method === 'HEAD') return new Response(null, { headers })
-          if (url.searchParams.get('download') !== 'true') {
-            return new Response(file, { headers })
-          }
-          const requestedName = url.searchParams.get('name')
-          const downloadName = basename(requestedName || resolved).replace(
-            /["\r\n]/g,
-            '_',
-          )
-          return new Response(file, {
-            headers: {
-              'content-disposition': `attachment; filename="${downloadName}"`,
-            },
-          })
-        }
+        return (
+          routes[request.method]?.() ??
+          new Response('Not found', { status: 404 })
+        )
+      }
+
+      async function postRunResource(): Promise<Response> {
         const cancelMatch = url.pathname.match(/^\/api\/runs\/([^/]+)\/cancel$/)
-        if (cancelMatch && request.method === 'POST') {
-          if (!options.gateway) {
-            return new Response('Test runs are unavailable', { status: 501 })
-          }
-          await options.gateway.cancel(decodeURIComponent(cancelMatch[1]!))
-          return new Response(null, { status: 204 })
-        }
+        return cancelMatch
+          ? cancelRun(cancelMatch)
+          : new Response('Not found', { status: 404 })
+      }
+
+      async function getRunResource(): Promise<Response | undefined> {
         const eventsMatch = url.pathname.match(/^\/api\/runs\/([^/]+)\/events$/)
-        if (eventsMatch && request.method === 'GET') {
-          const runId = decodeURIComponent(eventsMatch[1]!)
-          const upgraded = server.upgrade(request, {
-            data: { kind: 'run', runId },
-          })
-          if (upgraded) return
-          return new Response('WebSocket upgrade failed', { status: 400 })
-        }
+        if (eventsMatch) return upgradeRunEvents(eventsMatch)
         const runMatch = url.pathname.match(/^\/api\/runs\/([^/]+)$/)
-        if (runMatch && request.method === 'GET') {
-          if (!options.gateway) {
-            return new Response('Test runs are unavailable', { status: 501 })
-          }
-          return Response.json(
-            await options.gateway.snapshot(decodeURIComponent(runMatch[1]!)),
-          )
-        }
+        if (runMatch) return runSnapshot(runMatch)
         return new Response('Not found', { status: 404 })
       }
 
-      async function routeRequest(): Promise<Response | undefined> {
+      function staticAsset(): Response | null {
         const asset =
           ui.files.get(url.pathname) ?? ui.files.get(basename(url.pathname))
-        if (asset && request.method === 'GET') {
-          if (!authorized(request, origin)) {
-            return new Response('Unauthorized', { status: 401 })
-          }
-          return new Response(asset)
+        return asset && request.method === 'GET' ? new Response(asset) : null
+      }
+
+      function studioPage(): Response | null {
+        if (request.method !== 'GET') return null
+        const routeKind = parseStudioRoute(url.href).kind
+        const page =
+          url.pathname === '/' ||
+          url.pathname === '/index.html' ||
+          ['runs', 'run', 'result'].includes(routeKind)
+        if (!page) return null
+        return new Response(ui.index, {
+          headers: {
+            'content-type': 'text/html; charset=utf-8',
+            'set-cookie': `${sessionCookie}=${encodeURIComponent(token)}; Path=/; HttpOnly; SameSite=Strict`,
+          },
+        })
+      }
+
+      async function routeAuthenticatedApi(): Promise<Response | undefined> {
+        if (requestKey === 'GET /api/project') {
+          return Response.json(await currentProject())
         }
-        if (
-          request.method === 'GET' &&
-          (url.pathname === '/' ||
-            url.pathname === '/index.html' ||
-            ['runs', 'run', 'result'].includes(parseStudioRoute(url.href).kind))
-        ) {
-          if (!authorized(request, origin)) {
-            return new Response('Unauthorized', { status: 401 })
-          }
-          return new Response(ui.index, {
-            headers: {
-              'content-type': 'text/html; charset=utf-8',
-              'set-cookie': `${sessionCookie}=${encodeURIComponent(token)}; Path=/; HttpOnly; SameSite=Strict`,
-            },
-          })
+        const routes = [
+          routeHistory,
+          routeExecutionCache,
+          routeManagement,
+          routeDocuments,
+        ]
+        for (const route of routes) {
+          const response = await route()
+          if (response) return response
         }
+        return routeExecution()
+      }
+
+      async function routeRequest(): Promise<Response | undefined> {
+        const publicResponse = staticAsset() ?? studioPage()
+        if (publicResponse) return authorizePublicResponse(publicResponse)
         if (!authorized(request, origin)) {
           return new Response('Unauthorized', { status: 401 })
         }
-        if (url.pathname === '/api/project' && request.method === 'GET') {
-          return Response.json(await currentProject())
-        }
-        const historyResponse = await routeHistory()
-        if (historyResponse) return historyResponse
-        const executionCacheResponse = await routeExecutionCache()
-        if (executionCacheResponse) return executionCacheResponse
-        const managementResponse = await routeManagement()
-        if (managementResponse) return managementResponse
-        const documentResponse = await routeDocuments()
-        if (documentResponse) return documentResponse
-        return routeExecution()
+        return routeAuthenticatedApi()
+      }
+
+      function authorizePublicResponse(response: Response): Response {
+        return authorized(request, origin)
+          ? response
+          : new Response('Unauthorized', { status: 401 })
       }
       const response = await routeRequest()
       return response ? secureResponse(response, origin) : undefined

--- a/packages/studio/src/settings/execution-cache-settings.tsx
+++ b/packages/studio/src/settings/execution-cache-settings.tsx
@@ -41,6 +41,97 @@ function errorMessage(reason: unknown): string {
   return reason instanceof Error ? reason.message : String(reason)
 }
 
+function ExecutionCacheTable(props: {
+  inspection: StudioExecutionCacheInspection
+}) {
+  const usedBytes = props.inspection.entries.reduce(
+    (total, entry) => total + entry.sizeBytes,
+    0,
+  )
+  if (props.inspection.entries.length === 0) {
+    return (
+      <p
+        className="rounded-md border border-dashed p-4 text-sm text-muted-foreground"
+        role="status"
+      >
+        No cached replay revisions for this checkout.
+      </p>
+    )
+  }
+  return (
+    <div className="space-y-2">
+      <div className="flex flex-wrap items-center gap-2 text-sm text-muted-foreground">
+        <Badge>
+          {props.inspection.entries.length}{' '}
+          {props.inspection.entries.length === 1 ? 'revision' : 'revisions'}
+        </Badge>
+        <span>
+          {byteCount(usedBytes)} of {byteCount(props.inspection.maxBytes)} used
+        </span>
+      </div>
+      <Table aria-label="Execution cache revisions">
+        <TableHeader>
+          <TableRow>
+            <TableHead>Scenario</TableHead>
+            <TableHead>Target</TableHead>
+            <TableHead>Scenario revision</TableHead>
+            <TableHead>Application revision</TableHead>
+            <TableHead>Adapter revision</TableHead>
+            <TableHead>Size</TableHead>
+            <TableHead>Last used</TableHead>
+            <TableHead>Hits</TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {props.inspection.entries.map((entry) => (
+            <TableRow key={entry.payloadDigest}>
+              <TableCell className="font-mono">
+                {entry.key.scenarioId}
+              </TableCell>
+              <TableCell>{entry.key.executionTargetProfileId}</TableCell>
+              <TableCell className="font-mono">
+                {entry.key.scenarioRevision}
+              </TableCell>
+              <TableCell className="font-mono">
+                {entry.key.applicationRevision}
+              </TableCell>
+              <TableCell className="font-mono">
+                {entry.key.adapterCacheSchemaVersion}
+              </TableCell>
+              <TableCell>{byteCount(entry.sizeBytes)}</TableCell>
+              <TableCell>{dateTime(entry.lastUsedAt)}</TableCell>
+              <TableCell>{entry.hitCount}</TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+    </div>
+  )
+}
+
+function ExecutionCacheContent(props: {
+  loading: boolean
+  error?: string
+  inspection?: StudioExecutionCacheInspection
+  onRetry: () => void
+}) {
+  if (props.loading)
+    return <LedgerRowsSkeleton label="Loading Execution cache" />
+  if (props.error) {
+    return (
+      <div className="space-y-2" role="alert">
+        <p className="text-sm text-destructive">{props.error}</p>
+        <Button type="button" variant="outline" onClick={props.onRetry}>
+          Retry
+        </Button>
+      </div>
+    )
+  }
+  return props.inspection ? (
+    <ExecutionCacheTable inspection={props.inspection} />
+  ) : null
+}
+
 export function ExecutionCacheSettings(props: ExecutionCacheSettingsProps) {
   const [inspection, setInspection] = useState<StudioExecutionCacheInspection>()
   const [error, setError] = useState<string>()
@@ -89,9 +180,22 @@ export function ExecutionCacheSettings(props: ExecutionCacheSettingsProps) {
     }
   }
 
-  const usedBytes =
-    inspection?.entries.reduce((total, entry) => total + entry.sizeBytes, 0) ??
-    0
+  function openConfirmation() {
+    setClearError(undefined)
+    setConfirmOpen(true)
+  }
+
+  function retry() {
+    void load()
+  }
+
+  function closeConfirmation() {
+    setConfirmOpen(false)
+  }
+
+  function confirmClear() {
+    void clear()
+  }
 
   return (
     <section
@@ -112,82 +216,18 @@ export function ExecutionCacheSettings(props: ExecutionCacheSettingsProps) {
           type="button"
           variant="destructive"
           disabled={loading || !inspection?.entries.length}
-          onClick={() => {
-            setClearError(undefined)
-            setConfirmOpen(true)
-          }}
+          onClick={openConfirmation}
         >
           Clear Execution cache
         </Button>
       </div>
 
-      {loading ? <LedgerRowsSkeleton label="Loading Execution cache" /> : null}
-      {!loading && error ? (
-        <div className="space-y-2" role="alert">
-          <p className="text-sm text-destructive">{error}</p>
-          <Button type="button" variant="outline" onClick={() => void load()}>
-            Retry
-          </Button>
-        </div>
-      ) : null}
-      {!loading && !error && inspection ? (
-        inspection.entries.length === 0 ? (
-          <p
-            className="rounded-md border border-dashed p-4 text-sm text-muted-foreground"
-            role="status"
-          >
-            No cached replay revisions for this checkout.
-          </p>
-        ) : (
-          <div className="space-y-2">
-            <div className="flex flex-wrap items-center gap-2 text-sm text-muted-foreground">
-              <Badge>
-                {inspection.entries.length}{' '}
-                {inspection.entries.length === 1 ? 'revision' : 'revisions'}
-              </Badge>
-              <span>
-                {byteCount(usedBytes)} of {byteCount(inspection.maxBytes)} used
-              </span>
-            </div>
-            <Table aria-label="Execution cache revisions">
-              <TableHeader>
-                <TableRow>
-                  <TableHead>Scenario</TableHead>
-                  <TableHead>Target</TableHead>
-                  <TableHead>Scenario revision</TableHead>
-                  <TableHead>Application revision</TableHead>
-                  <TableHead>Adapter revision</TableHead>
-                  <TableHead>Size</TableHead>
-                  <TableHead>Last used</TableHead>
-                  <TableHead>Hits</TableHead>
-                </TableRow>
-              </TableHeader>
-              <TableBody>
-                {inspection.entries.map((entry) => (
-                  <TableRow key={entry.payloadDigest}>
-                    <TableCell className="font-mono">
-                      {entry.key.scenarioId}
-                    </TableCell>
-                    <TableCell>{entry.key.executionTargetProfileId}</TableCell>
-                    <TableCell className="font-mono">
-                      {entry.key.scenarioRevision}
-                    </TableCell>
-                    <TableCell className="font-mono">
-                      {entry.key.applicationRevision}
-                    </TableCell>
-                    <TableCell className="font-mono">
-                      {entry.key.adapterCacheSchemaVersion}
-                    </TableCell>
-                    <TableCell>{byteCount(entry.sizeBytes)}</TableCell>
-                    <TableCell>{dateTime(entry.lastUsedAt)}</TableCell>
-                    <TableCell>{entry.hitCount}</TableCell>
-                  </TableRow>
-                ))}
-              </TableBody>
-            </Table>
-          </div>
-        )
-      ) : null}
+      <ExecutionCacheContent
+        loading={loading}
+        error={error}
+        inspection={inspection}
+        onRetry={retry}
+      />
 
       <Dialog open={confirmOpen} onOpenChange={setConfirmOpen}>
         <DialogContent>
@@ -208,7 +248,7 @@ export function ExecutionCacheSettings(props: ExecutionCacheSettingsProps) {
               type="button"
               variant="outline"
               disabled={clearing}
-              onClick={() => setConfirmOpen(false)}
+              onClick={closeConfirmation}
             >
               Cancel
             </Button>
@@ -216,7 +256,7 @@ export function ExecutionCacheSettings(props: ExecutionCacheSettingsProps) {
               type="button"
               variant="destructive"
               disabled={clearing}
-              onClick={() => void clear()}
+              onClick={confirmClear}
             >
               {clearing ? 'Clearing…' : 'Clear cache'}
             </Button>

--- a/packages/studio/src/settings/settings.tsx
+++ b/packages/studio/src/settings/settings.tsx
@@ -1,4 +1,10 @@
-import { useEffect, useState } from 'react'
+import {
+  type ChangeEvent,
+  type Dispatch,
+  type SetStateAction,
+  useEffect,
+  useState,
+} from 'react'
 import type { StudioApi } from '../app/studio-api'
 import { Badge } from '../components/ui/badge'
 import { Button } from '../components/ui/button'
@@ -64,6 +70,494 @@ function pathsText(paths: StudioSuite['paths']): string {
   return paths.join(', ')
 }
 
+function initialSuiteEditor(suites: readonly StudioSuite[] | undefined) {
+  const suite = suites?.[0]
+  return {
+    name: suite?.name ?? '',
+    paths: pathsText(suite?.paths),
+    tags: suite?.tagExpression ?? '',
+    states: (suite?.states ?? ['active']).join(', '),
+    scenario: suite?.scenarioName ?? '',
+  }
+}
+
+function initialProfileEditor(profiles: readonly StudioProfile[] | undefined) {
+  const profile = profiles?.[0]
+  return {
+    id: profile?.id ?? '',
+    adapter: profile?.adapter ?? 'custom',
+    capabilities: (profile?.capabilities ?? []).join(', '),
+    mobile:
+      profile?.mobile ??
+      ({
+        executionTarget: 'android-emulator',
+        application: { id: '', binaryPath: '' },
+      } satisfies StudioMobileProfile),
+  }
+}
+
+function suiteConfiguration(suite: StudioSuite) {
+  return {
+    ...(suite.paths ? { paths: suite.paths } : {}),
+    ...(suite.tagExpression ? { tagExpression: suite.tagExpression } : {}),
+    ...(suite.states ? { states: suite.states } : {}),
+    ...(suite.scenarioName ? { scenarioName: suite.scenarioName } : {}),
+  }
+}
+
+function existingSuites(suites: readonly StudioSuite[] | undefined) {
+  return Object.fromEntries(
+    (suites ?? []).map((suite) => [suite.name, suiteConfiguration(suite)]),
+  )
+}
+
+function profileConfiguration(profile: StudioProfile) {
+  return {
+    adapter: profile.adapter,
+    ...(profile.capabilities ? { capabilities: profile.capabilities } : {}),
+    ...(profile.mobile ? { mobile: profile.mobile } : {}),
+  }
+}
+
+function existingProfiles(profiles: readonly StudioProfile[] | undefined) {
+  return Object.fromEntries(
+    (profiles ?? []).map((profile) => [
+      profile.id,
+      profileConfiguration(profile),
+    ]),
+  )
+}
+
+function commaSeparatedValues(value: string): string[] {
+  return value
+    .split(',')
+    .map((item) => item.trim())
+    .filter(Boolean)
+}
+
+function editedSuiteConfiguration(input: {
+  paths: string
+  tags: string
+  states: string
+  scenario: string
+}) {
+  const paths = commaSeparatedValues(input.paths)
+  const states = commaSeparatedValues(input.states).filter(
+    (state): state is (typeof specificationStates)[number] =>
+      specificationStates.includes(
+        state as (typeof specificationStates)[number],
+      ),
+  )
+  return {
+    ...(paths.length ? { paths } : {}),
+    ...(input.tags.trim() ? { tagExpression: input.tags.trim() } : {}),
+    ...(states.length ? { states } : {}),
+    ...(input.scenario.trim() ? { scenarioName: input.scenario.trim() } : {}),
+  }
+}
+
+function editedProfileConfiguration(
+  adapter: string,
+  capabilities: string,
+  mobileProfile: StudioMobileProfile,
+) {
+  const selectedAdapter = adapter.trim() || 'custom'
+  const nextCapabilities = commaSeparatedValues(capabilities)
+  return {
+    adapter: selectedAdapter,
+    ...(nextCapabilities.length ? { capabilities: nextCapabilities } : {}),
+    ...(selectedAdapter === 'mobile'
+      ? {
+          mobile: {
+            ...mobileProfile,
+            targetId: mobileProfile.targetId?.trim() || undefined,
+            application: {
+              id: mobileProfile.application.id.trim(),
+              binaryPath: mobileProfile.application.binaryPath.trim(),
+            },
+          },
+        }
+      : {}),
+  }
+}
+
+function MobileAdapterConfiguration(props: {
+  adapter: string
+  api: StudioApi
+  mobileProfile: StudioMobileProfile
+  profileId: string
+  onChange: (profile: StudioMobileProfile) => void
+  onError: (message: string | undefined) => void
+}) {
+  if (props.adapter.trim() !== 'mobile') return null
+  return (
+    <MobileProfileSettings
+      api={props.api}
+      onChange={props.onChange}
+      onError={props.onError}
+      profile={props.mobileProfile}
+      profileId={props.profileId}
+    />
+  )
+}
+
+function CredentialReferences(props: { secrets: readonly StudioCredential[] }) {
+  if (props.secrets.length === 0) {
+    return (
+      <p className="text-sm text-muted-foreground">
+        Project configuration stores keychain references only.
+      </p>
+    )
+  }
+  return (
+    <ul aria-label="Credential references" className="space-y-1 text-sm">
+      {props.secrets.map((secret) => (
+        <li key={secret.name}>
+          {secret.name}
+          {secret.present ? ' (present)' : ' (missing)'}
+        </li>
+      ))}
+    </ul>
+  )
+}
+
+function GitFileRow(props: {
+  file: GitFile
+  selected: boolean
+  expanded: boolean
+  onSelected: (path: string, selected: boolean) => void
+  onExpanded: (path: string) => void
+}) {
+  function handleSelected(checked: boolean) {
+    props.onSelected(props.file.path, checked)
+  }
+  function handleExpanded() {
+    props.onExpanded(props.file.path)
+  }
+  return (
+    <li className="space-y-1 rounded-md border border-border bg-card p-3">
+      <div className="flex items-center gap-2">
+        <Checkbox
+          id={`git-${props.file.path}`}
+          checked={props.selected}
+          onCheckedChange={handleSelected}
+        />
+        <Label htmlFor={`git-${props.file.path}`} className="font-mono">
+          {props.file.path}
+        </Label>
+        <Badge>
+          {props.file.status}
+          {props.file.staged ? ' staged' : ''}
+        </Badge>
+      </div>
+      <Button
+        type="button"
+        size="sm"
+        variant="outline"
+        onClick={handleExpanded}
+      >
+        {props.expanded ? 'Hide diff' : 'Show diff'}
+      </Button>
+      {props.expanded ? (
+        <section
+          aria-label={`${props.file.path} diff`}
+          className="max-h-64 overflow-auto"
+        >
+          <pre className="font-mono text-xs">
+            {props.file.diff || 'No textual diff'}
+          </pre>
+        </section>
+      ) : null}
+    </li>
+  )
+}
+
+function RepositoryChanges(props: {
+  files: readonly GitFile[] | undefined
+  selectedPaths: readonly string[]
+  expandedDiff?: string
+  onSelectedPaths: (paths: string[]) => void
+  onExpandedDiff: (path: string | undefined) => void
+}) {
+  if (!props.files?.length) {
+    return (
+      <p className="text-sm text-muted-foreground">No repository changes.</p>
+    )
+  }
+  function selectPath(path: string, selected: boolean) {
+    props.onSelectedPaths(
+      selected
+        ? [...props.selectedPaths, path]
+        : props.selectedPaths.filter((selectedPath) => selectedPath !== path),
+    )
+  }
+  function expandPath(path: string) {
+    props.onExpandedDiff(props.expandedDiff === path ? undefined : path)
+  }
+  return (
+    <ul aria-label="Repository changes" className="space-y-2">
+      {props.files.map((file) => (
+        <GitFileRow
+          key={file.path}
+          file={file}
+          selected={props.selectedPaths.includes(file.path)}
+          expanded={props.expandedDiff === file.path}
+          onSelected={selectPath}
+          onExpanded={expandPath}
+        />
+      ))}
+    </ul>
+  )
+}
+
+function PullRequestAction(props: {
+  git: GitStatus | undefined
+  onOpen: () => void
+}) {
+  if (props.git?.pullRequestAvailable) {
+    return (
+      <Button type="button" variant="outline" onClick={props.onOpen}>
+        Create pull request
+      </Button>
+    )
+  }
+  return (
+    <p className="text-xs text-muted-foreground">
+      {props.git?.pullRequestReason ??
+        'Pull request actions use the GitHub CLI when available.'}
+    </p>
+  )
+}
+
+function RepositorySettings(props: {
+  git: GitStatus | undefined
+  selectedPaths: string[]
+  expandedDiff?: string
+  commitMessage: string
+  confirmOpen: boolean
+  onSelectedPaths: (paths: string[]) => void
+  onExpandedDiff: (path: string | undefined) => void
+  onCommitMessage: (message: string) => void
+  onConfirmOpen: (open: boolean) => void
+  onStage: () => Promise<void>
+  onCommit: () => Promise<void>
+  onPullRequest: () => void
+}) {
+  function stage() {
+    void props.onStage()
+  }
+  function openConfirmation() {
+    props.onConfirmOpen(true)
+  }
+  function closeConfirmation() {
+    props.onConfirmOpen(false)
+  }
+  function commit() {
+    void props.onCommit()
+  }
+  function changeCommitMessage(event: ChangeEvent<HTMLInputElement>) {
+    props.onCommitMessage(event.target.value)
+  }
+  return (
+    <>
+      <section
+        className="space-y-4 border-t border-border pt-5"
+        aria-labelledby="git-heading"
+      >
+        <h2 id="git-heading" className="studio-display text-sm">
+          Repository
+        </h2>
+        <p className="font-mono text-xs text-muted-foreground" role="status">
+          {props.git?.branch
+            ? `Branch ${props.git.branch}`
+            : 'No Git repository'}
+        </p>
+        <RepositoryChanges
+          files={props.git?.files}
+          selectedPaths={props.selectedPaths}
+          expandedDiff={props.expandedDiff}
+          onSelectedPaths={props.onSelectedPaths}
+          onExpandedDiff={props.onExpandedDiff}
+        />
+        <div className="flex flex-wrap gap-2">
+          <Button
+            type="button"
+            variant="outline"
+            disabled={props.selectedPaths.length === 0}
+            onClick={stage}
+          >
+            Stage selected
+          </Button>
+          <Button
+            type="button"
+            disabled={
+              !props.commitMessage.trim() || props.selectedPaths.length === 0
+            }
+            onClick={openConfirmation}
+          >
+            Commit selected changes
+          </Button>
+          <PullRequestAction git={props.git} onOpen={props.onPullRequest} />
+        </div>
+        <div className="space-y-1">
+          <Label htmlFor="commit-message">Commit message</Label>
+          <Input
+            id="commit-message"
+            aria-label="Commit message"
+            value={props.commitMessage}
+            onChange={changeCommitMessage}
+          />
+        </div>
+      </section>
+
+      <Dialog open={props.confirmOpen} onOpenChange={props.onConfirmOpen}>
+        <DialogContent showCloseButton={false}>
+          <DialogHeader>
+            <DialogTitle>Commit selected changes?</DialogTitle>
+            <DialogDescription>
+              Studio will create a local commit. It will not push repository
+              changes.
+            </DialogDescription>
+          </DialogHeader>
+          <p className="font-mono text-xs">{props.commitMessage}</p>
+          <DialogFooter>
+            <Button type="button" variant="outline" onClick={closeConfirmation}>
+              Cancel
+            </Button>
+            <Button type="button" onClick={commit}>
+              Confirm commit
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </>
+  )
+}
+
+function SuiteSelector(props: {
+  suites: readonly StudioSuite[]
+  selectedName: string
+  onSelect: (suite: StudioSuite) => void
+  onNew: () => void
+}) {
+  return (
+    <div className="flex flex-wrap gap-1">
+      {props.suites.map((suite) => (
+        <Button
+          key={suite.name}
+          type="button"
+          size="sm"
+          variant={suite.name === props.selectedName ? 'default' : 'outline'}
+          aria-pressed={suite.name === props.selectedName}
+          onClick={() => props.onSelect(suite)}
+        >
+          {suite.name}
+        </Button>
+      ))}
+      <Button type="button" size="sm" variant="outline" onClick={props.onNew}>
+        New test suite
+      </Button>
+    </div>
+  )
+}
+
+function ProfileSelector(props: {
+  profiles: readonly StudioProfile[]
+  selectedId: string
+  onSelect: (id: string) => void
+}) {
+  return (
+    <div className="flex flex-wrap gap-1">
+      {props.profiles.map((profile) => (
+        <Button
+          key={profile.id}
+          type="button"
+          size="sm"
+          variant={profile.id === props.selectedId ? 'default' : 'outline'}
+          aria-pressed={profile.id === props.selectedId}
+          onClick={() => props.onSelect(profile.id)}
+        >
+          {profile.id}
+        </Button>
+      ))}
+    </div>
+  )
+}
+
+function useSuiteFieldSync(
+  suites: readonly StudioSuite[] | undefined,
+  selectedName: string,
+  setters: {
+    paths: Dispatch<SetStateAction<string>>
+    tags: Dispatch<SetStateAction<string>>
+    states: Dispatch<SetStateAction<string>>
+    scenario: Dispatch<SetStateAction<string>>
+  },
+): void {
+  const { paths, tags, states, scenario } = setters
+  useEffect(() => {
+    if (!selectedName) {
+      paths('')
+      tags('')
+      states('active')
+      scenario('')
+      return
+    }
+    const suite = suites?.find((item) => item.name === selectedName)
+    if (!suite) return
+    paths(pathsText(suite.paths))
+    tags(suite.tagExpression ?? '')
+    states((suite.states ?? ['active']).join(', '))
+    scenario(suite.scenarioName ?? '')
+  }, [paths, scenario, selectedName, states, suites, tags])
+}
+
+function useProfileFieldSync(
+  profiles: readonly StudioProfile[] | undefined,
+  profileId: string,
+  setters: {
+    adapter: Dispatch<SetStateAction<string>>
+    capabilities: Dispatch<SetStateAction<string>>
+    mobile: Dispatch<SetStateAction<StudioMobileProfile>>
+  },
+): void {
+  const { adapter, capabilities, mobile } = setters
+  useEffect(() => {
+    const profile =
+      profiles?.find((item) => item.id === profileId) ?? profiles?.[0]
+    adapter(profile?.adapter ?? 'custom')
+    capabilities((profile?.capabilities ?? []).join(', '))
+    mobile(
+      profile?.mobile ?? {
+        executionTarget: 'android-emulator',
+        application: { id: '', binaryPath: '' },
+      },
+    )
+  }, [adapter, capabilities, mobile, profileId, profiles])
+}
+
+function useGitStatus(
+  api: StudioApi,
+  onError: (message: string | undefined) => void,
+): [GitStatus | undefined, Dispatch<SetStateAction<GitStatus | undefined>>] {
+  const [git, setGit] = useState<GitStatus>()
+  useEffect(() => {
+    let cancelled = false
+    void api<GitStatus>('/api/git').then(
+      (value) => {
+        if (!cancelled) setGit(value)
+      },
+      (reason: unknown) => {
+        if (!cancelled) onError(reasonMessage(reason))
+      },
+    )
+    return () => {
+      cancelled = true
+    }
+  }, [api, onError])
+  return [git, setGit]
+}
+
 export function SettingsPanel<
   T extends {
     suiteDetails?: readonly StudioSuite[]
@@ -76,91 +570,39 @@ export function SettingsPanel<
   onProject: (project: T) => void
   onError: (message: string | undefined) => void
 }) {
-  const [suiteName, setSuiteName] = useState(
-    props.project.suiteDetails?.[0]?.name ?? '',
-  )
+  const initialSuite = initialSuiteEditor(props.project.suiteDetails)
+  const [suiteName, setSuiteName] = useState(initialSuite.name)
   const [originalSuiteName, setOriginalSuiteName] = useState(suiteName)
-  const selectedSuite = props.project.suiteDetails?.find(
-    (suite) => suite.name === originalSuiteName,
-  )
-  const [suitePaths, setSuitePaths] = useState(pathsText(selectedSuite?.paths))
-  const [suiteTags, setSuiteTags] = useState(selectedSuite?.tagExpression ?? '')
-  const [suiteStates, setSuiteStates] = useState(
-    (selectedSuite?.states ?? ['active']).join(', '),
-  )
-  const [suiteScenario, setSuiteScenario] = useState(
-    selectedSuite?.scenarioName ?? '',
-  )
-  const [profileId, setProfileId] = useState(
-    props.project.profileDetails?.[0]?.id ?? '',
-  )
-  const selectedProfile =
-    props.project.profileDetails?.find((profile) => profile.id === profileId) ??
-    props.project.profileDetails?.[0]
-  const [adapter, setAdapter] = useState(selectedProfile?.adapter ?? 'custom')
-  const [capabilities, setCapabilities] = useState(
-    (selectedProfile?.capabilities ?? []).join(', '),
-  )
+  const [suitePaths, setSuitePaths] = useState(initialSuite.paths)
+  const [suiteTags, setSuiteTags] = useState(initialSuite.tags)
+  const [suiteStates, setSuiteStates] = useState(initialSuite.states)
+  const [suiteScenario, setSuiteScenario] = useState(initialSuite.scenario)
+  const initialProfile = initialProfileEditor(props.project.profileDetails)
+  const [profileId, setProfileId] = useState(initialProfile.id)
+  const [adapter, setAdapter] = useState(initialProfile.adapter)
+  const [capabilities, setCapabilities] = useState(initialProfile.capabilities)
   const [mobileProfile, setMobileProfile] = useState<StudioMobileProfile>(
-    selectedProfile?.mobile ?? {
-      executionTarget: 'android-emulator',
-      application: { id: '', binaryPath: '' },
-    },
+    initialProfile.mobile,
   )
   const [secretName, setSecretName] = useState('')
   const [secretValue, setSecretValue] = useState('')
-  const [git, setGit] = useState<GitStatus>()
+  const [git, setGit] = useGitStatus(props.api, props.onError)
   const [selectedPaths, setSelectedPaths] = useState<string[]>([])
   const [commitMessage, setCommitMessage] = useState('')
   const [confirmOpen, setConfirmOpen] = useState(false)
   const [expandedDiff, setExpandedDiff] = useState<string>()
 
-  useEffect(() => {
-    if (!originalSuiteName) {
-      setSuitePaths('')
-      setSuiteTags('')
-      setSuiteStates('active')
-      setSuiteScenario('')
-      return
-    }
-    const suite = props.project.suiteDetails?.find(
-      (item) => item.name === originalSuiteName,
-    )
-    if (!suite) return
-    setSuitePaths(pathsText(suite.paths))
-    setSuiteTags(suite.tagExpression ?? '')
-    setSuiteStates((suite.states ?? ['active']).join(', '))
-    setSuiteScenario(suite.scenarioName ?? '')
-  }, [props.project.suiteDetails, originalSuiteName])
-
-  useEffect(() => {
-    const profile =
-      props.project.profileDetails?.find((item) => item.id === profileId) ??
-      props.project.profileDetails?.[0]
-    setAdapter(profile?.adapter ?? 'custom')
-    setCapabilities((profile?.capabilities ?? []).join(', '))
-    setMobileProfile(
-      profile?.mobile ?? {
-        executionTarget: 'android-emulator',
-        application: { id: '', binaryPath: '' },
-      },
-    )
-  }, [props.project.profileDetails, profileId])
-
-  useEffect(() => {
-    let cancelled = false
-    props
-      .api<GitStatus>('/api/git')
-      .then((value) => {
-        if (!cancelled) setGit(value)
-      })
-      .catch((reason: unknown) => {
-        if (!cancelled) props.onError(reasonMessage(reason))
-      })
-    return () => {
-      cancelled = true
-    }
-  }, [props.api, props.onError])
+  useSuiteFieldSync(props.project.suiteDetails, originalSuiteName, {
+    paths: setSuitePaths,
+    tags: setSuiteTags,
+    states: setSuiteStates,
+    scenario: setSuiteScenario,
+  })
+  useProfileFieldSync(props.project.profileDetails, profileId, {
+    adapter: setAdapter,
+    capabilities: setCapabilities,
+    mobile: setMobileProfile,
+  })
 
   async function saveSuites() {
     const name = suiteName.trim()
@@ -168,37 +610,13 @@ export function SettingsPanel<
       props.onError('A test suite name is required')
       return
     }
-    const suites = Object.fromEntries(
-      (props.project.suiteDetails ?? []).map((suite) => [
-        suite.name,
-        {
-          ...(suite.paths ? { paths: suite.paths } : {}),
-          ...(suite.tagExpression
-            ? { tagExpression: suite.tagExpression }
-            : {}),
-          ...(suite.states ? { states: suite.states } : {}),
-          ...(suite.scenarioName ? { scenarioName: suite.scenarioName } : {}),
-        },
-      ]),
-    )
-    const paths = suitePaths
-      .split(',')
-      .map((path) => path.trim())
-      .filter(Boolean)
-    const states = suiteStates
-      .split(',')
-      .map((state) => state.trim())
-      .filter((state): state is (typeof specificationStates)[number] =>
-        specificationStates.includes(
-          state as (typeof specificationStates)[number],
-        ),
-      )
-    suites[name] = {
-      ...(paths.length ? { paths } : {}),
-      ...(suiteTags.trim() ? { tagExpression: suiteTags.trim() } : {}),
-      ...(states.length ? { states } : {}),
-      ...(suiteScenario.trim() ? { scenarioName: suiteScenario.trim() } : {}),
-    }
+    const suites = existingSuites(props.project.suiteDetails)
+    suites[name] = editedSuiteConfiguration({
+      paths: suitePaths,
+      tags: suiteTags,
+      states: suiteStates,
+      scenario: suiteScenario,
+    })
     if (originalSuiteName && originalSuiteName !== name) {
       delete suites[originalSuiteName]
     }
@@ -223,38 +641,12 @@ export function SettingsPanel<
       props.onError('An execution target profile id is required')
       return
     }
-    const profiles = Object.fromEntries(
-      (props.project.profileDetails ?? []).map((profile) => [
-        profile.id,
-        {
-          adapter: profile.adapter,
-          ...(profile.capabilities
-            ? { capabilities: profile.capabilities }
-            : {}),
-          ...(profile.mobile ? { mobile: profile.mobile } : {}),
-        },
-      ]),
+    const profiles = existingProfiles(props.project.profileDetails)
+    profiles[id] = editedProfileConfiguration(
+      adapter,
+      capabilities,
+      mobileProfile,
     )
-    const nextCapabilities = capabilities
-      .split(',')
-      .map((value) => value.trim())
-      .filter(Boolean)
-    profiles[id] = {
-      adapter: adapter.trim() || 'custom',
-      ...(nextCapabilities.length ? { capabilities: nextCapabilities } : {}),
-      ...(adapter.trim() === 'mobile'
-        ? {
-            mobile: {
-              ...mobileProfile,
-              targetId: mobileProfile.targetId?.trim() || undefined,
-              application: {
-                id: mobileProfile.application.id.trim(),
-                binaryPath: mobileProfile.application.binaryPath.trim(),
-              },
-            },
-          }
-        : {}),
-    }
     props.onError(undefined)
     try {
       const project = await props.api<T>('/api/config', {
@@ -340,6 +732,24 @@ export function SettingsPanel<
     }
   }
 
+  function openPullRequestFromSettings() {
+    void openPullRequest()
+  }
+
+  function selectSuite(suite: StudioSuite) {
+    setSuiteName(suite.name)
+    setOriginalSuiteName(suite.name)
+  }
+
+  function newSuite() {
+    setSuiteName('')
+    setOriginalSuiteName('')
+    setSuitePaths('')
+    setSuiteTags('')
+    setSuiteStates('active')
+    setSuiteScenario('')
+  }
+
   const secrets: readonly StudioCredential[] = props.project.secrets ?? []
   const profiles: readonly StudioProfile[] = props.project.profileDetails ?? []
   const suites: readonly StudioSuite[] = props.project.suiteDetails ?? []
@@ -362,38 +772,12 @@ export function SettingsPanel<
         <h2 id="suites-heading" className="studio-display text-sm">
           Test suites
         </h2>
-        <div className="flex flex-wrap gap-1">
-          {suites.map((suite) => (
-            <Button
-              key={suite.name}
-              type="button"
-              size="sm"
-              variant={suite.name === originalSuiteName ? 'default' : 'outline'}
-              aria-pressed={suite.name === originalSuiteName}
-              onClick={() => {
-                setSuiteName(suite.name)
-                setOriginalSuiteName(suite.name)
-              }}
-            >
-              {suite.name}
-            </Button>
-          ))}
-          <Button
-            type="button"
-            size="sm"
-            variant="outline"
-            onClick={() => {
-              setSuiteName('')
-              setOriginalSuiteName('')
-              setSuitePaths('')
-              setSuiteTags('')
-              setSuiteStates('active')
-              setSuiteScenario('')
-            }}
-          >
-            New test suite
-          </Button>
-        </div>
+        <SuiteSelector
+          suites={suites}
+          selectedName={originalSuiteName}
+          onSelect={selectSuite}
+          onNew={newSuite}
+        />
         <div className="grid gap-3 sm:grid-cols-2">
           <div className="space-y-1">
             <Label htmlFor="suite-name">Suite name</Label>
@@ -453,20 +837,11 @@ export function SettingsPanel<
         <h2 id="profiles-heading" className="studio-display text-sm">
           Execution target profiles
         </h2>
-        <div className="flex flex-wrap gap-1">
-          {profiles.map((profile) => (
-            <Button
-              key={profile.id}
-              type="button"
-              size="sm"
-              variant={profile.id === profileId ? 'default' : 'outline'}
-              aria-pressed={profile.id === profileId}
-              onClick={() => setProfileId(profile.id)}
-            >
-              {profile.id}
-            </Button>
-          ))}
-        </div>
+        <ProfileSelector
+          profiles={profiles}
+          selectedId={profileId}
+          onSelect={setProfileId}
+        />
         <div className="grid gap-3 sm:grid-cols-3">
           <div className="space-y-1">
             <Label htmlFor="profile-id">Profile id</Label>
@@ -496,15 +871,14 @@ export function SettingsPanel<
             />
           </div>
         </div>
-        {adapter.trim() === 'mobile' ? (
-          <MobileProfileSettings
-            api={props.api}
-            onChange={setMobileProfile}
-            onError={props.onError}
-            profile={mobileProfile}
-            profileId={profileId}
-          />
-        ) : null}
+        <MobileAdapterConfiguration
+          adapter={adapter}
+          api={props.api}
+          mobileProfile={mobileProfile}
+          profileId={profileId}
+          onChange={setMobileProfile}
+          onError={props.onError}
+        />
         <Button type="button" onClick={() => void saveProfiles()}>
           Save execution target profile
         </Button>
@@ -517,20 +891,7 @@ export function SettingsPanel<
         <h2 id="credentials-heading" className="studio-display text-sm">
           Credentials
         </h2>
-        {secrets.length === 0 ? (
-          <p className="text-sm text-muted-foreground">
-            Project configuration stores keychain references only.
-          </p>
-        ) : (
-          <ul aria-label="Credential references" className="space-y-1 text-sm">
-            {secrets.map((secret) => (
-              <li key={secret.name}>
-                {secret.name}
-                {secret.present ? ' (present)' : ' (missing)'}
-              </li>
-            ))}
-          </ul>
-        )}
+        <CredentialReferences secrets={secrets} />
         <div className="grid gap-3 sm:grid-cols-2">
           <div className="space-y-1">
             <Label htmlFor="credential-name">Credential name</Label>
@@ -557,139 +918,20 @@ export function SettingsPanel<
         </Button>
       </section>
 
-      <section
-        className="space-y-4 border-t border-border pt-5"
-        aria-labelledby="git-heading"
-      >
-        <h2 id="git-heading" className="studio-display text-sm">
-          Repository
-        </h2>
-        <p className="font-mono text-xs text-muted-foreground" role="status">
-          {git?.branch ? `Branch ${git.branch}` : 'No Git repository'}
-        </p>
-        {git?.files.length ? (
-          <ul aria-label="Repository changes" className="space-y-2">
-            {git.files.map((file) => (
-              <li
-                key={file.path}
-                className="space-y-1 rounded-md border border-border bg-card p-3"
-              >
-                <div className="flex items-center gap-2">
-                  <Checkbox
-                    id={`git-${file.path}`}
-                    checked={selectedPaths.includes(file.path)}
-                    onCheckedChange={(checked) => {
-                      setSelectedPaths((current) =>
-                        checked
-                          ? [...current, file.path]
-                          : current.filter((path) => path !== file.path),
-                      )
-                    }}
-                  />
-                  <Label htmlFor={`git-${file.path}`} className="font-mono">
-                    {file.path}
-                  </Label>
-                  <Badge>
-                    {file.status}
-                    {file.staged ? ' staged' : ''}
-                  </Badge>
-                </div>
-                <Button
-                  type="button"
-                  size="sm"
-                  variant="outline"
-                  onClick={() =>
-                    setExpandedDiff((current) =>
-                      current === file.path ? undefined : file.path,
-                    )
-                  }
-                >
-                  {expandedDiff === file.path ? 'Hide diff' : 'Show diff'}
-                </Button>
-                {expandedDiff === file.path ? (
-                  <section
-                    aria-label={`${file.path} diff`}
-                    className="max-h-64 overflow-auto"
-                  >
-                    <pre className="font-mono text-xs">
-                      {file.diff || 'No textual diff'}
-                    </pre>
-                  </section>
-                ) : null}
-              </li>
-            ))}
-          </ul>
-        ) : (
-          <p className="text-sm text-muted-foreground">
-            No repository changes.
-          </p>
-        )}
-        <div className="flex flex-wrap gap-2">
-          <Button
-            type="button"
-            variant="outline"
-            disabled={selectedPaths.length === 0}
-            onClick={() => void stageSelected()}
-          >
-            Stage selected
-          </Button>
-          <Button
-            type="button"
-            disabled={!commitMessage.trim() || selectedPaths.length === 0}
-            onClick={() => setConfirmOpen(true)}
-          >
-            Commit selected changes
-          </Button>
-          {git?.pullRequestAvailable ? (
-            <Button
-              type="button"
-              variant="outline"
-              onClick={() => void openPullRequest()}
-            >
-              Create pull request
-            </Button>
-          ) : (
-            <p className="text-xs text-muted-foreground">
-              {git?.pullRequestReason ??
-                'Pull request actions use the GitHub CLI when available.'}
-            </p>
-          )}
-        </div>
-        <div className="space-y-1">
-          <Label htmlFor="commit-message">Commit message</Label>
-          <Input
-            id="commit-message"
-            aria-label="Commit message"
-            value={commitMessage}
-            onChange={(event) => setCommitMessage(event.target.value)}
-          />
-        </div>
-      </section>
-
-      <Dialog open={confirmOpen} onOpenChange={setConfirmOpen}>
-        <DialogContent showCloseButton={false}>
-          <DialogHeader>
-            <DialogTitle>Commit selected changes?</DialogTitle>
-            <DialogDescription>
-              Studio will create a local commit. It will not push repository
-              changes.
-            </DialogDescription>
-          </DialogHeader>
-          <p className="font-mono text-xs">{commitMessage}</p>
-          <DialogFooter>
-            <Button
-              type="button"
-              variant="outline"
-              onClick={() => setConfirmOpen(false)}
-            >
-              Cancel
-            </Button>
-            <Button type="button" onClick={() => void commitSelected()}>
-              Confirm commit
-            </Button>
-          </DialogFooter>
-        </DialogContent>
-      </Dialog>
+      <RepositorySettings
+        git={git}
+        selectedPaths={selectedPaths}
+        expandedDiff={expandedDiff}
+        commitMessage={commitMessage}
+        confirmOpen={confirmOpen}
+        onSelectedPaths={setSelectedPaths}
+        onExpandedDiff={setExpandedDiff}
+        onCommitMessage={setCommitMessage}
+        onConfirmOpen={setConfirmOpen}
+        onStage={stageSelected}
+        onCommit={commitSelected}
+        onPullRequest={openPullRequestFromSettings}
+      />
     </main>
   )
 }

--- a/packages/web/src/adapter/direct-browser.ts
+++ b/packages/web/src/adapter/direct-browser.ts
@@ -63,13 +63,27 @@ async function waitForNthLocator(
     const visible = exists
       ? await locatorFor(page, locator, bindings).isVisible()
       : false
-    if (state === 'attached' && exists) return true
-    if (state === 'detached' && !exists) return true
-    if (state === 'visible' && visible) return true
-    if (state === 'hidden' && !visible) return true
+    if (locatorReachedState(state, exists, visible)) return true
     await Bun.sleep(50)
   }
   return false
+}
+
+function locatorReachedState(
+  state: 'attached' | 'detached' | 'visible' | 'hidden',
+  exists: boolean,
+  visible: boolean,
+): boolean {
+  switch (state) {
+    case 'attached':
+      return exists
+    case 'detached':
+      return !exists
+    case 'visible':
+      return visible
+    case 'hidden':
+      return !visible
+  }
 }
 
 function comparison(
@@ -84,6 +98,134 @@ function comparison(
         actualState: String(actual),
         message: `Expected ${JSON.stringify(expected)} but received ${JSON.stringify(actual)}`,
       }
+}
+
+async function executeLocatorAction(
+  instruction: WebInstruction,
+  locator: Locator,
+  bindings: readonly ScenarioVariableBinding[],
+  signal?: AbortSignal,
+): Promise<WebDirectExecutionResult | undefined> {
+  switch (instruction.kind) {
+    case 'click':
+      await withAbort(locator.sendClickEvent(), signal)
+      return { success: true }
+    case 'fill':
+      await withAbort(
+        locator.fill(boundValue(instruction.value, bindings)),
+        signal,
+      )
+      return { success: true }
+    case 'type':
+      await withAbort(
+        locator.type(boundValue(instruction.value, bindings)),
+        signal,
+      )
+      return { success: true }
+    case 'hover':
+      await withAbort(locator.hover(), signal)
+      return { success: true }
+    case 'select-option':
+      await withAbort(
+        locator.selectOption(
+          instruction.values.map((value) => boundValue(value, bindings)),
+        ),
+        signal,
+      )
+      return { success: true }
+    default:
+      return undefined
+  }
+}
+
+function countExpectation(
+  instruction: Extract<WebInstruction, { kind: 'count-equals' }>,
+  bindings: readonly ScenarioVariableBinding[],
+): number {
+  const expectation = instruction.expected
+  const expected =
+    typeof expectation === 'number'
+      ? expectation
+      : Number(
+          bindings.find((binding) => binding.name === expectation.variable)
+            ?.value,
+        )
+  if (!Number.isSafeInteger(expected) || expected < 0) {
+    throw new Error('Replay count variable must be a non-negative integer')
+  }
+  return expected
+}
+
+async function executeLocatorAssertion(
+  page: Page,
+  instruction: WebInstruction,
+  locator: Locator,
+  bindings: readonly ScenarioVariableBinding[],
+  timeoutMs: number,
+  signal?: AbortSignal,
+): Promise<WebDirectExecutionResult> {
+  switch (instruction.kind) {
+    case 'wait-for': {
+      const success = await waitForNthLocator(
+        page,
+        instruction.locator,
+        instruction.state,
+        bindings,
+        timeoutMs,
+        signal,
+      )
+      return success
+        ? { success: true }
+        : {
+            success: false,
+            actualState: 'wait timed out',
+            message: `Timed out waiting for locator to be ${instruction.state}`,
+          }
+    }
+    case 'exists': {
+      const actual = await locatorCount(page, instruction.locator, bindings)
+      const minimum = (instruction.locator.nth ?? 0) + 1
+      return comparison(
+        actual >= minimum,
+        `at least ${minimum} matches`,
+        actual,
+      )
+    }
+    case 'visible': {
+      const actual = await locator.isVisible()
+      return comparison(actual, true, actual)
+    }
+    case 'hidden': {
+      const count = await locatorCount(page, instruction.locator, bindings)
+      const actual =
+        count <= (instruction.locator.nth ?? 0) || !(await locator.isVisible())
+      return comparison(actual, true, actual)
+    }
+    case 'text-equals': {
+      const expected = boundValue(instruction.expected, bindings)
+      const actual = await locator.innerText()
+      return comparison(actual === expected, expected, actual)
+    }
+    case 'text-contains': {
+      const expected = boundValue(instruction.expected, bindings)
+      const actual = await locator.innerText()
+      return comparison(actual.includes(expected), expected, actual)
+    }
+    case 'value-equals': {
+      const expected = boundValue(instruction.expected, bindings)
+      const actual = await locator.inputValue()
+      return comparison(actual === expected, expected, actual)
+    }
+    case 'count-equals': {
+      const expected = countExpectation(instruction, bindings)
+      const actual = await locatorCount(page, instruction.locator, bindings)
+      return comparison(actual === expected, expected, actual)
+    }
+    default:
+      throw new Error(
+        `Unsupported direct browser instruction: ${instruction.kind}`,
+      )
+  }
 }
 
 export function createDirectBrowser(
@@ -120,104 +262,21 @@ export function createDirectBrowser(
         return comparison(actual === expected, expected, actual)
       }
       const locator = locatorFor(page, instruction.locator, bindings)
-      switch (instruction.kind) {
-        case 'click':
-          await withAbort(locator.sendClickEvent(), signal)
-          return { success: true }
-        case 'fill':
-          await withAbort(
-            locator.fill(boundValue(instruction.value, bindings)),
-            signal,
-          )
-          return { success: true }
-        case 'type':
-          await withAbort(
-            locator.type(boundValue(instruction.value, bindings)),
-            signal,
-          )
-          return { success: true }
-        case 'hover':
-          await withAbort(locator.hover(), signal)
-          return { success: true }
-        case 'select-option':
-          await withAbort(
-            locator.selectOption(
-              instruction.values.map((value) => boundValue(value, bindings)),
-            ),
-            signal,
-          )
-          return { success: true }
-        case 'wait-for': {
-          const success = await waitForNthLocator(
-            page,
-            instruction.locator,
-            instruction.state,
-            bindings,
-            options.actionTimeoutMs,
-            signal,
-          )
-          return success
-            ? { success: true }
-            : {
-                success: false,
-                actualState: 'wait timed out',
-                message: `Timed out waiting for locator to be ${instruction.state}`,
-              }
-        }
-        case 'exists': {
-          const actual = await locatorCount(page, instruction.locator, bindings)
-          const minimum = (instruction.locator.nth ?? 0) + 1
-          return comparison(
-            actual >= minimum,
-            `at least ${minimum} matches`,
-            actual,
-          )
-        }
-        case 'visible': {
-          const actual = await locator.isVisible()
-          return comparison(actual, true, actual)
-        }
-        case 'hidden': {
-          const count = await locatorCount(page, instruction.locator, bindings)
-          const actual =
-            count <= (instruction.locator.nth ?? 0) ||
-            !(await locator.isVisible())
-          return comparison(actual, true, actual)
-        }
-        case 'text-equals': {
-          const expected = boundValue(instruction.expected, bindings)
-          const actual = await locator.innerText()
-          return comparison(actual === expected, expected, actual)
-        }
-        case 'text-contains': {
-          const expected = boundValue(instruction.expected, bindings)
-          const actual = await locator.innerText()
-          return comparison(actual.includes(expected), expected, actual)
-        }
-        case 'value-equals': {
-          const expected = boundValue(instruction.expected, bindings)
-          const actual = await locator.inputValue()
-          return comparison(actual === expected, expected, actual)
-        }
-        case 'count-equals': {
-          const countExpectation = instruction.expected
-          const expected =
-            typeof countExpectation === 'number'
-              ? countExpectation
-              : Number(
-                  bindings.find(
-                    (binding) => binding.name === countExpectation.variable,
-                  )?.value,
-                )
-          if (!Number.isSafeInteger(expected) || expected < 0) {
-            throw new Error(
-              'Replay count variable must be a non-negative integer',
-            )
-          }
-          const actual = await locatorCount(page, instruction.locator, bindings)
-          return comparison(actual === expected, expected, actual)
-        }
-      }
+      const action = await executeLocatorAction(
+        instruction,
+        locator,
+        bindings,
+        signal,
+      )
+      if (action) return action
+      return executeLocatorAssertion(
+        page,
+        instruction,
+        locator,
+        bindings,
+        options.actionTimeoutMs,
+        signal,
+      )
     },
   }
 }

--- a/packages/web/src/adapter/stagehand-factory.ts
+++ b/packages/web/src/adapter/stagehand-factory.ts
@@ -22,7 +22,7 @@ import {
 } from './fidelity'
 import { createStagehandAutomation } from './stagehand-automation'
 import type { WebAutomationFactory, WebClientContext } from './web-automation'
-import { defaultModelName } from './web-options'
+import { type BrowserOptions, defaultModelName } from './web-options'
 
 const defaultDomSettleTimeoutMs = 3_000
 const defaultObserveTimeoutMs = 10_000
@@ -87,6 +87,44 @@ async function applyFidelity(
   }
 }
 
+function stagehandModel(
+  context: WebClientContext,
+  defaults: BrowserOptions,
+): ModelConfig {
+  const modelName =
+    context.browser.modelName ?? defaults.modelName ?? defaultModelName
+  const modelApiKey = context.browser.modelApiKey ?? defaults.modelApiKey
+  const model: ModelConfig = {
+    modelName: modelName as ModelConfig['modelName'],
+  }
+  if (modelApiKey !== undefined) model.apiKey = modelApiKey
+  return model
+}
+
+function stagehandCreateOptions(
+  browser: StagehandCreateOptions['browser'],
+  context: WebClientContext,
+  defaults: BrowserOptions,
+): StagehandCreateOptions {
+  const selfHeal = context.browser.selfHeal ?? defaults.selfHeal ?? true
+  const domSettleTimeoutMs =
+    context.browser.domSettleTimeoutMs ??
+    defaults.domSettleTimeoutMs ??
+    defaultDomSettleTimeoutMs
+  const cache = context.browser.cache ?? defaults.cache
+  const createOptions: StagehandCreateOptions = {
+    browser,
+    logging: { level: 'off', format: 'json' },
+    selfHeal,
+    domSettleTimeoutMs,
+  }
+  if (context.mode !== 'replay') {
+    createOptions.model = stagehandModel(context, defaults)
+  }
+  if (cache !== undefined) createOptions.cache = cache
+  return createOptions
+}
+
 export const stagehandFactory: WebAutomationFactory = {
   async launch({ browser: options, signal }) {
     if (signal?.aborted) throw abortError()
@@ -108,32 +146,9 @@ export const stagehandFactory: WebAutomationFactory = {
       context: WebClientContext,
     ): Promise<Stagehand> {
       if (stagehand) return stagehand
-      const selfHeal = context.browser.selfHeal ?? options.selfHeal ?? true
-      const domSettleTimeoutMs =
-        context.browser.domSettleTimeoutMs ??
-        options.domSettleTimeoutMs ??
-        defaultDomSettleTimeoutMs
-      const cache = context.browser.cache ?? options.cache
-
-      const createOptions: StagehandCreateOptions = {
-        browser,
-        logging: { level: 'off', format: 'json' },
-        selfHeal,
-        domSettleTimeoutMs,
-      }
-      if (context.mode !== 'replay') {
-        const modelName =
-          context.browser.modelName ?? options.modelName ?? defaultModelName
-        const modelApiKey = context.browser.modelApiKey ?? options.modelApiKey
-        const model: ModelConfig = {
-          modelName: modelName as ModelConfig['modelName'],
-        }
-        if (modelApiKey !== undefined) model.apiKey = modelApiKey
-        createOptions.model = model
-      }
-      if (cache !== undefined) createOptions.cache = cache
-
-      stagehand = await Stagehand.create(createOptions)
+      stagehand = await Stagehand.create(
+        stagehandCreateOptions(browser, context, options),
+      )
       return stagehand
     }
 

--- a/packages/web/src/adapter/web-adapter.ts
+++ b/packages/web/src/adapter/web-adapter.ts
@@ -1,4 +1,5 @@
 import type {
+  OpenSessionInput,
   StepExecutionTargetAdapter,
   StepTargetSession,
 } from '@pickle-spec/runner'
@@ -99,6 +100,39 @@ function resolveBrowserLaunchOptions({
   return resolvedBrowser
 }
 
+function browserOptionsForSession(
+  input: OpenSessionInput,
+  options: WebAdapterOptions,
+  requireProviderApiKey: boolean,
+): BrowserOptions {
+  const executionMode = input.mode ?? 'adaptive'
+  const cacheReplay =
+    executionMode === 'replay' && input.executionCache !== undefined
+  return resolveBrowserLaunchOptions({
+    browser: {
+      ...options.browser,
+      selfHeal:
+        executionMode === 'replay'
+          ? false
+          : (options.browser?.selfHeal ?? true),
+    },
+    requireProviderApiKey,
+    requiresInference: !cacheReplay,
+  })
+}
+
+function shouldNavigateEagerly(
+  behavior: WebAdapterBehavior,
+  cacheReplay: boolean,
+  supportsInstructions: boolean,
+): boolean {
+  return (
+    behavior.navigationPolicy === 'eager' &&
+    !cacheReplay &&
+    !supportsInstructions
+  )
+}
+
 export interface WebAdapterBehavior {
   navigationPolicy?: 'delayed' | 'eager'
 }
@@ -139,17 +173,11 @@ export function createWebAdapter(
       const executionMode = input.mode ?? 'adaptive'
       const cacheReplay =
         executionMode === 'replay' && input.executionCache !== undefined
-      const browserOptions = resolveBrowserLaunchOptions({
-        browser: {
-          ...options.browser,
-          selfHeal:
-            executionMode === 'replay'
-              ? false
-              : (options.browser?.selfHeal ?? true),
-        },
+      const browserOptions = browserOptionsForSession(
+        input,
+        options,
         requireProviderApiKey,
-        requiresInference: !cacheReplay,
-      })
+      )
       const logicalSession = await pool.openLogicalSession(
         browserOptions,
         input.signal,
@@ -182,9 +210,11 @@ export function createWebAdapter(
 
       let eagerlyNavigated = false
       if (
-        behavior.navigationPolicy === 'eager' &&
-        !cacheReplay &&
-        !automation.executeInstruction
+        shouldNavigateEagerly(
+          behavior,
+          cacheReplay,
+          Boolean(automation.executeInstruction),
+        )
       ) {
         await automation.navigate(options.baseUrl, input.signal)
         eagerlyNavigated = true

--- a/packages/web/src/adapter/web-live-session.ts
+++ b/packages/web/src/adapter/web-live-session.ts
@@ -84,6 +84,34 @@ export function createWebLiveSession({
     return { state: 'passed', resolvedActions }
   }
 
+  async function executePrompt(
+    step: ScenarioStep,
+    prompt: string,
+    signal: AbortSignal | undefined,
+  ): Promise<StepExecution> {
+    const target = navigationTarget(prompt)
+    if (target) {
+      const url = navigationUrl(options.baseUrl, target)
+      await automation.navigate(url, signal)
+      navigated = true
+      return {
+        state: 'passed',
+        resolvedActions: [{ description: `Navigate to ${url}` }],
+      }
+    }
+    await ensureNavigation(signal)
+    if (step.type !== 'outcome') return resolveByObservation(prompt, signal)
+    const verification = await automation.verify(prompt, signal)
+    const resolvedActions = [{ description: `Verify: ${prompt}` }]
+    return verification.meetsExpectation
+      ? { state: 'passed', resolvedActions }
+      : {
+          state: 'failed',
+          resolvedActions,
+          message: `Expected: "${prompt}" | Actual: ${verification.actualState}`,
+        }
+  }
+
   return {
     async executeStep(step, signal) {
       const operationSignal = signal ?? input.signal
@@ -91,41 +119,7 @@ export function createWebLiveSession({
       const prompt = promptFor(step)
 
       try {
-        const target = navigationTarget(prompt)
-        if (target) {
-          const url = navigationUrl(options.baseUrl, target)
-          await automation.navigate(url, operationSignal)
-          navigated = true
-          return finish(
-            {
-              state: 'passed',
-              resolvedActions: [{ description: `Navigate to ${url}` }],
-            },
-            step,
-          )
-        }
-
-        await ensureNavigation(operationSignal)
-        if (step.type !== 'outcome') {
-          return finish(
-            await resolveByObservation(prompt, operationSignal),
-            step,
-          )
-        }
-
-        const verification = await automation.verify(prompt, operationSignal)
-        const resolvedActions = [{ description: `Verify: ${prompt}` }]
-        if (verification.meetsExpectation) {
-          return finish({ state: 'passed', resolvedActions }, step)
-        }
-        return finish(
-          {
-            state: 'failed',
-            resolvedActions,
-            message: `Expected: "${prompt}" | Actual: ${verification.actualState}`,
-          },
-          step,
-        )
+        return finish(await executePrompt(step, prompt, operationSignal), step)
       } catch (error) {
         if (isAbortError(error, operationSignal)) throw abortError()
         return finish(

--- a/packages/web/src/evidence/web-evidence.ts
+++ b/packages/web/src/evidence/web-evidence.ts
@@ -212,34 +212,42 @@ export function createWebEvidenceCollector(
     }
   }
 
+  function recordBufferedEntry(
+    entry: z.infer<typeof bufferedEvidenceSchema>[number],
+  ): void {
+    if (entry.kind === 'diagnostic') {
+      const { kind: _kind, ...diagnostic } = entry
+      diagnostics.push(diagnostic)
+      return
+    }
+    const { kind: _kind, ...browserActivity } = entry
+    activity.push(browserActivity)
+  }
+
+  async function collectPage(page: unknown): Promise<void> {
+    if (!isObservablePage(page)) return
+    try {
+      const parsed = bufferedEvidenceSchema.safeParse(
+        await page.evaluate(consumeWebEvidenceScript),
+      )
+      if (!parsed.success) {
+        recordDiagnostic(
+          'adapter',
+          'Browser evidence buffer returned invalid data',
+        )
+        return
+      }
+      for (const entry of parsed.data) recordBufferedEntry(entry)
+    } catch (error) {
+      recordAdapterFailure('Browser evidence collection failed', error)
+    }
+  }
+
   async function collect(
     pages: readonly unknown[],
   ): Promise<CollectedWebEvidence> {
     for (const page of pages) {
-      if (!isObservablePage(page)) continue
-      try {
-        const parsed = bufferedEvidenceSchema.safeParse(
-          await page.evaluate(consumeWebEvidenceScript),
-        )
-        if (!parsed.success) {
-          recordDiagnostic(
-            'adapter',
-            'Browser evidence buffer returned invalid data',
-          )
-        } else {
-          for (const entry of parsed.data) {
-            if (entry.kind === 'diagnostic') {
-              const { kind: _kind, ...diagnostic } = entry
-              diagnostics.push(diagnostic)
-            } else {
-              const { kind: _kind, ...browserActivity } = entry
-              activity.push(browserActivity)
-            }
-          }
-        }
-      } catch (error) {
-        recordAdapterFailure('Browser evidence collection failed', error)
-      }
+      await collectPage(page)
     }
     return consume()
   }

--- a/packages/web/src/evidence/web-step-evidence.ts
+++ b/packages/web/src/evidence/web-step-evidence.ts
@@ -18,6 +18,38 @@ type ProjectedWebStepEvidence = {
   nextResolvedActionTrace: TraceEntry[]
 }
 
+function adapterDiagnostics(
+  input: ProjectWebStepEvidenceInput,
+  occurredAt: string,
+): DiagnosticEntry[] {
+  if (!input.execution.message) return []
+  return [
+    {
+      occurredAt,
+      level:
+        input.execution.state === 'infrastructure-error' ? 'error' : 'warning',
+      origin: 'adapter',
+      message: input.execution.message,
+    },
+  ]
+}
+
+function evidenceAvailability(
+  input: ProjectWebStepEvidenceInput,
+  diagnostics: readonly DiagnosticEntry[],
+  trace: readonly TraceEntry[],
+) {
+  return [
+    ...(input.execution.evidenceAvailability ?? []),
+    ...(diagnostics.length > 0
+      ? [{ kind: 'diagnostics' as const, state: 'available' as const }]
+      : []),
+    ...(trace.length > 0
+      ? [{ kind: 'trace' as const, state: 'available' as const }]
+      : []),
+  ]
+}
+
 export function projectWebStepEvidence(
   input: ProjectWebStepEvidenceInput,
   now = () => new Date().toISOString(),
@@ -26,23 +58,10 @@ export function projectWebStepEvidence(
     input.collected.diagnostics.at(-1)?.occurredAt ??
     input.collected.activity.at(-1)?.occurredAt ??
     now()
-  const adapterDiagnostics: DiagnosticEntry[] = input.execution.message
-    ? [
-        {
-          occurredAt,
-          level:
-            input.execution.state === 'infrastructure-error'
-              ? 'error'
-              : 'warning',
-          origin: 'adapter',
-          message: input.execution.message,
-        },
-      ]
-    : []
   const diagnostics = [
     ...(input.execution.diagnostics ?? []),
     ...input.collected.diagnostics,
-    ...adapterDiagnostics,
+    ...adapterDiagnostics(input, occurredAt),
   ].map((entry) => ({ ...entry, causalAt: occurredAt }))
   const resolvedActionTrace: TraceEntry[] = input.execution.resolvedActions.map(
     (action) => ({
@@ -74,15 +93,7 @@ export function projectWebStepEvidence(
       ...input.execution,
       diagnostics: diagnostics.length > 0 ? diagnostics : undefined,
       trace: trace.length > 0 ? trace : undefined,
-      evidenceAvailability: [
-        ...(input.execution.evidenceAvailability ?? []),
-        ...(diagnostics.length > 0
-          ? [{ kind: 'diagnostics' as const, state: 'available' as const }]
-          : []),
-        ...(trace.length > 0
-          ? [{ kind: 'trace' as const, state: 'available' as const }]
-          : []),
-      ],
+      evidenceAvailability: evidenceAvailability(input, diagnostics, trace),
     },
     nextResolvedActionTrace:
       input.step.type === 'outcome' ? [] : resolvedActionTrace,

--- a/packages/web/src/execution-cache/web-cache-adaptive-session.ts
+++ b/packages/web/src/execution-cache/web-cache-adaptive-session.ts
@@ -46,6 +46,77 @@ function definedSteps(
   return values.every((value) => value !== undefined)
 }
 
+async function compileAssertionDraft(
+  automation: WebAutomation,
+  prompt: string,
+  signal: AbortSignal | undefined,
+): Promise<WebAssertionDraft | undefined> {
+  try {
+    return await automation.compileAssertion?.(prompt, signal)
+  } catch {
+    return undefined
+  }
+}
+
+function verificationExecution(
+  prompt: string,
+  meetsExpectation: boolean,
+  actualState: string,
+): StepExecution {
+  const resolvedActions = [{ description: `Verify: ${prompt}` }]
+  return meetsExpectation
+    ? { state: 'passed', resolvedActions }
+    : {
+        state: 'failed',
+        resolvedActions,
+        message: `Expected: "${prompt}" | Actual: ${actualState}`,
+      }
+}
+
+type ObservedActions = Awaited<ReturnType<WebAutomation['observe']>>
+
+async function observeActions(
+  automation: WebAutomation,
+  prompt: string,
+  signal: AbortSignal | undefined,
+  onInference: () => void,
+): Promise<ObservedActions> {
+  let actions = await automation.observe(prompt, signal)
+  onInference()
+  if (actions.length > 0) return actions
+  actions = await automation.observe(prompt, signal)
+  onInference()
+  return actions
+}
+
+async function executeObservedActions(
+  automation: WebAutomation,
+  actions: ObservedActions,
+  signal: AbortSignal | undefined,
+  onInference: () => void,
+): Promise<StepExecution> {
+  const resolvedActions: ResolvedAction[] = []
+  for (const action of actions) {
+    onInference()
+    const result = await automation.act(action, signal)
+    resolvedActions.push({ description: action.description })
+    if (!result.success) {
+      return {
+        state: 'failed',
+        resolvedActions,
+        message: result.message ?? 'Web action failed',
+      }
+    }
+  }
+  return actions.length > 0
+    ? { state: 'passed', resolvedActions }
+    : {
+        state: 'failed',
+        resolvedActions,
+        message: 'Observe returned no actions',
+      }
+}
+
 export function createWebAdaptiveSession({
   input,
   options,
@@ -129,12 +200,7 @@ export function createWebAdaptiveSession({
     )
     if (navigationFailure) return navigationFailure
     inferenceCount++
-    let draft: WebAssertionDraft | undefined
-    try {
-      draft = await automation.compileAssertion?.(prompt, signal)
-    } catch {
-      draft = undefined
-    }
+    const draft = await compileAssertionDraft(automation, prompt, signal)
     const assertion = draft
       ? compileWebAssertion(draft, runtimeBindings)
       : undefined
@@ -150,16 +216,11 @@ export function createWebAdaptiveSession({
       : 'non-deterministic-assertion'
     inferenceCount++
     const verification = await automation.verify(prompt, signal)
-    return verification.meetsExpectation
-      ? {
-          state: 'passed',
-          resolvedActions: [{ description: `Verify: ${prompt}` }],
-        }
-      : {
-          state: 'failed',
-          resolvedActions: [{ description: `Verify: ${prompt}` }],
-          message: `Expected: "${prompt}" | Actual: ${verification.actualState}`,
-        }
+    return verificationExecution(
+      prompt,
+      verification.meetsExpectation,
+      verification.actualState,
+    )
   }
 
   async function adaptiveAction(
@@ -174,12 +235,12 @@ export function createWebAdaptiveSession({
       signal,
     )
     if (navigationFailure) return navigationFailure
-    let actions = await automation.observe(prompt, signal)
-    inferenceCount++
-    if (actions.length === 0) {
-      actions = await automation.observe(prompt, signal)
-      inferenceCount++
-    }
+    const actions = await observeActions(
+      automation,
+      prompt,
+      signal,
+      () => inferenceCount++,
+    )
     const compiled = actions.map((action) => {
       const payload = parseObservedActionPayload(action.handle)
       return payload
@@ -195,26 +256,12 @@ export function createWebAdaptiveSession({
       return executeCompiledStep(instructions, compiled, index, signal)
     }
     uncacheableReason = 'non-deterministic-action'
-    const resolvedActions: ResolvedAction[] = []
-    for (const action of actions) {
-      inferenceCount++
-      const result = await automation.act(action, signal)
-      resolvedActions.push({ description: action.description })
-      if (!result.success) {
-        return {
-          state: 'failed',
-          resolvedActions,
-          message: result.message ?? 'Web action failed',
-        }
-      }
-    }
-    return actions.length > 0
-      ? { state: 'passed', resolvedActions }
-      : {
-          state: 'failed',
-          resolvedActions,
-          message: 'Observe returned no actions',
-        }
+    return executeObservedActions(
+      automation,
+      actions,
+      signal,
+      () => inferenceCount++,
+    )
   }
 
   return {

--- a/packages/web/src/execution-cache/web-cache-compilation.ts
+++ b/packages/web/src/execution-cache/web-cache-compilation.ts
@@ -186,23 +186,30 @@ export function compileWebAssertion(
     return { kind: draft.kind, locator }
   }
   if (draft.kind === 'count-equals') {
-    if (draft.nth !== undefined) return undefined
-    if (typeof draft.expected === 'number') {
-      return { kind: draft.kind, locator, expected: draft.expected }
-    }
-    const expected = parameterizeWebValue(draft.expected, bindings)
-    if (expected?.segments.length !== 1) return undefined
-    const segment = expected.segments[0]!
-    if ('literal' in segment) {
-      const count = Number(segment.literal)
-      return Number.isSafeInteger(count) && count >= 0
-        ? { kind: draft.kind, locator, expected: count }
-        : undefined
-    }
-    return { kind: draft.kind, locator, expected: segment }
+    return compileCountAssertion(draft, locator, bindings)
   }
   const expected = parameterizeWebValue(draft.expected, bindings)
   return expected ? { kind: draft.kind, locator, expected } : undefined
+}
+
+function compileCountAssertion(
+  draft: Extract<WebAssertionDraft, { kind: 'count-equals' }>,
+  locator: WebLocator,
+  bindings: readonly ScenarioVariableBinding[],
+): WebInstruction | undefined {
+  if (draft.nth !== undefined) return undefined
+  if (typeof draft.expected === 'number') {
+    return { kind: draft.kind, locator, expected: draft.expected }
+  }
+  const expected = parameterizeWebValue(draft.expected, bindings)
+  if (expected?.segments.length !== 1) return undefined
+  const segment = expected.segments[0]!
+  if (!('literal' in segment))
+    return { kind: draft.kind, locator, expected: segment }
+  const count = Number(segment.literal)
+  return Number.isSafeInteger(count) && count >= 0
+    ? { kind: draft.kind, locator, expected: count }
+    : undefined
 }
 
 export function compileObservedWebAction(
@@ -213,19 +220,61 @@ export function compileObservedWebAction(
   if (!locator) return undefined
   const method = payload.method ?? 'click'
   const args = payload.arguments ?? []
-  if (method === 'click' && args.length === 0) return { kind: 'click', locator }
-  if (method === 'hover' && args.length === 0) return { kind: 'hover', locator }
-  if ((method === 'fill' || method === 'type') && args.length === 1) {
-    const value = parameterizeWebValue(args[0]!, bindings)
-    return value ? { kind: method, locator, value } : undefined
+  const simple = compileSimpleAction(method, args, locator)
+  if (simple) return simple
+  return compileActionWithArguments(method, args, locator, bindings)
+}
+
+function compileSimpleAction(
+  method: string,
+  args: readonly string[],
+  locator: WebLocator,
+): WebInstruction | undefined {
+  if (args.length !== 0) return undefined
+  if (method === 'click') return { kind: 'click', locator }
+  if (method === 'hover') return { kind: 'hover', locator }
+  return undefined
+}
+
+function compileActionWithArguments(
+  method: string,
+  args: readonly string[],
+  locator: WebLocator,
+  bindings: readonly ScenarioVariableBinding[],
+): WebInstruction | undefined {
+  switch (method) {
+    case 'fill':
+    case 'type': {
+      if (args.length !== 1) return undefined
+      const value = parameterizeWebValue(args[0]!, bindings)
+      return value ? { kind: method, locator, value } : undefined
+    }
+    case 'selectOption':
+      return compileSelectOption(locator, args, bindings)
+    case 'waitForSelector':
+      return compileWaitFor(locator, args)
+    default:
+      return undefined
   }
-  if (method === 'selectOption' && args.length > 0) {
-    const values = args.map((value) => parameterizeWebValue(value, bindings))
-    return values.every((value) => value !== undefined)
-      ? { kind: 'select-option', locator, values: values as WebTemplate[] }
-      : undefined
-  }
-  if (method !== 'waitForSelector' || args.length !== 1) return undefined
+}
+
+function compileSelectOption(
+  locator: WebLocator,
+  args: readonly string[],
+  bindings: readonly ScenarioVariableBinding[],
+): WebInstruction | undefined {
+  if (args.length === 0) return undefined
+  const values = args.map((value) => parameterizeWebValue(value, bindings))
+  return values.every((value) => value !== undefined)
+    ? { kind: 'select-option', locator, values: values as WebTemplate[] }
+    : undefined
+}
+
+function compileWaitFor(
+  locator: WebLocator,
+  args: readonly string[],
+): WebInstruction | undefined {
+  if (args.length !== 1) return undefined
   const state = args[0]
   if (
     state !== 'attached' &&

--- a/packages/web/src/execution-cache/web-cache-instructions.ts
+++ b/packages/web/src/execution-cache/web-cache-instructions.ts
@@ -99,17 +99,30 @@ export function createWebInstructionExecutor({
     return execution
   }
 
+  function failurePrefix(): string {
+    return replay ? 'Replay diverged' : 'Deterministic web instruction failed'
+  }
+
+  function unavailableMessage(): string {
+    return `${failurePrefix()}: direct browser execution is unavailable`
+  }
+
+  function failedResultMessage(
+    instruction: WebInstruction,
+    result: { message?: string; actualState?: string },
+  ): string {
+    return (
+      result.message ??
+      `${failurePrefix()}: ${result.actualState ?? instruction.kind}`
+    )
+  }
+
   async function executeDirect(
     instruction: WebInstruction,
     signal: AbortSignal | undefined,
   ): Promise<StepExecution | undefined> {
     if (!automation.executeInstruction) {
-      return failure(
-        instruction,
-        replay
-          ? 'Replay diverged: direct browser execution is unavailable'
-          : 'Deterministic web instruction failed: direct browser execution is unavailable',
-      )
+      return failure(instruction, unavailableMessage())
     }
     try {
       const result = await automation.executeInstruction(
@@ -118,17 +131,10 @@ export function createWebInstructionExecutor({
         signal,
       )
       if (result.success) return undefined
-      return failure(
-        instruction,
-        result.message ??
-          `${replay ? 'Replay diverged' : 'Deterministic web instruction failed'}: ${result.actualState ?? instruction.kind}`,
-      )
+      return failure(instruction, failedResultMessage(instruction, result))
     } catch (error) {
       if (isAbortError(error, signal)) throw abortError()
-      return failure(
-        instruction,
-        `${replay ? 'Replay diverged' : 'Deterministic web instruction failed'}: ${errorMessage(error)}`,
-      )
+      return failure(instruction, `${failurePrefix()}: ${errorMessage(error)}`)
     }
   }
 


### PR DESCRIPTION
Sets Biome’s cognitive-complexity limit to 10 and refactors hotspots across the CLI, runner, Studio, web, mobile, and spec packages into smaller focused helpers without changing public behavior.

Simplifies configuration, execution/cache orchestration, persistence, reporting, evidence projection, Studio state and server flows, and adapter/worker control paths while preserving ordering and optional-field contracts.

Updates the Studio history assertion to expect Failure context when the fixture lacks an exact causal timestamp.

Validation: bun run lint, bun run typecheck, and bun run test all pass; two hardware-dependent mobile smoke tests remain skipped.