### PR TITLE
feat(web): connect to custom CDP browsers

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -167,4 +167,4 @@ Domain documentation uses the single-context layout. See `docs/agents/domain.md`
 
 ### Coding standards
 
-Use 10x-coder skills to always apply code best practices
+Use 10x-coder skills to before writing code to apply code best practices

--- a/README.md
+++ b/README.md
@@ -112,6 +112,19 @@ Create `pickle.config.jsonc` in the project root:
 
 Adaptive execution and Cache refresh require the API key for the configured model provider. Bun loads environment variables from `.env`. For local Chrome, set `web.browser.modelApiKey` or the provider environment variable (`OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, `GOOGLE_API_KEY`, `GEMINI_API_KEY`, or `GOOGLE_GENERATIVE_AI_API_KEY`). `web.browser.modelName` must be a Stagehand-supported `provider/model` value; Pickle Spec rejects unknown names before Adaptive execution starts. Replay and `--cache-only` execute browser primitives without model credentials.
 
+To attach to an existing browser, set `web.browser.cdpUrl` to an absolute HTTP, HTTPS, WS, or WSS URL:
+
+```jsonc
+"browser": {
+  "cdpUrl": "http://127.0.0.1:9222",
+  "cdpExtensionId": "stagehand-extension-id"
+}
+```
+
+If you omit `cdpExtensionId`, the browser must allow Stagehand to load its extension. Set `cdpExtensionId` when the external browser already has the extension loaded. Pickle Spec closes its CDP connection after the run. The external browser owner controls the browser process and must stop it when appropriate.
+
+Treat cloud CDP URLs as secrets because they often contain credentials. Do not commit a credential-bearing `cdpUrl`. The external browser also controls launch settings such as headless mode. Pickle Spec ignores `web.browser.headless` when `cdpUrl` is set.
+
 ## Open Studio
 
 Studio binds to loopback and opens the configured project by default:

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -23,7 +23,7 @@ Every phase inherits the design law in `DESIGN.md`: flat plates, spelled result 
 
 Goal: make Studio navigable, addressable, and shareable as a full application. Runs become a first-class global area instead of history nested under each Specification.
 - [x] Global Runs area: a cross-Specification dashboard with live progress and a filterable run list backed by the existing `index.sqlite` projection, plus a unified run detail page that joins the manifest and the event stream
-- [ ] Real URL routing and deep links: replace the query-param history location so every Specification, scenario, run, result, and artifact has a shareable URL
+- [x] Real URL routing and deep links: replace the query-param history location so every Specification, scenario, run, result, and artifact has a shareable URL
 - [x] Command palette (Cmd+K): jump to any Specification, scenario, or run; start and cancel runs; switch profiles
 - [ ] First-run onboarding: a visual readiness checklist built on the existing run-readiness API, guiding a new user to a first green run
 - [x] Design-system fill-in: add the missing shadcn Mira primitives (toast, tooltip, dropdown menu, command, skeleton)

--- a/packages/cli/src/studio/studio.test.ts
+++ b/packages/cli/src/studio/studio.test.ts
@@ -267,7 +267,9 @@ Feature: Search
         await scenarioRow.evaluate((element) => element.matches(':focus')),
       ).toBe(true)
       expect(await scenarioRow.getAttribute('data-state')).toBe('selected')
-      expect(new URL(page.url()).pathname).toBe('/')
+      expect(new URL(page.url()).pathname).toBe(
+        '/specifications/specsearchaaaaaaa/scenarios/scnquerybbbbbbbb',
+      )
 
       const trigger = page.getByRole('button', {
         name: 'Open Studio commands',
@@ -335,7 +337,9 @@ Feature: Search
       expect(
         await checkoutHeading.evaluate((element) => element.matches(':focus')),
       ).toBe(true)
-      expect(new URL(page.url()).pathname).toBe('/')
+      expect(new URL(page.url()).pathname).toBe(
+        '/specifications/speccheckaaaaaaaa',
+      )
     } finally {
       await page.close()
       child.kill()
@@ -842,6 +846,9 @@ export default {
       await page
         .getByRole('button', { name: 'Pay for the order chrome failed' })
         .click()
+      expect(new URL(page.url()).pathname).toMatch(
+        /^\/runs\/[^/]+\/results\/features%2Fcheckout\.feature\/scenarios\/scnpaybbbbbbbbbb\/profiles\/chrome\/attempts\/1$/,
+      )
       expect(await timeline.textContent()).toContain('Then payment is captured')
       expect(await timeline.textContent()).toContain('Payment was declined')
       await page.getByRole('tab', { name: 'Artifacts' }).click()
@@ -1187,7 +1194,7 @@ Feature: Search
         })
         .waitFor()
       expect(new URL(page.url()).pathname).toMatch(
-        /^\/runs\/[^/]+\/results\/scnpaybbbbbbbbbb\/chrome\/1$/,
+        /^\/runs\/[^/]+\/results\/features%2Fcheckout\.feature\/scenarios\/scnpaybbbbbbbbbb\/profiles\/chrome\/attempts\/1$/,
       )
       expect(
         await page

--- a/packages/cli/src/workspace/workspace.test.ts
+++ b/packages/cli/src/workspace/workspace.test.ts
@@ -544,6 +544,27 @@ export default { adapter: missingAdapter }
     )
   })
 
+  test('check accepts CDP web browser configuration', async () => {
+    const project = await createCheckProject('cdp-web-policy', {
+      config: {
+        ...defaultCheckConfig,
+        web: {
+          baseUrl: 'https://example.com',
+          browser: {
+            environment: 'local',
+            cdpUrl: 'wss://browser.example.test/session',
+            cdpExtensionId: 'stagehand-extension',
+          },
+        },
+      },
+      specification: validSpecification,
+    })
+
+    const checked = runCheck(project)
+
+    expect(checked.exitCode).toBe(0)
+  })
+
   test('check rejects an unsupported Stagehand model before execution resources start', async () => {
     const project = await createCheckProject('invalid-model-name', {
       config: {

--- a/packages/cli/test/studio-hardening-suite.ts
+++ b/packages/cli/test/studio-hardening-suite.ts
@@ -234,6 +234,8 @@ Feature: Checkout
       expect(await selectedEvidence.textContent()).toContain(
         'Then the basket is reviewed',
       )
+      await page.goBack()
+      await attention.waitFor()
       await attention
         .getByRole('button', { name: /Pay for the order.*failed/ })
         .click()

--- a/packages/cli/test/studio-routing.test.ts
+++ b/packages/cli/test/studio-routing.test.ts
@@ -1,0 +1,133 @@
+import { afterAll, beforeAll, describe, expect, test } from 'bun:test'
+import { join } from 'node:path'
+import type { Browser } from 'playwright'
+import { StudioBrowserFixture } from './studio-browser-fixture'
+
+describe('Studio route restoration', () => {
+  const fixture = new StudioBrowserFixture()
+  let browser: Browser
+
+  beforeAll(async () => {
+    await fixture.setup()
+    browser = fixture.browser
+  }, 120_000)
+
+  afterAll(async () => {
+    await fixture.teardown()
+  }, 15_000)
+
+  test('restores Specification, scenario, run, result, and artifact pages after refresh', async () => {
+    const project = await fixture.createProject('route-restoration')
+    await Bun.write(
+      join(project, 'features', 'search.feature'),
+      `@pickle:id:specsearchaaaaaaa @pickle:state:active
+Feature: Search
+  @pickle:id:scnquerybbbbbbbb
+  Scenario: Query the catalog
+    Then results are shown`,
+    )
+    const { child, url } = await fixture.start(project)
+    const page = await browser.newPage()
+    try {
+      await page.goto(url)
+
+      await page.getByRole('button', { name: 'Search', exact: true }).click()
+      expect(new URL(page.url()).pathname).toBe(
+        '/specifications/specsearchaaaaaaa',
+      )
+      await page.reload()
+      await page.getByRole('heading', { name: 'Search' }).waitFor()
+
+      await page.keyboard.press('Meta+k')
+      await page
+        .locator('[data-slot="command-input"]')
+        .fill('Query the catalog')
+      await page
+        .getByRole('dialog', { name: 'Studio commands' })
+        .getByRole('option')
+        .filter({ hasText: 'Query the catalog' })
+        .click()
+      expect(new URL(page.url()).pathname).toBe(
+        '/specifications/specsearchaaaaaaa/scenarios/scnquerybbbbbbbb',
+      )
+      await page.reload()
+      const queryScenario = page
+        .getByRole('table', { name: 'Scenarios' })
+        .getByRole('row')
+        .filter({ hasText: 'Query the catalog' })
+      await queryScenario.waitFor()
+      expect(await queryScenario.getAttribute('data-state')).toBe('selected')
+
+      await page
+        .getByRole('button', { name: 'Specifications', exact: true })
+        .click()
+      await page.getByRole('button', { name: 'Checkout', exact: true }).click()
+      await page.getByRole('button', { name: 'Run Specification' }).click()
+      await page
+        .getByRole('button', {
+          name: 'Pay for the order chrome failed',
+          exact: true,
+        })
+        .waitFor({ timeout: 20_000 })
+      await page.getByRole('button', { name: 'Run Specification' }).waitFor({
+        timeout: 20_000,
+      })
+
+      await page.getByRole('button', { name: 'Runs', exact: true }).click()
+      const history = page.getByRole('table', { name: 'Test run history' })
+      await history
+        .getByRole('row')
+        .nth(1)
+        .getByRole('button', { name: 'Review run' })
+        .click()
+      const runPath = new URL(page.url()).pathname
+      expect(runPath).toMatch(/^\/runs\/[^/]+$/)
+      await page.reload()
+      const results = page.getByRole('table', { name: 'Test run results' })
+      await results.waitFor()
+
+      await results
+        .getByRole('row')
+        .filter({ hasText: 'Pay for the order' })
+        .filter({ hasText: 'chrome' })
+        .first()
+        .getByRole('button', { name: 'Inspect result' })
+        .click()
+      expect(new URL(page.url()).pathname).toMatch(
+        /^\/runs\/[^/]+\/results\/features%2Fcheckout\.feature\/scenarios\/scnpaybbbbbbbbbb\/profiles\/chrome\/attempts\/1$/,
+      )
+      await page.reload()
+      await page
+        .getByRole('heading', { name: 'Pay for the order · chrome' })
+        .waitFor()
+
+      await page.getByRole('tab', { name: 'Artifacts' }).click()
+      await page.getByRole('link', { name: 'Open artifact page' }).click()
+      expect(new URL(page.url()).pathname).toMatch(/\/artifacts\/0$/)
+      await page.reload()
+      await page
+        .getByRole('heading', { name: 'screenshot · Pay for the order' })
+        .waitFor()
+      expect(page.url()).not.toContain('failure.png')
+
+      await page.goBack()
+      await page
+        .getByRole('heading', { name: 'Pay for the order · chrome' })
+        .waitFor()
+      expect(new URL(page.url()).searchParams.get('tab')).toBe('artifacts')
+
+      const resultUrl = new URL(page.url())
+      await page.goto(
+        `${resultUrl.origin}${resultUrl.pathname}/artifacts/99?tab=artifacts`,
+      )
+      await page
+        .getByRole('alert')
+        .filter({ hasText: 'Test artifact 99 is not available' })
+        .waitFor()
+    } finally {
+      await page.close()
+      child.kill()
+      await child.exited
+    }
+  }, 60_000)
+})

--- a/packages/studio/src/app/studio-api.ts
+++ b/packages/studio/src/app/studio-api.ts
@@ -3,21 +3,8 @@ export type StudioApi = <Value>(
   init?: RequestInit,
 ) => Promise<Value>
 
-function consumeStudioToken() {
-  const token = new URLSearchParams(location.search).get('token') ?? ''
-  if (!token) return token
-
-  const address = new URL(location.href)
-  address.searchParams.delete('token')
-  history.replaceState(
-    null,
-    '',
-    `${address.pathname}${address.search}${address.hash}`,
-  )
-  return token
-}
-
-export const studioToken = consumeStudioToken()
+export const studioToken =
+  new URLSearchParams(location.search).get('token') ?? ''
 
 export const studioApi: StudioApi = async <Value>(
   path: string,

--- a/packages/studio/src/app/studio-app.tsx
+++ b/packages/studio/src/app/studio-app.tsx
@@ -25,7 +25,8 @@ export function StudioApp({ loadingFallback }: { loadingFallback: ReactNode }) {
         ? studio.selection.focus.scenarioId
         : undefined,
     headingRef: studio.selection.headingRef,
-    onRememberScenario: studio.selection.rememberScenario,
+    missing: studio.selection.missing,
+    onSelectScenario: studio.selection.selectScenario,
     onSelect: studio.selection.selectSpecification,
     onSelectCreated: studio.selection.selectCreatedSpecification,
     selected: studio.selection.selected,
@@ -86,7 +87,8 @@ export function StudioApp({ loadingFallback }: { loadingFallback: ReactNode }) {
       ) : studio.navigation.area === 'Runs' &&
         (studio.navigation.route.kind === 'runs' ||
           studio.navigation.route.kind === 'run' ||
-          studio.navigation.route.kind === 'result') ? (
+          studio.navigation.route.kind === 'result' ||
+          studio.navigation.route.kind === 'artifact') ? (
         <div className="studio-stage flex min-h-0 flex-1 overflow-hidden">
           <RunsArea
             api={studioApi}

--- a/packages/studio/src/app/studio-route.test.ts
+++ b/packages/studio/src/app/studio-route.test.ts
@@ -1,76 +1,187 @@
-import { expect, test } from 'bun:test'
+import { describe, expect, test } from 'bun:test'
 import {
   parseStudioRoute,
   type StudioRoute,
   studioRouteHref,
 } from './studio-route'
 
-test('round-trips Runs filters through the global Runs URL', () => {
-  const route: StudioRoute = {
-    kind: 'runs',
-    filters: {
-      q: 'checkout run',
-      state: 'failed',
-      specification: 'features/checkout.feature',
-      profile: 'Pixel 9 / API 36',
-      suite: 'smoke',
+describe('Studio route contract', () => {
+  const routes = [
+    { kind: 'specifications' },
+    {
+      kind: 'specification',
+      specificationId: 'specification/slash space % café',
     },
+    {
+      kind: 'scenario',
+      specificationId: 'specification/slash space % café',
+      scenarioId: 'scenario/slash space % 東京',
+    },
+    {
+      kind: 'runs',
+      filters: {
+        q: 'checkout run',
+        state: 'failed',
+        specification: 'features/checkout flow %.feature',
+        profile: 'Pixel 9 / API 36',
+        suite: 'smoke/rápido',
+      },
+    },
+    { kind: 'run', runId: 'run/slash space % 測試' },
+    {
+      kind: 'result',
+      location: {
+        runId: 'run/slash space % 測試',
+        specificationUri: 'features/payment flows %.feature',
+        scenarioId: 'scenario/pay now % 東京',
+        profileId: 'Pixel 9 / API 36 %',
+        attempt: 2,
+        tab: 'diagnostics',
+      },
+    },
+    {
+      kind: 'result',
+      location: {
+        runId: 'run/slash space % 測試',
+        specificationUri: 'features/payment flows %.feature',
+        scenarioId: 'scenario/pay now % 東京',
+        examplesRowId: 'row/slash space % café',
+        profileId: 'Pixel 9 / API 36 %',
+        attempt: 2,
+        tab: 'artifacts',
+      },
+    },
+    {
+      kind: 'artifact',
+      location: {
+        result: {
+          runId: 'run/slash space % 測試',
+          specificationUri: 'features/payment flows %.feature',
+          scenarioId: 'scenario/pay now % 東京',
+          examplesRowId: 'row/slash space % café',
+          profileId: 'Pixel 9 / API 36 %',
+          attempt: 2,
+          tab: 'timeline',
+        },
+        artifactIndex: 0,
+      },
+    },
+  ] satisfies Exclude<StudioRoute, { kind: 'not-found' }>[]
+
+  for (const route of routes) {
+    test(`round-trips ${route.kind}`, () => {
+      expect(parseStudioRoute(studioRouteHref(route))).toEqual(route)
+    })
   }
 
-  expect(parseStudioRoute(studioRouteHref(route))).toEqual(route)
-})
+  test('writes the canonical entity grammar', () => {
+    expect(
+      studioRouteHref({
+        kind: 'scenario',
+        specificationId: 'features/checkout.feature',
+        scenarioId: 'pay now',
+      }),
+    ).toBe('/specifications/features%2Fcheckout.feature/scenarios/pay%20now')
+    expect(
+      studioRouteHref({
+        kind: 'result',
+        location: {
+          runId: 'run-42',
+          specificationUri: 'features/checkout.feature',
+          scenarioId: 'scenario-pay',
+          examplesRowId: 'row-2',
+          profileId: 'chrome desktop',
+          attempt: 3,
+          tab: 'timeline',
+        },
+      }),
+    ).toBe(
+      '/runs/run-42/results/features%2Fcheckout.feature/scenarios/scenario-pay/examples/row-2/profiles/chrome%20desktop/attempts/3?tab=timeline',
+    )
+  })
 
-test('round-trips encoded result identity and evidence tab', () => {
-  const route: StudioRoute = {
-    kind: 'result',
-    location: {
-      runId: 'run/78',
-      specificationUri: 'features/payment flows.feature',
-      scenarioId: 'scenario/pay now',
-      examplesRowId: 'row one',
-      profileId: 'Pixel 9 / API 36',
-      attempt: 2,
-      tab: 'diagnostics',
-    },
+  test('parses valid presentation queries without moving identity out of the path', () => {
+    expect(
+      parseStudioRoute(
+        '/runs?state=passed&specification=features%2Fcheckout.feature&profile=chrome&suite=smoke&q=run%2042',
+      ),
+    ).toEqual({
+      kind: 'runs',
+      filters: {
+        state: 'passed',
+        specification: 'features/checkout.feature',
+        profile: 'chrome',
+        suite: 'smoke',
+        q: 'run 42',
+      },
+    })
+    expect(
+      parseStudioRoute(
+        '/runs/run-42/results/features%2Fcheckout.feature/scenarios/scenario-pay/profiles/chrome/attempts/1?tab=overview',
+      ),
+    ).toEqual({
+      kind: 'result',
+      location: {
+        runId: 'run-42',
+        specificationUri: 'features/checkout.feature',
+        scenarioId: 'scenario-pay',
+        profileId: 'chrome',
+        attempt: 1,
+        tab: 'overview',
+      },
+    })
+  })
+
+  test('ignores unsupported Runs filters and result tabs', () => {
+    expect(parseStudioRoute('/runs?state=unknown')).toEqual({
+      kind: 'runs',
+      filters: {},
+    })
+    expect(
+      parseStudioRoute(
+        '/runs/run-42/results/features%2Fcheckout.feature/scenarios/scenario-pay/profiles/chrome/attempts/1?tab=unknown',
+      ),
+    ).toEqual({
+      kind: 'result',
+      location: {
+        runId: 'run-42',
+        specificationUri: 'features/checkout.feature',
+        scenarioId: 'scenario-pay',
+        profileId: 'chrome',
+        attempt: 1,
+      },
+    })
+  })
+
+  const rejectedPaths = [
+    '/unknown',
+    '/index.html',
+    '/specifications/',
+    '/specifications/specification/scenarios',
+    '/specifications/specification/scenarios/',
+    '/specifications/specification/scenarios/scenario/trailing',
+    '/runs/',
+    '/runs/run-42/',
+    '/runs/run-42/results',
+    '/runs/run-42/results/specification/scenarios/scenario/profiles/chrome/attempts',
+    '/runs/run-42/results/specification/scenarios/scenario/profiles/chrome/attempts/0',
+    '/runs/run-42/results/specification/scenarios/scenario/profiles/chrome/attempts/-1',
+    '/runs/run-42/results/specification/scenarios/scenario/profiles/chrome/attempts/1.5',
+    '/runs/run-42/results/specification/scenarios/scenario/profiles/chrome/attempts/NaN',
+    '/runs/run-42/results/specification/scenarios/scenario/examples/row/profiles/chrome/attempts/1/artifacts/-1',
+    '/runs/run-42/results/specification/scenarios/scenario/examples/row/profiles/chrome/attempts/1/artifacts/1.5',
+    '/runs/run-42/results/specification/scenarios/scenario/examples/row/profiles/chrome/attempts/1/artifacts/NaN',
+    '/runs/run-42/results/specification/scenarios/scenario/examples/row/profiles/chrome/attempts/1/artifacts/0/trailing',
+    '/runs/run-42/results/scenario/chrome/1?specification=features%2Fcheckout.feature',
+    '/runs/run-42/results/specification/scenarios/scenario/profiles/chrome/attempts/1?specification=legacy',
+    '/runs/run-42/results/specification/scenarios/scenario/profiles/chrome/attempts/1?examplesRow=legacy',
+    '/runs/%E0%A4%A',
+    '/specifications/%E0%A4%A',
+  ]
+
+  for (const path of rejectedPaths) {
+    test(`rejects ${path}`, () => {
+      expect(parseStudioRoute(path)).toEqual({ kind: 'not-found' })
+    })
   }
-
-  expect(parseStudioRoute(studioRouteHref(route))).toEqual(route)
-})
-
-test('parses the Runs list and run detail routes', () => {
-  expect(parseStudioRoute('/runs')).toEqual({ kind: 'runs', filters: {} })
-  expect(parseStudioRoute('/runs/run-42')).toEqual({
-    kind: 'run',
-    runId: 'run-42',
-  })
-})
-
-test('rejects malformed attempts and unknown Studio paths', () => {
-  expect(
-    parseStudioRoute(
-      '/runs/run-42/results/scenario/chrome/zero?specification=features%2Fcheckout.feature',
-    ),
-  ).toEqual({ kind: 'not-found' })
-  expect(parseStudioRoute('/unknown')).toEqual({ kind: 'not-found' })
-})
-
-test('ignores unsupported filter and tab values', () => {
-  expect(parseStudioRoute('/runs?state=unknown')).toEqual({
-    kind: 'runs',
-    filters: {},
-  })
-  expect(
-    parseStudioRoute(
-      '/runs/run-42/results/scenario/chrome/1?specification=features%2Fcheckout.feature&tab=unknown',
-    ),
-  ).toEqual({
-    kind: 'result',
-    location: {
-      runId: 'run-42',
-      specificationUri: 'features/checkout.feature',
-      scenarioId: 'scenario',
-      profileId: 'chrome',
-      attempt: 1,
-    },
-  })
 })

--- a/packages/studio/src/app/studio-route.ts
+++ b/packages/studio/src/app/studio-route.ts
@@ -22,23 +22,48 @@ export type RunsFilters = {
   suite?: string
 }
 
+export type ResultArtifactLocation = {
+  result: ResultInspectionLocation
+  artifactIndex: number
+}
+
 export type StudioRoute =
   | { kind: 'specifications' }
+  | { kind: 'specification'; specificationId: string }
+  | {
+      kind: 'scenario'
+      specificationId: string
+      scenarioId: string
+    }
   | { kind: 'runs'; filters: RunsFilters }
   | { kind: 'run'; runId: string }
   | { kind: 'result'; location: ResultInspectionLocation }
+  | { kind: 'artifact'; location: ResultArtifactLocation }
   | { kind: 'not-found' }
 
+const specificationRoutePattern = /^\/specifications\/([^/]+)$/
+const scenarioRoutePattern = /^\/specifications\/([^/]+)\/scenarios\/([^/]+)$/
+const runRoutePattern = /^\/runs\/([^/]+)$/
 const resultRoutePattern =
-  /^\/runs\/([^/]+)\/results\/([^/]+)\/([^/]+)\/([^/]+)\/?$/
-const runRoutePattern = /^\/runs\/([^/]+)\/?$/
+  /^\/runs\/([^/]+)\/results\/([^/]+)\/scenarios\/([^/]+)(?:\/examples\/([^/]+))?\/profiles\/([^/]+)\/attempts\/([^/]+)(?:\/artifacts\/([^/]+))?$/
 
 export function parseStudioRoute(input: string): StudioRoute {
-  const url = new URL(input, 'http://studio.local')
+  let url: URL
+  try {
+    url = new URL(input, 'http://studio.local')
+  } catch {
+    return { kind: 'not-found' }
+  }
   if (url.pathname === '/') return { kind: 'specifications' }
-  if (url.pathname === '/runs' || url.pathname === '/runs/') {
+  if (url.pathname === '/runs') {
     return { kind: 'runs', filters: parseRunsFilters(url.searchParams) }
   }
+
+  const scenarioMatch = url.pathname.match(scenarioRoutePattern)
+  if (scenarioMatch) return parseScenarioRoute(scenarioMatch)
+
+  const specificationMatch = url.pathname.match(specificationRoutePattern)
+  if (specificationMatch) return parseSpecificationRoute(specificationMatch)
 
   const resultMatch = url.pathname.match(resultRoutePattern)
   if (resultMatch) return parseResultRoute(resultMatch, url.searchParams)
@@ -55,26 +80,37 @@ export function studioRouteHref(
   route: Exclude<StudioRoute, { kind: 'not-found' }>,
 ): string {
   if (route.kind === 'specifications') return '/'
+  if (route.kind === 'specification') {
+    return `/specifications/${encodeURIComponent(route.specificationId)}`
+  }
+  if (route.kind === 'scenario') {
+    return `/specifications/${encodeURIComponent(route.specificationId)}/scenarios/${encodeURIComponent(route.scenarioId)}`
+  }
   if (route.kind === 'runs') {
     const query = runsFilterQuery(route.filters)
     return query ? `/runs?${query}` : '/runs'
   }
   if (route.kind === 'run') return `/runs/${encodeURIComponent(route.runId)}`
+  if (route.kind === 'result') return resultRouteHref(route.location)
 
-  const { location } = route
-  const query = new URLSearchParams({
-    specification: location.specificationUri,
-  })
-  if (location.examplesRowId) query.set('examplesRow', location.examplesRowId)
-  if (location.tab) query.set('tab', location.tab)
-  return `${[
-    '/runs',
-    encodeURIComponent(location.runId),
-    'results',
-    encodeURIComponent(location.scenarioId),
-    encodeURIComponent(location.profileId),
-    String(location.attempt),
-  ].join('/')}?${query}`
+  const { result, artifactIndex } = route.location
+  const path = `${resultRoutePath(result)}/artifacts/${artifactIndex}`
+  return result.tab ? `${path}?tab=${result.tab}` : path
+}
+
+function parseSpecificationRoute(match: RegExpMatchArray): StudioRoute {
+  const specificationId = decodeSegment(match[1])
+  return specificationId
+    ? { kind: 'specification', specificationId }
+    : { kind: 'not-found' }
+}
+
+function parseScenarioRoute(match: RegExpMatchArray): StudioRoute {
+  const specificationId = decodeSegment(match[1])
+  const scenarioId = decodeSegment(match[2])
+  return specificationId && scenarioId
+    ? { kind: 'scenario', specificationId, scenarioId }
+    : { kind: 'not-found' }
 }
 
 function parseRunsFilters(parameters: URLSearchParams): RunsFilters {
@@ -113,37 +149,71 @@ function parseResultRoute(
   match: RegExpMatchArray,
   parameters: URLSearchParams,
 ): StudioRoute {
+  if (hasLegacyResultIdentity(parameters)) {
+    return { kind: 'not-found' }
+  }
   const runId = decodeSegment(match[1])
-  const scenarioId = decodeSegment(match[2])
-  const profileId = decodeSegment(match[3])
-  const attempt = Number(match[4])
-  const specificationUri = parameters.get('specification')
+  const specificationUri = decodeSegment(match[2])
+  const scenarioId = decodeSegment(match[3])
+  const examplesRowId = match[4] ? decodeSegment(match[4]) : undefined
+  const profileId = decodeSegment(match[5])
+  const attempt = positiveInteger(match[6])
+  const artifactIndex = match[7] ? nonNegativeInteger(match[7]) : undefined
   if (
     !runId ||
-    !scenarioId ||
-    !profileId ||
     !specificationUri ||
-    !Number.isInteger(attempt) ||
-    attempt < 1
+    !scenarioId ||
+    (match[4] && !examplesRowId) ||
+    !profileId ||
+    attempt === undefined ||
+    (match[7] && artifactIndex === undefined)
   ) {
     return { kind: 'not-found' }
   }
+
+  const location: ResultInspectionLocation = {
+    runId,
+    specificationUri,
+    scenarioId,
+    profileId,
+    attempt,
+  }
+  if (examplesRowId) location.examplesRowId = examplesRowId
   const requestedTab = parameters.get('tab')
   const tab = resultInspectorTabs.find(
     (candidate) => candidate === requestedTab,
   )
-  return {
-    kind: 'result',
-    location: {
-      runId,
-      specificationUri,
-      scenarioId,
-      examplesRowId: parameters.get('examplesRow') ?? undefined,
-      profileId,
-      attempt,
-      tab,
-    },
-  }
+  if (tab) location.tab = tab
+  return artifactIndex === undefined
+    ? { kind: 'result', location }
+    : { kind: 'artifact', location: { result: location, artifactIndex } }
+}
+
+function hasLegacyResultIdentity(parameters: URLSearchParams): boolean {
+  return parameters.has('specification') || parameters.has('examplesRow')
+}
+
+function resultRouteHref(location: ResultInspectionLocation): string {
+  const path = resultRoutePath(location)
+  return location.tab ? `${path}?tab=${location.tab}` : path
+}
+
+function resultRoutePath(location: ResultInspectionLocation): string {
+  const examples = location.examplesRowId
+    ? `/examples/${encodeURIComponent(location.examplesRowId)}`
+    : ''
+  return `/runs/${encodeURIComponent(location.runId)}/results/${encodeURIComponent(location.specificationUri)}/scenarios/${encodeURIComponent(location.scenarioId)}${examples}/profiles/${encodeURIComponent(location.profileId)}/attempts/${location.attempt}`
+}
+
+function positiveInteger(value: string | undefined): number | undefined {
+  const number = nonNegativeInteger(value)
+  return number && number > 0 ? number : undefined
+}
+
+function nonNegativeInteger(value: string | undefined): number | undefined {
+  if (!value || !/^\d+$/.test(value)) return undefined
+  const number = Number(value)
+  return Number.isSafeInteger(number) ? number : undefined
 }
 
 function decodeSegment(value: string | undefined): string | undefined {

--- a/packages/studio/src/app/use-studio-controller.ts
+++ b/packages/studio/src/app/use-studio-controller.ts
@@ -21,12 +21,9 @@ export function useStudioController() {
       ? selectedProfileId
       : undefined
 
-  function showSpecifications(replace = false) {
-    navigation.showArea('Specifications', replace)
-  }
-
   const selection = useSpecificationSelection({
-    onShowSpecifications: showSpecifications,
+    navigate: navigation.navigate,
+    route: navigation.route,
     specifications: data.project?.specifications ?? noSpecifications,
   })
   const run = useLiveRun({
@@ -34,6 +31,8 @@ export function useStudioController() {
     api: studioApi,
     onClearError: data.clearError,
     onError: data.reportError,
+    onInspectResult: (location) =>
+      navigation.navigate({ kind: 'result', location }),
     registerActiveRun: data.registerActiveRun,
     reloadRunsIndex: data.reloadRunsIndex,
     runsIndex: data.runsIndex,

--- a/packages/studio/src/app/use-studio-navigation.ts
+++ b/packages/studio/src/app/use-studio-navigation.ts
@@ -14,7 +14,8 @@ const initialStudioRoute = parseStudioRoute(location.href)
 function areaForRoute(route: StudioRoute): StudioArea {
   return route.kind === 'runs' ||
     route.kind === 'run' ||
-    route.kind === 'result'
+    route.kind === 'result' ||
+    route.kind === 'artifact'
     ? 'Runs'
     : 'Specifications'
 }
@@ -49,6 +50,12 @@ export function useStudioNavigation() {
   )
 
   useEffect(() => {
+    if (
+      initialStudioRoute.kind !== 'not-found' &&
+      new URLSearchParams(location.search).has('token')
+    ) {
+      history.replaceState(null, '', studioRouteHref(initialStudioRoute))
+    }
     function restoreLocation() {
       const next = parseStudioRoute(location.href)
       setRoute(next)

--- a/packages/studio/src/runs/result/result-evidence-panels.test.tsx
+++ b/packages/studio/src/runs/result/result-evidence-panels.test.tsx
@@ -2,7 +2,7 @@ import { expect, test } from 'bun:test'
 import type { ScenarioAttempt } from '@pickle-spec/runner'
 import { renderToStaticMarkup } from 'react-dom/server'
 import { ArtifactViewer } from './artifact-viewer'
-import { ResultDiagnostics } from './result-evidence-panels'
+import { ResultArtifacts, ResultDiagnostics } from './result-evidence-panels'
 
 const diagnosticsAvailability: ScenarioAttempt['evidenceAvailability'] = [
   { kind: 'diagnostics', state: 'available' },
@@ -67,4 +67,41 @@ test('keeps media and text payloads unloaded until investigation requests them',
   expect(recording).not.toContain('<video')
   expect(deviceLog).toContain('Load device log')
   expect(deviceLog).not.toContain('<pre')
+})
+
+test('links an artifact occurrence through the page route without exposing its path', () => {
+  const markup = renderToStaticMarkup(
+    <ResultArtifacts
+      artifacts={[
+        {
+          index: 0,
+          artifact: {
+            kind: 'screenshot',
+            path: '/private/test-runs/run-42/secret screenshot.png',
+            mediaType: 'image/png',
+          },
+          stepIndex: 3,
+          stepText: 'Then receipt appears',
+          capturedAt: '2026-08-24T12:00:00.000Z',
+        },
+      ]}
+      availability={[{ kind: 'screenshot', state: 'available' }]}
+      resultLocation={{
+        runId: 'run-42',
+        specificationUri: 'features/checkout.feature',
+        scenarioId: 'pay',
+        profileId: 'chrome',
+        attempt: 1,
+        tab: 'artifacts',
+      }}
+      resultState="passed"
+      scenarioName="Pay"
+    />,
+  )
+
+  expect(markup).toContain(
+    'href="/runs/run-42/results/features%2Fcheckout.feature/scenarios/pay/profiles/chrome/attempts/1/artifacts/0?tab=artifacts"',
+  )
+  expect(markup).not.toContain('href="/private')
+  expect(markup).toContain('/api/artifact?path=')
 })

--- a/packages/studio/src/runs/result/result-evidence-panels.tsx
+++ b/packages/studio/src/runs/result/result-evidence-panels.tsx
@@ -5,7 +5,9 @@ import type {
   EvidenceAvailability,
   TestResultState,
 } from '@pickle-spec/runner'
+import type { MouseEvent } from 'react'
 import { useMemo, useState } from 'react'
+import { studioRouteHref } from '../../app/studio-route'
 import { Button, ButtonLink } from '../../components/ui/button'
 import {
   Card,
@@ -26,6 +28,7 @@ import {
   type InspectedResult,
   recoveryGuidance,
 } from './result-evidence'
+import type { ResultInspectionLocation } from './result-inspection'
 
 const diagnosticLevels = [
   'debug',
@@ -68,6 +71,16 @@ type MetadataProps = {
 type ResultArtifactsProps = {
   artifacts: readonly ArtifactEvidence[]
   availability: readonly EvidenceAvailability[]
+  onOpenArtifact?: (artifactIndex: number) => void
+  resultLocation: ResultInspectionLocation
+  scenarioName: string
+  resultState: TestResultState
+}
+
+type ResultArtifactProps = {
+  evidence: ArtifactEvidence
+  onOpen?: () => void
+  pageHref?: string
   scenarioName: string
   resultState: TestResultState
 }
@@ -236,6 +249,7 @@ function formatBytes(sizeBytes: number | undefined): string {
 }
 
 export function ResultArtifacts(props: ResultArtifactsProps) {
+  const onOpenArtifact = props.onOpenArtifact
   return (
     <div className="space-y-3">
       <ArtifactAvailability availability={props.availability} />
@@ -243,60 +257,109 @@ export function ResultArtifacts(props: ResultArtifactsProps) {
         <EmptyEvidence message="No Test artifacts were retained for this Scenario attempt." />
       ) : null}
       {props.artifacts.map((evidence) => {
-        const { artifact } = evidence
-        const downloadHref = artifactDownloadUrl(artifact.path, artifact.name)
+        const pageHref = studioRouteHref({
+          kind: 'artifact',
+          location: {
+            result: props.resultLocation,
+            artifactIndex: evidence.index,
+          },
+        })
         return (
-          <Card key={`${artifact.path}:${evidence.stepIndex}`}>
-            <CardHeader>
-              <CardTitle>{artifact.kind}</CardTitle>
-              <CardDescription>{evidence.stepText}</CardDescription>
-            </CardHeader>
-            <CardContent className="grid gap-4 lg:grid-cols-[minmax(0,2fr)_minmax(16rem,1fr)]">
-              <ArtifactViewer
-                artifact={artifact}
-                resultState={props.resultState}
-                scenarioName={props.scenarioName}
-                stepText={evidence.stepText}
-              />
-              <div className="space-y-4">
-                <dl className="space-y-3">
-                  <Metadata label="Kind" value={artifact.kind} />
-                  <Metadata
-                    label="File name"
-                    value={artifact.name ?? 'Not recorded'}
-                    mono
-                  />
-                  <Metadata
-                    label="Media type"
-                    value={artifact.mediaType ?? 'Not recorded'}
-                  />
-                  <Metadata
-                    label="File size"
-                    value={formatBytes(artifact.sizeBytes)}
-                  />
-                  <Metadata
-                    label="Captured"
-                    value={new Date(evidence.capturedAt).toLocaleString()}
-                  />
-                  <Metadata
-                    label="Step index"
-                    value={String(evidence.stepIndex)}
-                  />
-                  <Metadata label="Persisted path" value={artifact.path} mono />
-                </dl>
-                <ButtonLink
-                  variant="outline"
-                  href={downloadHref}
-                  download={artifact.name ?? true}
-                >
-                  Download {artifact.kind}
-                </ButtonLink>
-              </div>
-            </CardContent>
-          </Card>
+          <ResultArtifact
+            key={evidence.index}
+            evidence={evidence}
+            onOpen={
+              onOpenArtifact ? () => onOpenArtifact(evidence.index) : undefined
+            }
+            pageHref={pageHref}
+            resultState={props.resultState}
+            scenarioName={props.scenarioName}
+          />
         )
       })}
     </div>
+  )
+}
+
+export function ResultArtifact(props: ResultArtifactProps) {
+  const { artifact } = props.evidence
+  const downloadHref = artifactDownloadUrl(artifact.path, artifact.name)
+
+  function handleOpen(event: MouseEvent<HTMLAnchorElement>) {
+    if (
+      !props.onOpen ||
+      event.button !== 0 ||
+      event.metaKey ||
+      event.ctrlKey ||
+      event.shiftKey ||
+      event.altKey
+    ) {
+      return
+    }
+    event.preventDefault()
+    props.onOpen()
+  }
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>{artifact.kind}</CardTitle>
+        <CardDescription>{props.evidence.stepText}</CardDescription>
+      </CardHeader>
+      <CardContent className="grid gap-4 lg:grid-cols-[minmax(0,2fr)_minmax(16rem,1fr)]">
+        <ArtifactViewer
+          artifact={artifact}
+          resultState={props.resultState}
+          scenarioName={props.scenarioName}
+          stepText={props.evidence.stepText}
+        />
+        <div className="space-y-4">
+          <dl className="space-y-3">
+            <Metadata label="Kind" value={artifact.kind} />
+            <Metadata
+              label="File name"
+              value={artifact.name ?? 'Not recorded'}
+              mono
+            />
+            <Metadata
+              label="Media type"
+              value={artifact.mediaType ?? 'Not recorded'}
+            />
+            <Metadata
+              label="File size"
+              value={formatBytes(artifact.sizeBytes)}
+            />
+            <Metadata
+              label="Captured"
+              value={new Date(props.evidence.capturedAt).toLocaleString()}
+            />
+            <Metadata
+              label="Step index"
+              value={String(props.evidence.stepIndex)}
+            />
+            <Metadata label="Persisted path" value={artifact.path} mono />
+          </dl>
+          <div className="flex flex-wrap gap-2">
+            {props.pageHref ? (
+              <ButtonLink
+                variant="outline"
+                href={props.pageHref}
+                onClick={handleOpen}
+              >
+                Open artifact page
+              </ButtonLink>
+            ) : null}
+            <ButtonLink
+              variant="outline"
+              href={downloadHref}
+              download={artifact.name ?? true}
+            >
+              Download {artifact.kind}
+            </ButtonLink>
+          </div>
+        </div>
+      </CardContent>
+    </Card>
   )
 }
 

--- a/packages/studio/src/runs/result/result-evidence.test.ts
+++ b/packages/studio/src/runs/result/result-evidence.test.ts
@@ -767,3 +767,47 @@ test('uses canonical artifact capture time and selects viewers without adapter k
     artifactViewerKind({ kind: 'screenshot', mediaType: 'image/png' }),
   ).toBe('image')
 })
+
+test('assigns a stable flattened occurrence index even when artifact paths repeat', () => {
+  const repeatedPath = '/tmp/repeated.png'
+  const inspectedAttempt: ScenarioAttempt = {
+    ...attempt(1),
+    steps: [
+      {
+        index: 3,
+        startedAt: '2026-08-22T12:00:00.000Z',
+        finishedAt: '2026-08-22T12:00:01.000Z',
+        durationMs: 1_000,
+        step: { keyword: 'When', text: 'payment starts', type: 'action' },
+        state: 'passed',
+        resolvedActions: [],
+        artifacts: [
+          { kind: 'screenshot', path: repeatedPath },
+          { kind: 'screenshot', path: repeatedPath },
+        ],
+      },
+      {
+        index: 8,
+        startedAt: '2026-08-22T12:00:01.000Z',
+        finishedAt: '2026-08-22T12:00:02.000Z',
+        durationMs: 1_000,
+        step: { keyword: 'Then', text: 'receipt appears', type: 'outcome' },
+        state: 'passed',
+        resolvedActions: [],
+        artifacts: [{ kind: 'screenshot', path: repeatedPath }],
+      },
+    ],
+  }
+
+  expect(
+    artifactsFor(inspectedAttempt).map((evidence) => ({
+      index: evidence.index,
+      stepIndex: evidence.stepIndex,
+      path: evidence.artifact.path,
+    })),
+  ).toEqual([
+    { index: 0, stepIndex: 3, path: repeatedPath },
+    { index: 1, stepIndex: 3, path: repeatedPath },
+    { index: 2, stepIndex: 8, path: repeatedPath },
+  ])
+})

--- a/packages/studio/src/runs/result/result-evidence.ts
+++ b/packages/studio/src/runs/result/result-evidence.ts
@@ -21,6 +21,7 @@ export type InspectedResult = {
 
 export type ArtifactEvidence = {
   artifact: TestArtifact
+  index: number
   stepIndex: number
   stepText: string
   capturedAt: string
@@ -229,14 +230,16 @@ function scopedEvents(
 }
 
 export function artifactsFor(attempt: ScenarioAttempt): ArtifactEvidence[] {
-  return attempt.steps.flatMap((step) =>
-    (step.artifacts ?? []).map((artifact) => ({
-      artifact,
-      stepIndex: step.index,
-      stepText: `${step.step.keyword.trim()} ${step.step.text}`,
-      capturedAt: artifact.capturedAt ?? step.finishedAt,
-    })),
-  )
+  return attempt.steps
+    .flatMap((step) =>
+      (step.artifacts ?? []).map((artifact) => ({
+        artifact,
+        stepIndex: step.index,
+        stepText: `${step.step.keyword.trim()} ${step.step.text}`,
+        capturedAt: artifact.capturedAt ?? step.finishedAt,
+      })),
+    )
+    .map((evidence, index) => ({ ...evidence, index }))
 }
 
 export function artifactViewerKind(

--- a/packages/studio/src/runs/result/result-inspector.tsx
+++ b/packages/studio/src/runs/result/result-inspector.tsx
@@ -1,3 +1,4 @@
+import type { TestResultState } from '@pickle-spec/runner'
 import { useEffect, useState } from 'react'
 import type { StudioApi } from '../../app/studio-api'
 import { LedgerLoadingSkeleton } from '../../components/loading-skeletons'
@@ -24,6 +25,7 @@ import {
   timelineFor,
 } from './result-evidence'
 import {
+  ResultArtifact,
   ResultArtifacts,
   ResultDiagnostics,
   ResultOverview,
@@ -37,8 +39,11 @@ import { reasonMessage, resultBadgeVariant } from './result-presentation'
 
 type ResultInspectorProps = {
   api: StudioApi
+  artifactIndex?: number
   location: ResultInspectionLocation
   onBack?: () => void
+  onBackToResult?: () => void
+  onOpenArtifact?: (artifactIndex: number) => void
   onTabChange: (tab: ResultInspectorTab) => void
   snapshot?: StudioRunSnapshot
   connection?: LiveConnectionStatus
@@ -137,6 +142,19 @@ function InspectedResultView(
     inspected.attempt,
     props.location,
   )
+  if (props.artifactIndex !== undefined) {
+    const artifact = artifacts[props.artifactIndex]
+    return (
+      <ArtifactPage
+        artifact={artifact}
+        artifactIndex={props.artifactIndex}
+        onBack={props.onBackToResult}
+        resultState={resultState}
+        scenarioName={inspected.result.scenario.name}
+        snapshot={snapshot}
+      />
+    )
+  }
   return (
     <section
       aria-labelledby="result-inspector-title"
@@ -218,6 +236,8 @@ function InspectedResultView(
           <ResultArtifacts
             artifacts={artifacts}
             availability={inspected.attempt.evidenceAvailability}
+            onOpenArtifact={props.onOpenArtifact}
+            resultLocation={props.location}
             scenarioName={inspected.result.scenario.name}
             resultState={resultState}
           />
@@ -232,6 +252,63 @@ function InspectedResultView(
           />
         </TabsContent>
       </Tabs>
+    </section>
+  )
+}
+
+type ArtifactPageProps = {
+  artifact: ReturnType<typeof artifactsFor>[number] | undefined
+  artifactIndex: number
+  onBack?: () => void
+  resultState: TestResultState
+  scenarioName: string
+  snapshot: StudioRunSnapshot
+}
+
+function ArtifactPage(props: ArtifactPageProps) {
+  if (!props.artifact) {
+    return (
+      <section className="min-h-0 flex-1 space-y-3 overflow-auto p-4">
+        <p role="alert" className="text-sm text-destructive">
+          Test artifact {props.artifactIndex} is not available in test run{' '}
+          {props.snapshot.id}.
+        </p>
+        {props.onBack ? (
+          <Button type="button" variant="outline" onClick={props.onBack}>
+            Back to Test result
+          </Button>
+        ) : null}
+      </section>
+    )
+  }
+  return (
+    <section
+      aria-labelledby="artifact-page-title"
+      className="min-h-0 flex-1 space-y-4 overflow-auto px-3 py-4 sm:px-5"
+    >
+      <header className="space-y-2 border-b border-border pb-4">
+        {props.onBack ? (
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            onClick={props.onBack}
+          >
+            Back to Test result
+          </Button>
+        ) : null}
+        <h3 id="artifact-page-title" className="studio-display text-sm">
+          {props.artifact.artifact.kind} · {props.scenarioName}
+        </h3>
+        <p className="font-mono text-xs text-muted-foreground">
+          Test run {props.snapshot.id} · Artifact {props.artifactIndex}
+        </p>
+      </header>
+      <ResultArtifact
+        evidence={props.artifact}
+        resultState={props.resultState}
+        scenarioName={props.scenarioName}
+      />
     </section>
   )
 }

--- a/packages/studio/src/runs/runs.tsx
+++ b/packages/studio/src/runs/runs.tsx
@@ -67,7 +67,7 @@ type RunsAreaProps = {
   api: StudioApi
   index?: StudioRunsIndex
   project: StudioProject
-  route: Extract<StudioRoute, { kind: 'runs' | 'run' | 'result' }>
+  route: Extract<StudioRoute, { kind: 'runs' | 'run' | 'result' | 'artifact' }>
   runsBlocked: boolean
   onCancel: (runId: string) => void
   onError: (message: string) => void
@@ -88,16 +88,31 @@ export function RunsArea(props: RunsAreaProps) {
     onFinished: () => void props.reloadIndex(),
   })
 
-  if (props.route.kind === 'result') {
-    const location = props.route.location
+  if (props.route.kind === 'result' || props.route.kind === 'artifact') {
+    const location =
+      props.route.kind === 'result'
+        ? props.route.location
+        : props.route.location.result
     const live = inspections.get(location.runId)
     return (
       <ResultInspector
         api={props.api}
+        artifactIndex={
+          props.route.kind === 'artifact'
+            ? props.route.location.artifactIndex
+            : undefined
+        }
         location={location}
         snapshot={live?.snapshot}
         connection={live?.connection}
         onBack={() => props.onNavigate({ kind: 'run', runId: location.runId })}
+        onBackToResult={() => props.onNavigate({ kind: 'result', location })}
+        onOpenArtifact={(artifactIndex) =>
+          props.onNavigate({
+            kind: 'artifact',
+            location: { result: location, artifactIndex },
+          })
+        }
         onTabChange={(tab) =>
           props.onNavigate(
             {

--- a/packages/studio/src/runs/use-live-run.ts
+++ b/packages/studio/src/runs/use-live-run.ts
@@ -20,7 +20,10 @@ import {
   selectLiveInspectorTab,
   startLiveInspection,
 } from './result/live-result-inspection'
-import type { ResultInspectorTab } from './result/result-inspection'
+import type {
+  ResultInspectionLocation,
+  ResultInspectorTab,
+} from './result/result-inspection'
 import type { MatrixCell } from './result/run-view'
 import { type RunOrigin, runOriginFromRequest } from './run-origin'
 
@@ -29,6 +32,7 @@ type UseLiveRunOptions = {
   api: StudioApi
   onClearError: () => void
   onError: (reason: unknown) => void
+  onInspectResult: (location: ResultInspectionLocation) => void
   registerActiveRun: (runId: string) => void
   reloadRunsIndex: () => Promise<StudioRunsIndex>
   runsIndex?: StudioRunsIndex
@@ -100,7 +104,10 @@ export function useLiveRun(options: UseLiveRunOptions) {
   }
 
   function pinSelection(cell: MatrixCell) {
-    updateLive((current) => pinLiveCell(current, cell))
+    if (!live) return
+    const pinned = pinLiveCell(live, cell)
+    setLive(pinned)
+    if (pinned.location) options.onInspectResult(pinned.location)
   }
 
   async function startRun(request: StudioRunRequest) {

--- a/packages/studio/src/server/server-runs.test.ts
+++ b/packages/studio/src/server/server-runs.test.ts
@@ -132,12 +132,28 @@ test('serves the Runs index, active lifecycle, compatibility alias, and deep lin
   })
   expect(replayedSchedule).toEqual(schedule)
 
+  const pagePaths = [
+    '/',
+    '/specifications/checkout',
+    '/specifications/checkout/scenarios/scenario',
+    '/runs',
+    '/runs/run-live',
+    '/runs/run-live/results/features%2Fcheckout.feature/scenarios/scenario/profiles/chrome/attempts/1?tab=timeline',
+    '/runs/run-live/results/features%2Fcheckout.feature/scenarios/scenario/examples/row-1/profiles/chrome/attempts/1',
+    '/runs/run-live/results/features%2Fcheckout.feature/scenarios/scenario/profiles/chrome/attempts/1/artifacts/0',
+  ]
+  for (const path of pagePaths) {
+    const page = await fetch(
+      `${origin}${path}${path.includes('?') ? '&' : '?'}token=runs-token`,
+    )
+    expect(page.status).toBe(200)
+    expect(page.headers.get('content-type')).toContain('text/html')
+    expect(page.headers.get('set-cookie')).toContain('pickle_studio_token')
+  }
+
   const deepLink = await fetch(
-    `${origin}/runs/run-live/results/scenario/chrome/1?specification=features%2Fcheckout.feature&token=runs-token`,
+    `${origin}/runs/run-live/results/features%2Fcheckout.feature/scenarios/scenario/profiles/chrome/attempts/1?token=runs-token`,
   )
-  expect(deepLink.status).toBe(200)
-  expect(deepLink.headers.get('content-type')).toContain('text/html')
-  expect(deepLink.headers.get('set-cookie')).toContain('pickle_studio_token')
   const document = await deepLink.text()
   const scriptPath = document.match(/<script[^>]+src="([^"]+)"/)?.[1]
   expect(scriptPath).toBeDefined()
@@ -149,6 +165,18 @@ test('serves the Runs index, active lifecycle, compatibility alias, and deep lin
     `${origin}/runs/run-live/results/incomplete?token=runs-token`,
   )
   expect(unknownPath.status).toBe(404)
+  const legacyPath = await fetch(
+    `${origin}/runs/run-live/results/scenario/chrome/1?specification=features%2Fcheckout.feature&token=runs-token`,
+  )
+  expect(legacyPath.status).toBe(404)
+  const indexAsset = await fetch(`${origin}/index.html?token=runs-token`)
+  expect(indexAsset.status).toBe(200)
+  expect(indexAsset.headers.get('content-type')).toContain('text/html')
+  expect(indexAsset.headers.get('set-cookie')).toContain('pickle_studio_token')
+  const unauthorizedDeepLink = await fetch(
+    `${origin}/specifications/checkout/scenarios/scenario`,
+  )
+  expect(unauthorizedDeepLink.status).toBe(401)
 
   completion.resolve()
   await completion.promise

--- a/packages/studio/src/server/server.ts
+++ b/packages/studio/src/server/server.ts
@@ -1031,6 +1031,7 @@ export async function startStudio(
       }
 
       function staticAsset(): Response | null {
+        if (url.pathname === '/index.html') return null
         const asset =
           ui.files.get(url.pathname) ?? ui.files.get(basename(url.pathname))
         return asset && request.method === 'GET' ? new Response(asset) : null
@@ -1039,11 +1040,9 @@ export async function startStudio(
       function studioPage(): Response | null {
         if (request.method !== 'GET') return null
         const routeKind = parseStudioRoute(url.href).kind
-        const page =
-          url.pathname === '/' ||
-          url.pathname === '/index.html' ||
-          ['runs', 'run', 'result'].includes(routeKind)
-        if (!page) return null
+        if (url.pathname !== '/index.html' && routeKind === 'not-found') {
+          return null
+        }
         return new Response(ui.index, {
           headers: {
             'content-type': 'text/html; charset=utf-8',

--- a/packages/studio/src/specifications/specification-results.tsx
+++ b/packages/studio/src/specifications/specification-results.tsx
@@ -21,8 +21,8 @@ type SpecificationResultsProps = {
   live?: LiveResultInspection
   onPauseFollowing: () => void
   onPinSelection: (cell: MatrixCell) => void
-  onRememberScenario: (scenario: StudioScenario) => void
   onResumeFollowing: () => void
+  onSelectScenario: (scenario: StudioScenario) => void
   onRun: (request: StudioRunRequest) => void
   onSelectInspectorTab: (tab: ResultInspectorTab) => void
   origin?: RunOrigin
@@ -34,7 +34,7 @@ type SpecificationResultsProps = {
 
 export function SpecificationResults(props: SpecificationResultsProps) {
   function handleRunScenario(scenario: StudioScenario) {
-    props.onRememberScenario(scenario)
+    props.onSelectScenario(scenario)
     props.onRun({
       paths: [props.specification.uri],
       scenarioId: scenario.id,

--- a/packages/studio/src/specifications/specifications-screen.tsx
+++ b/packages/studio/src/specifications/specifications-screen.tsx
@@ -14,13 +14,15 @@ import type {
 import { SpecificationHeader } from './specification-header'
 import { SpecificationList } from './specification-list'
 import { SpecificationResults } from './specification-results'
+import type { MissingSpecificationSelection } from './use-specification-selection'
 
 type SpecificationSelection = {
   currentScenarioId?: string
   focusRequest: number
   focusTargetId?: string
   headingRef: RefObject<HTMLHeadingElement | null>
-  onRememberScenario: (scenario: StudioScenario) => void
+  missing?: MissingSpecificationSelection
+  onSelectScenario: (scenario: StudioScenario) => void
   onSelect: (id: string) => void
   onSelectCreated: (
     specifications: readonly StudioSpecification[],
@@ -94,6 +96,20 @@ type SpecificationDetailProps = SpecificationsScreenProps & {
 
 function SpecificationDetail(props: SpecificationDetailProps) {
   const { selected } = props.selection
+  if (props.selection.missing) {
+    const missing = props.selection.missing
+    const label =
+      missing.kind === 'scenario'
+        ? `Scenario ${missing.scenarioId}`
+        : `Specification ${missing.specificationId}`
+    return (
+      <main className="flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden p-5">
+        <p role="alert" className="text-sm text-destructive">
+          {label} was not found in this project.
+        </p>
+      </main>
+    )
+  }
   if (!selected) {
     return (
       <main className="flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden">
@@ -156,7 +172,7 @@ function SpecificationDetail(props: SpecificationDetailProps) {
           live={props.run.live}
           onPauseFollowing={props.run.onPauseFollowing}
           onPinSelection={props.run.onPinSelection}
-          onRememberScenario={props.selection.onRememberScenario}
+          onSelectScenario={props.selection.onSelectScenario}
           onResumeFollowing={props.run.onResumeFollowing}
           onRun={props.run.onRun}
           onSelectInspectorTab={props.run.onSelectInspectorTab}

--- a/packages/studio/src/specifications/use-specification-selection.test.ts
+++ b/packages/studio/src/specifications/use-specification-selection.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, test } from 'bun:test'
+import type { StudioSpecification } from '../server/server'
+import { resolveSpecificationSelection } from './use-specification-selection'
+
+const specifications = [
+  {
+    id: 'checkout',
+    uri: 'features/checkout.feature',
+    name: 'Checkout',
+    state: 'active',
+    scenarios: [{ id: 'pay', name: 'Pay' }],
+  },
+  {
+    id: 'refunds',
+    uri: 'features/refunds.feature',
+    name: 'Refunds',
+    state: 'active',
+    scenarios: [
+      {
+        id: 'request-refund',
+        name: 'Request refund',
+      },
+    ],
+  },
+] satisfies readonly StudioSpecification[]
+
+describe('Specification route selection', () => {
+  test('defaults the Specifications root to the first Specification', () => {
+    expect(
+      resolveSpecificationSelection({ kind: 'specifications' }, specifications),
+    ).toEqual({ selected: specifications[0] })
+  })
+
+  test('resolves Specification and scenario identity from the route', () => {
+    expect(
+      resolveSpecificationSelection(
+        { kind: 'specification', specificationId: 'refunds' },
+        specifications,
+      ),
+    ).toEqual({ selected: specifications[1] })
+    expect(
+      resolveSpecificationSelection(
+        {
+          kind: 'scenario',
+          specificationId: 'checkout',
+          scenarioId: 'pay',
+        },
+        specifications,
+      ),
+    ).toEqual({
+      selected: specifications[0],
+      currentScenario: specifications[0]?.scenarios[0],
+    })
+  })
+
+  test('keeps semantic misses explicit instead of selecting another entity', () => {
+    expect(
+      resolveSpecificationSelection(
+        { kind: 'specification', specificationId: 'missing' },
+        specifications,
+      ),
+    ).toEqual({
+      missing: { kind: 'specification', specificationId: 'missing' },
+    })
+    expect(
+      resolveSpecificationSelection(
+        {
+          kind: 'scenario',
+          specificationId: 'checkout',
+          scenarioId: 'missing',
+        },
+        specifications,
+      ),
+    ).toEqual({
+      selected: specifications[0],
+      missing: {
+        kind: 'scenario',
+        specificationId: 'checkout',
+        scenarioId: 'missing',
+      },
+    })
+  })
+
+  test('does not invent a Specification selection for Runs routes', () => {
+    expect(
+      resolveSpecificationSelection(
+        { kind: 'run', runId: 'run-42' },
+        specifications,
+      ),
+    ).toEqual({})
+  })
+})

--- a/packages/studio/src/specifications/use-specification-selection.ts
+++ b/packages/studio/src/specifications/use-specification-selection.ts
@@ -1,42 +1,82 @@
 import { useEffect, useRef, useState } from 'react'
 import type { CurrentScenario } from '../app/command-palette'
+import type { StudioRoute } from '../app/studio-route'
 import type { StudioScenario, StudioSpecification } from '../server/server'
 
 type UseSpecificationSelectionOptions = {
-  onShowSpecifications: (replace?: boolean) => void
+  navigate: (route: StudioRoute, replace?: boolean) => void
+  route: StudioRoute
   specifications: readonly StudioSpecification[]
 }
 
-type RememberedScenario = {
-  id: string
-  specificationUri: string
+export type MissingSpecificationSelection =
+  | { kind: 'specification'; specificationId: string }
+  | {
+      kind: 'scenario'
+      specificationId: string
+      scenarioId: string
+    }
+
+type ResolvedSpecificationSelection = {
+  selected?: StudioSpecification
+  currentScenario?: StudioScenario
+  missing?: MissingSpecificationSelection
 }
 
 type SelectionFocus =
   | { kind: 'scenario'; request: number; scenarioId: string }
   | { kind: 'specification'; request: number }
 
+export function resolveSpecificationSelection(
+  route: StudioRoute,
+  specifications: readonly StudioSpecification[],
+): ResolvedSpecificationSelection {
+  if (route.kind === 'specifications') return { selected: specifications[0] }
+  if (route.kind !== 'specification' && route.kind !== 'scenario') return {}
+
+  const selected = specifications.find(
+    (specification) => specification.id === route.specificationId,
+  )
+  if (!selected) {
+    return {
+      missing: {
+        kind: 'specification',
+        specificationId: route.specificationId,
+      },
+    }
+  }
+  if (route.kind === 'specification') return { selected }
+
+  const currentScenario = selected.scenarios.find(
+    (scenario) => scenario.id === route.scenarioId,
+  )
+  return currentScenario
+    ? { selected, currentScenario }
+    : {
+        selected,
+        missing: {
+          kind: 'scenario',
+          specificationId: route.specificationId,
+          scenarioId: route.scenarioId,
+        },
+      }
+}
+
 export function useSpecificationSelection(
   options: UseSpecificationSelectionOptions,
 ) {
-  const [selectedId, setSelectedId] = useState<string>()
-  const [rememberedScenario, setRememberedScenario] =
-    useState<RememberedScenario>()
   const [focus, setFocus] = useState<SelectionFocus>()
   const headingRef = useRef<HTMLHeadingElement>(null)
-
-  const selected =
-    options.specifications.find((item) => item.id === selectedId) ??
-    options.specifications[0]
-  const currentScenario =
-    selected && selected.uri === rememberedScenario?.specificationUri
-      ? selected.scenarios.find(
-          (scenario) => scenario.id === rememberedScenario.id,
-        )
-      : undefined
+  const resolved = resolveSpecificationSelection(
+    options.route,
+    options.specifications,
+  )
   const currentScenarioContext: CurrentScenario | undefined =
-    selected && currentScenario
-      ? { specification: selected, scenario: currentScenario }
+    resolved.selected && resolved.currentScenario
+      ? {
+          specification: resolved.selected,
+          scenario: resolved.currentScenario,
+        }
       : undefined
 
   useEffect(() => {
@@ -44,9 +84,8 @@ export function useSpecificationSelection(
     headingRef.current?.focus()
   }, [focus])
 
-  function selectSpecification(id: string) {
-    setSelectedId(id)
-    setRememberedScenario(undefined)
+  function selectSpecification(specificationId: string) {
+    options.navigate({ kind: 'specification', specificationId })
     setFocus(undefined)
   }
 
@@ -54,12 +93,14 @@ export function useSpecificationSelection(
     specification: StudioSpecification,
     scenario?: StudioScenario,
   ) {
-    options.onShowSpecifications(true)
-    setSelectedId(specification.id)
-    setRememberedScenario(
+    options.navigate(
       scenario
-        ? { id: scenario.id, specificationUri: specification.uri }
-        : undefined,
+        ? {
+            kind: 'scenario',
+            specificationId: specification.id,
+            scenarioId: scenario.id,
+          }
+        : { kind: 'specification', specificationId: specification.id },
     )
     if (scenario) {
       setFocus((current) => ({
@@ -75,9 +116,13 @@ export function useSpecificationSelection(
     }))
   }
 
-  function rememberScenario(scenario: StudioScenario) {
-    if (!selected) return
-    setRememberedScenario({ id: scenario.id, specificationUri: selected.uri })
+  function selectScenario(scenario: StudioScenario) {
+    if (!resolved.selected) return
+    options.navigate({
+      kind: 'scenario',
+      specificationId: resolved.selected.id,
+      scenarioId: scenario.id,
+    })
   }
 
   function selectCreatedSpecification(
@@ -85,7 +130,12 @@ export function useSpecificationSelection(
     uri: string,
   ) {
     const created = specifications.find((item) => item.uri === uri)
-    if (created) setSelectedId(created.id)
+    if (created) {
+      options.navigate({
+        kind: 'specification',
+        specificationId: created.id,
+      })
+    }
   }
 
   return {
@@ -93,9 +143,10 @@ export function useSpecificationSelection(
     focus,
     headingRef,
     jumpToSpecification,
-    rememberScenario,
+    missing: resolved.missing,
     selectCreatedSpecification,
-    selected,
+    selected: resolved.selected,
+    selectScenario,
     selectSpecification,
   }
 }

--- a/packages/web/src/adapter/stagehand-factory.test.ts
+++ b/packages/web/src/adapter/stagehand-factory.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, mock, spyOn, test } from 'bun:test'
-import { localBrowser, Stagehand } from '@browserbasehq/stagehand'
+import { browserbase, localBrowser, Stagehand } from '@browserbasehq/stagehand'
 import type { Scenario, Specification } from '@pickle-spec/spec'
 import { z } from 'zod'
 import { createWebAdapter } from '../../index'
@@ -150,5 +150,86 @@ describe('stagehandFactory', () => {
     expect(goto).toHaveBeenCalledTimes(1)
     expect(create).toHaveBeenCalledTimes(1)
     expect(create.mock.calls[0]?.[0]).not.toHaveProperty('model')
+  })
+
+  test('connects to CDP with the configured extension and keeps Replay model-free', async () => {
+    const page = {
+      goto: mock(async () => null),
+      evaluate: mock(async () => 0),
+    }
+    const context = {
+      activePage: mock(async () => page),
+      cookies: mock(async () => []),
+      pages: mock(async () => [page]),
+      addInitScript: mock(async () => {}),
+    }
+    const browser = {
+      context,
+      close: mock(async () => {}),
+    } as unknown as LaunchedBrowser
+    const stagehand = {
+      browser,
+      close: mock(async () => {}),
+    } as unknown as Stagehand
+    const connect = spyOn(localBrowser, 'connect').mockResolvedValue(browser)
+    const create = spyOn(Stagehand, 'create').mockResolvedValue(stagehand)
+    const browserOptions = {
+      cdpUrl: 'wss://browser.example.test/session?token=secret',
+      cdpExtensionId: 'stagehand-extension',
+    }
+    const browserProcess = await stagehandFactory.launch({
+      browser: browserOptions,
+    })
+
+    try {
+      await browserProcess.openContext({
+        browser: browserOptions,
+        mode: 'replay',
+      })
+    } finally {
+      await browserProcess.close()
+    }
+
+    expect(connect).toHaveBeenCalledWith({
+      cdpUrl: browserOptions.cdpUrl,
+      extensionId: browserOptions.cdpExtensionId,
+    })
+    expect(create.mock.calls[0]?.[0]).not.toHaveProperty('model')
+  })
+
+  test('redacts CDP connection failures', async () => {
+    const cdpUrl = 'wss://browser.example.test/session?token=secret'
+    spyOn(localBrowser, 'connect').mockRejectedValue(
+      new Error(`Failed to connect to ${cdpUrl}`),
+    )
+
+    try {
+      await stagehandFactory.launch({ browser: { cdpUrl } })
+      throw new Error('Expected the CDP connection to fail')
+    } catch (error) {
+      expect(String(error)).toContain('web.browser.cdpUrl')
+      expect(String(error)).not.toContain(cdpUrl)
+    }
+  })
+
+  test('keeps the Browserbase launch branch unchanged', async () => {
+    const browser = {
+      close: mock(async () => {}),
+    } as unknown as LaunchedBrowser
+    const launch = spyOn(browserbase, 'launch').mockResolvedValue(browser)
+    const browserProcess = await stagehandFactory.launch({
+      browser: {
+        environment: 'browserbase',
+        browserbaseApiKey: 'browserbase-key',
+        browserbaseProjectId: 'browserbase-project',
+      },
+    })
+
+    await browserProcess.close()
+
+    expect(launch).toHaveBeenCalledWith({
+      apiKey: 'browserbase-key',
+      projectId: 'browserbase-project',
+    })
   })
 })

--- a/packages/web/src/adapter/stagehand-factory.ts
+++ b/packages/web/src/adapter/stagehand-factory.ts
@@ -22,10 +22,16 @@ import {
 } from './fidelity'
 import { createStagehandAutomation } from './stagehand-automation'
 import type { WebAutomationFactory, WebClientContext } from './web-automation'
-import { type BrowserOptions, defaultModelName } from './web-options'
+import {
+  type BrowserOptions,
+  defaultModelName,
+  resolveBrowserConnection,
+} from './web-options'
 
 const defaultDomSettleTimeoutMs = 3_000
 const defaultObserveTimeoutMs = 10_000
+
+type StagehandBrowser = Awaited<ReturnType<typeof localBrowser.launch>>
 
 type FidelityRoute = {
   request: () => { resourceType: () => string }
@@ -128,16 +134,28 @@ function stagehandCreateOptions(
 export const stagehandFactory: WebAutomationFactory = {
   async launch({ browser: options, signal }) {
     if (signal?.aborted) throw abortError()
-    const browser =
-      options.environment === 'browserbase'
-        ? await browserbase.launch({
-            apiKey:
-              options.browserbaseApiKey ?? process.env.BROWSERBASE_API_KEY!,
-            projectId:
-              options.browserbaseProjectId ??
-              process.env.BROWSERBASE_PROJECT_ID!,
-          })
-        : await localBrowser.launch({ headless: options.headless ?? true })
+    const connection = resolveBrowserConnection(options)
+    let browser: StagehandBrowser
+    if (connection.kind === 'cdp') {
+      try {
+        browser = await localBrowser.connect({
+          cdpUrl: connection.cdpUrl,
+          extensionId: connection.extensionId,
+        })
+      } catch {
+        throw new Error('Could not connect to web.browser.cdpUrl')
+      }
+    } else if (connection.kind === 'browserbase') {
+      browser = await browserbase.launch({
+        apiKey: options.browserbaseApiKey ?? process.env.BROWSERBASE_API_KEY!,
+        projectId:
+          options.browserbaseProjectId ?? process.env.BROWSERBASE_PROJECT_ID!,
+      })
+    } else {
+      browser = await localBrowser.launch({
+        headless: options.headless ?? true,
+      })
+    }
 
     let stagehand: Stagehand | undefined
     let evidenceScriptInstalled = false

--- a/packages/web/src/adapter/web-adapter.test.ts
+++ b/packages/web/src/adapter/web-adapter.test.ts
@@ -687,6 +687,90 @@ describe('createWebAdapter', () => {
     ).not.toThrow()
   })
 
+  test('accepts supported CDP URLs and preserves the extension ID', () => {
+    for (const cdpUrl of [
+      'http://127.0.0.1:9222',
+      'https://browser.example.test/cdp',
+      'ws://127.0.0.1:9222/devtools/browser/session',
+      'wss://browser.example.test/devtools/browser/session',
+    ]) {
+      expect(
+        validateWebAdapterOptions({
+          baseUrl: 'https://example.test',
+          browser: { cdpUrl, cdpExtensionId: 'stagehand-extension' },
+        }).browser,
+      ).toMatchObject({ cdpUrl, cdpExtensionId: 'stagehand-extension' })
+    }
+  })
+
+  test('rejects unsupported CDP URL schemes without exposing the value', () => {
+    for (const cdpUrl of [
+      'file:///secret/browser-profile',
+      '/relative/devtools/browser/session',
+    ]) {
+      expect(() =>
+        validateWebAdapterOptions({
+          baseUrl: 'https://example.test',
+          browser: { cdpUrl },
+        }),
+      ).toThrow('web.browser.cdpUrl must be an absolute HTTP(S) or WS(S) URL')
+
+      try {
+        validateWebAdapterOptions({
+          baseUrl: 'https://example.test',
+          browser: { cdpUrl },
+        })
+      } catch (error) {
+        expect(String(error)).not.toContain(cdpUrl)
+      }
+
+      const createInvalidAdapter = () =>
+        createWebAdapter({
+          baseUrl: 'https://example.test',
+          browser: { cdpUrl },
+        })
+
+      expect(createInvalidAdapter).toThrow(
+        'web.browser.cdpUrl must be an absolute HTTP(S) or WS(S) URL',
+      )
+      try {
+        createInvalidAdapter()
+      } catch (error) {
+        expect(String(error)).toContain('web.browser.cdpUrl')
+        expect(String(error)).not.toContain(cdpUrl)
+      }
+    }
+  })
+
+  test('rejects Browserbase with CDP and an extension ID without CDP', () => {
+    expect(() =>
+      validateWebAdapterOptions({
+        baseUrl: 'https://example.test',
+        browser: {
+          environment: 'browserbase',
+          cdpUrl: 'wss://browser.example.test/session',
+        },
+      }),
+    ).toThrow('web.browser.cdpUrl cannot be used with browserbase')
+
+    expect(() =>
+      validateWebAdapterOptions({
+        baseUrl: 'https://example.test',
+        browser: { cdpExtensionId: 'stagehand-extension' },
+      }),
+    ).toThrow('web.browser.cdpExtensionId requires web.browser.cdpUrl')
+
+    expect(() =>
+      validateWebAdapterOptions({
+        baseUrl: 'https://example.test',
+        browser: {
+          cdpUrl: 'wss://browser.example.test/session',
+          cdpExtensionId: '   ',
+        },
+      }),
+    ).toThrow('web.browser.cdpExtensionId must not be empty')
+  })
+
   test('forwards GOOGLE_API_KEY to the automation factory for a Google model', async () => {
     const openContext = mock(async () => stubAutomation())
     const launch = mock(async () => ({
@@ -723,6 +807,28 @@ describe('createWebAdapter', () => {
     const adapter = createWebAdapter({
       baseUrl: 'https://example.test',
       browser: { modelName: 'google/gemini-3.6-flash' },
+    })
+    await withEnv(clearedGoogleApiKeys, async () => {
+      await expect(
+        adapter.openSession({
+          executionTargetProfile: { id: 'web' },
+          specification,
+          scenario,
+        }),
+      ).rejects.toThrow(
+        'Model inference requires a provider API key or a Browserbase session',
+      )
+    })
+  })
+
+  test('does not grant Browserbase model credentials to a direct CDP caller', async () => {
+    const adapter = createWebAdapter({
+      baseUrl: 'https://example.test',
+      browser: {
+        environment: 'browserbase',
+        cdpUrl: 'wss://browser.example.test/session',
+        modelName: 'google/gemini-3.6-flash',
+      },
     })
     await withEnv(clearedGoogleApiKeys, async () => {
       await expect(

--- a/packages/web/src/adapter/web-adapter.ts
+++ b/packages/web/src/adapter/web-adapter.ts
@@ -17,6 +17,7 @@ import { createWebLiveSession } from './web-live-session'
 import {
   type BrowserOptions,
   defaultModelName,
+  resolveBrowserConnection,
   type WebAdapterOptions,
 } from './web-options'
 import { WebProcessPool } from './web-pool'
@@ -89,7 +90,7 @@ function resolveBrowserLaunchOptions({
   if (
     requireProviderApiKey &&
     requiresInference &&
-    resolvedBrowser.environment !== 'browserbase' &&
+    resolveBrowserConnection(resolvedBrowser).kind !== 'browserbase' &&
     !resolvedBrowser.modelApiKey
   ) {
     const envNames = providerApiKeyEnvNames(resolvedBrowser.modelName)

--- a/packages/web/src/adapter/web-options.ts
+++ b/packages/web/src/adapter/web-options.ts
@@ -14,6 +14,33 @@ export const screenshotModes = ['off', 'on-failure', 'on-step'] as const
 export const screenshotFormats = ['png', 'jpeg'] as const
 export const browserEnvironments = ['local', 'browserbase'] as const
 export const webProfiles = ['default', 'fast'] as const
+const cdpProtocols = ['http:', 'https:', 'ws:', 'wss:'] as const
+
+export function cdpEndpointOrigin(value: string): string | undefined {
+  try {
+    const url = new URL(value)
+    if (cdpProtocols.some((protocol) => protocol === url.protocol)) {
+      return url.origin
+    }
+  } catch {}
+}
+
+const cdpUrlSchema = optionalString('web.browser.cdpUrl').superRefine(
+  (value, context) => {
+    if (value === undefined) return
+    if (cdpEndpointOrigin(value) !== undefined) return
+    context.addIssue({
+      code: 'custom',
+      message: 'web.browser.cdpUrl must be an absolute HTTP(S) or WS(S) URL',
+    })
+  },
+)
+
+const cdpExtensionIdSchema = z
+  .string({ error: 'web.browser.cdpExtensionId must be a string' })
+  .trim()
+  .min(1, { error: 'web.browser.cdpExtensionId must not be empty' })
+  .optional()
 
 const browserOptionsSchema = strictObject('web.browser', {
   environment: z
@@ -44,6 +71,8 @@ const browserOptionsSchema = strictObject('web.browser', {
   ),
   modelApiKey: optionalString('web.browser.modelApiKey'),
   headless: optionalBoolean('web.browser.headless'),
+  cdpUrl: cdpUrlSchema,
+  cdpExtensionId: cdpExtensionIdSchema,
   browserbaseApiKey: optionalString('web.browser.browserbaseApiKey'),
   browserbaseProjectId: optionalString('web.browser.browserbaseProjectId'),
   cache: optionalBoolean('web.browser.cache'),
@@ -55,6 +84,19 @@ const browserOptionsSchema = strictObject('web.browser', {
     'web.browser.navigationTimeoutMs',
   ),
   idleTimeoutMs: optionalPositiveInteger('web.browser.idleTimeoutMs'),
+}).superRefine((options, context) => {
+  if (options.environment === 'browserbase' && options.cdpUrl !== undefined) {
+    context.addIssue({
+      code: 'custom',
+      message: 'web.browser.cdpUrl cannot be used with browserbase',
+    })
+  }
+  if (options.cdpExtensionId !== undefined && options.cdpUrl === undefined) {
+    context.addIssue({
+      code: 'custom',
+      message: 'web.browser.cdpExtensionId requires web.browser.cdpUrl',
+    })
+  }
 })
 
 const screenshotOptionsSchema = strictObject('web.screenshots', {
@@ -120,6 +162,24 @@ export const webAdapterOptionsSchema = strictObject('web', {
 export type BrowserOptions = z.infer<typeof browserOptionsSchema>
 export type ScreenshotOptions = z.infer<typeof screenshotOptionsSchema>
 export type WebAdapterOptions = z.infer<typeof webAdapterOptionsSchema>
+
+export type BrowserConnection =
+  | { kind: 'local' }
+  | { kind: 'browserbase' }
+  | { kind: 'cdp'; cdpUrl: string; extensionId?: string }
+
+export function resolveBrowserConnection(
+  options?: BrowserOptions,
+): BrowserConnection {
+  if (options?.cdpUrl !== undefined) {
+    return {
+      kind: 'cdp',
+      cdpUrl: options.cdpUrl,
+      extensionId: options.cdpExtensionId,
+    }
+  }
+  return { kind: options?.environment ?? 'local' }
+}
 
 export function validateWebAdapterOptions(value: unknown): WebAdapterOptions {
   return parseConfiguration(

--- a/packages/web/src/execution-cache/web-execution-cache.test.ts
+++ b/packages/web/src/execution-cache/web-execution-cache.test.ts
@@ -222,4 +222,51 @@ describe('web target configuration fingerprint', () => {
       )
     }
   })
+
+  test('uses a value-free CDP identity without launch-only headless state', () => {
+    const local = createWebAdapter({
+      baseUrl: 'https://example.test',
+    }).executionCache?.targetConfigurationFingerprint
+    const firstCdp = createWebAdapter({
+      baseUrl: 'https://example.test',
+      browser: {
+        cdpUrl: 'wss://first.example.test/session?token=first-secret',
+        cdpExtensionId: 'first-extension',
+        headless: false,
+      },
+    }).executionCache?.targetConfigurationFingerprint
+    const sameEndpointCdp = createWebAdapter({
+      baseUrl: 'https://example.test',
+      browser: {
+        environment: 'local',
+        cdpUrl: 'wss://first.example.test/other-session?token=second-secret',
+        cdpExtensionId: 'second-extension',
+        headless: true,
+      },
+    }).executionCache?.targetConfigurationFingerprint
+    const differentEndpointCdp = createWebAdapter({
+      baseUrl: 'https://example.test',
+      browser: {
+        cdpUrl: 'https://second.example.test/session?token=second-secret',
+      },
+    }).executionCache?.targetConfigurationFingerprint
+
+    expect(firstCdp).not.toBe(local)
+    expect(sameEndpointCdp).toBe(firstCdp)
+    expect(differentEndpointCdp).not.toBe(firstCdp)
+  })
+
+  test('keeps existing non-CDP fingerprints unchanged', () => {
+    expect(
+      createWebAdapter({
+        baseUrl: 'https://example.test',
+      }).executionCache?.targetConfigurationFingerprint,
+    ).toBe('949667228330a3ecee5a9bbf31cfc83496c84058e36d05fbd2d2d2a70d6e812d')
+    expect(
+      createWebAdapter({
+        baseUrl: 'https://example.test',
+        browser: { environment: 'browserbase' },
+      }).executionCache?.targetConfigurationFingerprint,
+    ).toBe('213e0f64d53c65ceabf82bf2e902b11c665fb006574e0c3450f734c9d86222bd')
+  })
 })

--- a/packages/web/src/execution-cache/web-execution-cache.ts
+++ b/packages/web/src/execution-cache/web-execution-cache.ts
@@ -1,6 +1,10 @@
 import type { ResolvedFidelity } from '../adapter/fidelity'
 import type { WebAdapterBehavior } from '../adapter/web-adapter'
-import type { WebAdapterOptions } from '../adapter/web-options'
+import {
+  cdpEndpointOrigin,
+  resolveBrowserConnection,
+  type WebAdapterOptions,
+} from '../adapter/web-options'
 import { webInstructionVariables } from './web-cache-compilation'
 import {
   type WebExecutionCachePayload,
@@ -73,16 +77,36 @@ interface WebFingerprintInput {
   fidelity: ResolvedFidelity
 }
 
+function cdpEndpointFingerprint(cdpUrl: string): string {
+  const origin = cdpEndpointOrigin(cdpUrl)
+  if (origin === undefined) {
+    throw new Error(
+      'web.browser.cdpUrl must be an absolute HTTP(S) or WS(S) URL',
+    )
+  }
+  return new Bun.CryptoHasher('sha256').update(origin).digest('hex')
+}
+
 export function webTargetConfigurationFingerprint({
   options,
   behavior,
   fidelity,
 }: WebFingerprintInput): string {
+  const connection = resolveBrowserConnection(options.browser)
+  const browserIdentity =
+    connection.kind === 'cdp'
+      ? {
+          environment: connection.kind,
+          endpoint: cdpEndpointFingerprint(connection.cdpUrl),
+        }
+      : {
+          environment: connection.kind,
+          headless: options.browser?.headless ?? true,
+        }
   const source = JSON.stringify({
     schemaVersion: 1,
     baseUrl: new URL(options.baseUrl).toString(),
-    environment: options.browser?.environment ?? 'local',
-    headless: options.browser?.headless ?? true,
+    ...browserIdentity,
     fidelity: {
       profile: fidelity.profile,
       tradeOffs: fidelity.tradeOffs,


### PR DESCRIPTION
## Why

Pickle Spec could launch local Chrome or Browserbase, but it could not attach the built-in web driver to an existing CDP browser. Users had to replace the full automation factory to use another cloud browser provider or a custom local Chrome process.

## Scope

- Add `web.browser.cdpUrl` and optional `cdpExtensionId` to the schema-derived web configuration.
- Route CDP connections through Stagehand's supported `localBrowser.connect` API.
- Keep local launch, Browserbase launch, Adaptive model credentials, and inference-free Replay behavior intact.
- Redact CDP connection failures and keep credential-bearing URLs out of cache fingerprint input.
- Derive CDP cache identity from a hashed endpoint origin. Rotating session paths and tokens share a cache identity, while another provider endpoint does not.
- Document extension loading, external browser ownership, ignored launch settings, and secret handling.

## Tradeoffs

- Pickle Spec disconnects from attached browsers but does not stop externally owned browser processes or cloud sessions.
- `web.browser.headless` does not affect an attached browser because its owner controls launch settings.
- Providers that block Stagehand from loading its extension must preload it and set `cdpExtensionId`.

## Blast Radius

The change affects web adapter configuration, Stagehand browser selection, and the web execution-cache fingerprint. Existing local and Browserbase fingerprints remain byte-for-byte unchanged. CLI config parsing reuses the same web schema, so root and profile configuration require no separate parser.

## Verification

- `bun test src` from `packages/web` passed 103 tests.
- `bun run typecheck` from `packages/web` passed.
- The focused CLI CDP configuration test passed.
- Biome passed on every changed file, and `git diff --check` passed.
- A live Chrome check attached through CDP, disconnected, and confirmed that the external Chrome process remained alive.
- The repository-wide test command passed. Later repository-wide lint and typecheck reruns encountered concurrent unstaged Studio changes outside this PR. The changed files and the web package remained green.
