### PR TITLE
feat(studio): stream live browser viewports in result inspection

### DIFF
--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -12,6 +12,7 @@ import {
 import type { SelectionOptions, SpecificationState } from '@pickle-spec/spec'
 import type {
   StudioAuthoringModel,
+  StudioLiveViewportEvent,
   StudioManagementGateway,
   StudioRunGateway,
   StudioRunReadinessCheck,
@@ -21,6 +22,7 @@ import {
   defaultModelName,
   screenshotModes,
   type WebAdapterOptions,
+  type WebLiveViewportUpdate,
 } from '@pickle-spec/web'
 import cliPackage from '../package.json' with { type: 'json' }
 import {
@@ -816,6 +818,16 @@ interface StudioRunGatewayInput {
   controller: AbortController
 }
 
+function studioLiveViewportEvent(
+  update: WebLiveViewportUpdate,
+): StudioLiveViewportEvent {
+  if (update.kind === 'closed') {
+    return { type: 'viewport-closed', target: update.target }
+  }
+  const { target, ...viewport } = update
+  return { type: 'viewport-updated', target, viewport }
+}
+
 function studioRunGateway(input: StudioRunGatewayInput): StudioRunGateway {
   const { activeRuns, context, controller } = input
   const { args, credentials, extensions, root } = context
@@ -855,6 +867,7 @@ function studioRunGateway(input: StudioRunGatewayInput): StudioRunGateway {
         onSchedule: (schedule) => onEvent({ type: 'run-scheduled', schedule }),
         onApplicationDiagnostic: (event) =>
           onEvent({ type: 'diagnostic-recorded', ...event }),
+        onLiveViewport: (update) => onEvent(studioLiveViewportEvent(update)),
       })
       activeRuns.set(started.id, runController)
       void started.done

--- a/packages/cli/src/run/execute-run.ts
+++ b/packages/cli/src/run/execute-run.ts
@@ -37,6 +37,7 @@ import {
   createWebAdapter,
   resolveWebArtifactCapture,
   type WebAdapterOptions,
+  type WebLiveViewportUpdate,
 } from '@pickle-spec/web'
 import { resolveApplicationRevision } from '../configuration/application-revision'
 import {
@@ -104,6 +105,7 @@ type StartProjectRunInput = {
   signal?: AbortSignal
   onEvent?: (event: RunEvent) => void | Promise<void>
   onApplicationDiagnostic?: (event: LiveApplicationDiagnostic) => void
+  onLiveViewport?: (update: WebLiveViewportUpdate) => void
   onSchedule?: (
     schedule: readonly ScheduledTestResult[],
   ) => void | Promise<void>
@@ -203,13 +205,16 @@ function configuredWebOptions(
 function configuredAdapter(
   extensions: Extensions,
   web: WebAdapterOptions | undefined,
+  onLiveViewport?: (update: WebLiveViewportUpdate) => void,
 ): ExecutionTargetAdapter {
   if (extensions.adapter) return extensions.adapter
   if (!web)
     throw new Error(
       'Configure web.baseUrl or export an adapter from pickle.extensions.ts',
     )
-  return createWebAdapter(web, extensions.webAutomationFactory)
+  return createWebAdapter(web, extensions.webAutomationFactory, {
+    onLiveViewport,
+  })
 }
 
 function configureProfileAdapter(
@@ -218,6 +223,7 @@ function configureProfileAdapter(
   config: PickleConfig,
   args: ProjectRunOptions,
   profile: ExecutionTargetProfile,
+  onLiveViewport?: (update: WebLiveViewportUpdate) => void,
 ): void {
   const configuredAdapters = adapters
   if (configuredAdapters[profile.id]) return
@@ -244,6 +250,7 @@ function configureProfileAdapter(
   configuredAdapters[profile.id] = createWebAdapter(
     web,
     extensions.webAutomationFactory,
+    { onLiveViewport },
   )
 }
 
@@ -252,6 +259,7 @@ function configuredRunExtensions(
   config: PickleConfig,
   args: ProjectRunOptions,
   profiles: readonly ExecutionTargetProfile[],
+  onLiveViewport?: (update: WebLiveViewportUpdate) => void,
 ): RunExtensions {
   const adapters: Record<string, ExecutionTargetAdapter> = {
     ...extensions.adapters,
@@ -259,13 +267,24 @@ function configuredRunExtensions(
   if (extensions.adapter) adapters.custom ??= extensions.adapter
 
   for (const profile of profiles) {
-    configureProfileAdapter(adapters, extensions, config, args, profile)
+    configureProfileAdapter(
+      adapters,
+      extensions,
+      config,
+      args,
+      profile,
+      onLiveViewport,
+    )
   }
 
   return {
     adapter: profiles.some((profile) => profile.adapter)
       ? extensions.adapter
-      : configuredAdapter(extensions, configuredWebOptions(config, args)),
+      : configuredAdapter(
+          extensions,
+          configuredWebOptions(config, args),
+          onLiveViewport,
+        ),
     adapters,
   }
 }
@@ -483,6 +502,7 @@ async function resolveProjectRunConfiguration(
   applicationRevision: string | undefined,
   profileIds: string[] | undefined,
   root: string,
+  onLiveViewport?: (update: WebLiveViewportUpdate) => void,
 ): Promise<ResolvedProjectRunConfiguration> {
   const extensions = await loadExtensions(args.extensionsPath, root)
   const runConfiguration = {
@@ -505,6 +525,7 @@ async function resolveProjectRunConfiguration(
       config,
       args,
       runConfiguration.executionTargetProfiles ?? [],
+      onLiveViewport,
     ),
   )
 }
@@ -718,6 +739,7 @@ async function runProjectWork(context: ProjectRunWorkInput) {
       applicationRevision,
       selection.profileIds,
       root,
+      input.onLiveViewport,
     )
     validateTargetSelection(selection.selections, configuration.targets)
     await publishRunSchedule(input, selection, configuration)

--- a/packages/studio/index.ts
+++ b/packages/studio/index.ts
@@ -1,3 +1,8 @@
+export type {
+  StudioLiveViewport,
+  StudioLiveViewportEvent,
+  StudioLiveViewportTarget,
+} from './src/live-viewport'
 export type { CredentialStore } from './src/server/credentials'
 export {
   createCredentialStore,

--- a/packages/studio/src/live-viewport.ts
+++ b/packages/studio/src/live-viewport.ts
@@ -1,0 +1,38 @@
+export type StudioLiveViewportTarget = {
+  scenarioId: string
+  examplesRowId?: string
+  profileId: string
+  attempt?: number
+}
+
+export type StudioLiveViewport =
+  | {
+      kind: 'frame'
+      data: string
+      mimeType: 'image/jpeg'
+      width?: number
+      height?: number
+    }
+  | { kind: 'browserbase'; sessionId: string; url: string }
+
+export type StudioLiveViewportEvent =
+  | {
+      type: 'viewport-updated'
+      target: StudioLiveViewportTarget
+      viewport: StudioLiveViewport
+    }
+  | {
+      type: 'viewport-closed'
+      target: StudioLiveViewportTarget
+    }
+
+export function liveViewportTargetKey(
+  target: StudioLiveViewportTarget,
+): string {
+  return JSON.stringify([
+    target.scenarioId,
+    target.examplesRowId ?? null,
+    target.profileId,
+    target.attempt ?? null,
+  ])
+}

--- a/packages/studio/src/runs/result/live-result-inspection.test.ts
+++ b/packages/studio/src/runs/result/live-result-inspection.test.ts
@@ -10,6 +10,7 @@ import {
   disconnectLiveInspection,
   hydrateLiveInspection,
   liveInspectionFromSnapshot,
+  liveViewportFor,
   pauseLiveFollowing,
   pinLiveInvestigation,
   receiveLiveStreamEvent,
@@ -251,6 +252,40 @@ test('restores a running inspection from an active snapshot and schedule', () =>
       state: 'running',
     },
   ])
+})
+
+test('keeps the latest viewport by Scenario and profile, independent of attempt', () => {
+  let inspection = startLiveInspection({
+    specificationUri,
+    runId: 'run-viewport',
+  })
+  const target = { scenarioId: scenario.id, profileId: 'chrome' }
+  inspection = receiveLiveStreamEvent(inspection, {
+    type: 'viewport-updated',
+    target,
+    viewport: { kind: 'frame', data: 'first', mimeType: 'image/jpeg' },
+  })
+  inspection = receiveLiveStreamEvent(inspection, {
+    type: 'viewport-updated',
+    target,
+    viewport: { kind: 'frame', data: 'latest', mimeType: 'image/jpeg' },
+  })
+
+  expect(
+    liveViewportFor(inspection, {
+      specificationUri,
+      runId: 'run-viewport',
+      scenarioId: scenario.id,
+      profileId: 'chrome',
+      attempt: 3,
+    }),
+  ).toEqual({ kind: 'frame', data: 'latest', mimeType: 'image/jpeg' })
+
+  inspection = receiveLiveStreamEvent(inspection, {
+    type: 'viewport-closed',
+    target,
+  })
+  expect(inspection.liveViewports.size).toBe(0)
 })
 
 test('shows managed application output while a step is still running', () => {

--- a/packages/studio/src/runs/result/live-result-inspection.ts
+++ b/packages/studio/src/runs/result/live-result-inspection.ts
@@ -3,6 +3,11 @@ import type {
   RunEvent,
   ScheduledTestResult,
 } from '@pickle-spec/runner'
+import {
+  liveViewportTargetKey,
+  type StudioLiveViewport,
+  type StudioLiveViewportEvent,
+} from '../../live-viewport'
 import type {
   StudioLiveDiagnosticEvent,
   StudioRunSnapshot,
@@ -27,6 +32,7 @@ export {
 
 export type LiveStreamEvent =
   | RunEvent
+  | StudioLiveViewportEvent
   | StudioLiveDiagnosticEvent
   | { type: 'run-scheduled'; schedule: readonly ScheduledTestResult[] }
   | { type: 'run-finished'; run: { id: string } }
@@ -51,6 +57,7 @@ export type LiveResultInspection = {
     scope?: StudioLiveDiagnosticEvent['scope']
     diagnostic: DiagnosticEntry
   }>
+  liveViewports: ReadonlyMap<string, StudioLiveViewport>
   snapshot?: StudioRunSnapshot
   connection: LiveConnectionStatus
   following: boolean
@@ -79,6 +86,7 @@ export function startLiveInspection(
     events: [],
     schedule: [],
     liveDiagnostics: [],
+    liveViewports: new Map(),
     connection: { kind: 'connected' },
     following: true,
     pinned: false,
@@ -186,6 +194,7 @@ export function hydrateLiveInspection(
       ...inspection,
       events: snapshot.events,
       liveDiagnostics: [],
+      liveViewports: new Map(),
       phase: 'finished',
       connection: { kind: 'connected' },
     },
@@ -198,7 +207,11 @@ export function receiveLiveStreamEvent(
   event: LiveStreamEvent,
 ): LiveResultInspection {
   if (event.type === 'run-finished') {
-    return withProjectedSnapshot({ ...inspection, phase: 'finished' })
+    return withProjectedSnapshot({
+      ...inspection,
+      phase: 'finished',
+      liveViewports: new Map(),
+    })
   }
   if (event.type === 'run-scheduled') {
     return withProjectedSnapshot({ ...inspection, schedule: event.schedule })
@@ -216,12 +229,35 @@ export function receiveLiveStreamEvent(
       ],
     })
   }
+  if (event.type === 'viewport-updated') {
+    const liveViewports = new Map(inspection.liveViewports)
+    liveViewports.set(liveViewportTargetKey(event.target), event.viewport)
+    return { ...inspection, liveViewports }
+  }
+  if (event.type === 'viewport-closed') {
+    const liveViewports = new Map(inspection.liveViewports)
+    liveViewports.delete(liveViewportTargetKey(event.target))
+    return { ...inspection, liveViewports }
+  }
   const events = insertRunEvent(inspection.events, event)
   return withProjectedSnapshot({
     ...inspection,
     events,
     connection: connectionFrom(events),
   })
+}
+
+export function liveViewportFor(
+  inspection: LiveResultInspection,
+  location: ResultInspectionLocation,
+): StudioLiveViewport | undefined {
+  return inspection.liveViewports.get(
+    liveViewportTargetKey({
+      scenarioId: location.scenarioId,
+      examplesRowId: location.examplesRowId,
+      profileId: location.profileId,
+    }),
+  )
 }
 
 function insertRunEvent(

--- a/packages/studio/src/runs/result/result-inspection.ts
+++ b/packages/studio/src/runs/result/result-inspection.ts
@@ -3,6 +3,7 @@ export const resultInspectorTabs = [
   'timeline',
   'artifacts',
   'diagnostics',
+  'viewport',
 ] as const
 
 export type ResultInspectorTab = (typeof resultInspectorTabs)[number]

--- a/packages/studio/src/runs/result/result-inspector.test.tsx
+++ b/packages/studio/src/runs/result/result-inspector.test.tsx
@@ -1,0 +1,36 @@
+import { expect, test } from 'bun:test'
+import { renderToStaticMarkup } from 'react-dom/server'
+import { ResultViewportPanel } from './result-inspector'
+
+test('renders local screencast frames in the viewport panel', () => {
+  const markup = renderToStaticMarkup(
+    <ResultViewportPanel
+      scenarioName="Pay for the order"
+      liveViewport={{
+        kind: 'frame',
+        data: 'jpeg-frame',
+        mimeType: 'image/jpeg',
+      }}
+    />,
+  )
+
+  expect(markup).toContain('data:image/jpeg;base64,jpeg-frame')
+  expect(markup).toContain('Live browser viewport for Pay for the order')
+})
+
+test('renders Browserbase live sessions with constrained iframe permissions', () => {
+  const markup = renderToStaticMarkup(
+    <ResultViewportPanel
+      scenarioName="Pay for the order"
+      liveViewport={{
+        kind: 'browserbase',
+        sessionId: 'session-1',
+        url: 'https://www.browserbase.com/sessions/session-1',
+      }}
+    />,
+  )
+
+  expect(markup).toContain('https://www.browserbase.com/sessions/session-1')
+  expect(markup).toContain('sandbox="allow-same-origin allow-scripts"')
+  expect(markup).toContain('allow="clipboard-read; clipboard-write"')
+})

--- a/packages/studio/src/runs/result/result-inspector.tsx
+++ b/packages/studio/src/runs/result/result-inspector.tsx
@@ -4,6 +4,13 @@ import type { StudioApi } from '../../app/studio-api'
 import { LedgerLoadingSkeleton } from '../../components/loading-skeletons'
 import { Badge } from '../../components/ui/badge'
 import { Button } from '../../components/ui/button'
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from '../../components/ui/card'
 import { ResultMark } from '../../components/ui/result-mark'
 import {
   Tabs,
@@ -11,6 +18,7 @@ import {
   TabsList,
   TabsTrigger,
 } from '../../components/ui/tabs'
+import type { StudioLiveViewport } from '../../live-viewport'
 import type { StudioRunSnapshot } from '../../server/server'
 import {
   displayedAttemptState,
@@ -46,6 +54,7 @@ type ResultInspectorProps = {
   onOpenArtifact?: (artifactIndex: number) => void
   onTabChange: (tab: ResultInspectorTab) => void
   snapshot?: StudioRunSnapshot
+  liveViewport?: StudioLiveViewport
   connection?: LiveConnectionStatus
   following?: boolean
   followedEntryId?: string
@@ -203,6 +212,7 @@ function ResultInspectorTabs(
         <TabsTrigger value="timeline">Timeline</TabsTrigger>
         <TabsTrigger value="artifacts">Artifacts</TabsTrigger>
         <TabsTrigger value="diagnostics">Diagnostics</TabsTrigger>
+        <TabsTrigger value="viewport">Viewport</TabsTrigger>
       </TabsList>
       <TabsContent value="overview">
         <ResultOverview {...inspected} inProgress={props.inProgress} />
@@ -237,6 +247,12 @@ function ResultInspectorTabs(
           applicationOutputAvailability={
             inspected.attempt.applicationOutputAvailability
           }
+        />
+      </TabsContent>
+      <TabsContent value="viewport">
+        <ResultViewportPanel
+          liveViewport={props.liveViewport}
+          scenarioName={inspected.result.scenario.name}
         />
       </TabsContent>
     </Tabs>
@@ -367,4 +383,65 @@ function ConnectionStatus(props: { connection?: LiveConnectionStatus }) {
     )
   }
   return null
+}
+
+export function ResultViewportPanel(props: {
+  liveViewport?: StudioLiveViewport
+  scenarioName: string
+}) {
+  if (!props.liveViewport) {
+    return (
+      <Card>
+        <CardHeader>
+          <CardTitle>Live viewport</CardTitle>
+          <CardDescription>
+            No live browser viewport is currently available for this Scenario
+            attempt.
+          </CardDescription>
+        </CardHeader>
+      </Card>
+    )
+  }
+  if (props.liveViewport.kind === 'browserbase') {
+    return (
+      <Card>
+        <CardHeader>
+          <CardTitle>Live viewport</CardTitle>
+          <CardDescription>
+            Streaming the remote Browserbase session for {props.scenarioName}.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-3">
+          <div className="overflow-hidden rounded-xl border border-border bg-muted">
+            <iframe
+              title={`Browserbase live session for ${props.scenarioName}`}
+              src={props.liveViewport.url}
+              sandbox="allow-same-origin allow-scripts"
+              allow="clipboard-read; clipboard-write"
+              className="h-[640px] w-full bg-background"
+            />
+          </div>
+        </CardContent>
+      </Card>
+    )
+  }
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Live viewport</CardTitle>
+        <CardDescription>
+          Latest browser frame streamed for {props.scenarioName}.
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        <div className="overflow-hidden rounded-xl border border-border bg-muted">
+          <img
+            alt={`Live browser viewport for ${props.scenarioName}`}
+            src={`data:${props.liveViewport.mimeType};base64,${props.liveViewport.data}`}
+            className="w-full"
+          />
+        </div>
+      </CardContent>
+    </Card>
+  )
 }

--- a/packages/studio/src/runs/runs.tsx
+++ b/packages/studio/src/runs/runs.tsx
@@ -46,7 +46,10 @@ import type {
   StudioRunRequest,
   StudioRunsIndex,
 } from '../server/server'
-import type { LiveResultInspection } from './result/live-result-inspection'
+import {
+  type LiveResultInspection,
+  liveViewportFor,
+} from './result/live-result-inspection'
 import { ResultInspector } from './result/result-inspector'
 import { reasonMessage, resultBadgeVariant } from './result/result-presentation'
 import { RunComparison } from './run-comparison'
@@ -127,6 +130,7 @@ function RunInspectionRoute(
       location={location}
       snapshot={live?.snapshot}
       connection={live?.connection}
+      liveViewport={live ? liveViewportFor(live, location) : undefined}
       onBack={() => props.onNavigate({ kind: 'run', runId: location.runId })}
       onBackToResult={() => props.onNavigate({ kind: 'result', location })}
       onOpenArtifact={(artifactIndex) =>

--- a/packages/studio/src/server/server-runs.test.ts
+++ b/packages/studio/src/server/server-runs.test.ts
@@ -38,6 +38,25 @@ test('serves the Runs index, active lifecycle, compatibility alias, and deep lin
         type: 'run-started',
         run: { id: 'run-live', startedAt: '2026-08-24T12:00:00.000Z' },
       })
+      const target = { scenarioId: 'scenario', profileId: 'chrome', attempt: 1 }
+      onEvent({
+        type: 'viewport-updated',
+        target,
+        viewport: {
+          kind: 'frame',
+          data: 'first-frame',
+          mimeType: 'image/jpeg',
+        },
+      })
+      onEvent({
+        type: 'viewport-updated',
+        target,
+        viewport: {
+          kind: 'frame',
+          data: 'latest-frame',
+          mimeType: 'image/jpeg',
+        },
+      })
       return { id: 'run-live', done: completion.promise }
     },
     async snapshot(id) {
@@ -135,6 +154,28 @@ test('serves the Runs index, active lifecycle, compatibility alias, and deep lin
   })
   expect(replayedSchedule).toEqual(schedule)
 
+  const replayedViewports = await new Promise<string[]>((resolve, reject) => {
+    const frames: string[] = []
+    const socket = new WebSocket(
+      `${origin.replace(/^http/, 'ws')}/api/runs/run-live/events?token=runs-token`,
+    )
+    const timeout = setTimeout(() => {
+      socket.close()
+      reject(new Error('Timed out waiting for viewport replay'))
+    }, 2_000)
+    socket.addEventListener('message', (event) => {
+      const value = JSON.parse(String(event.data))
+      if (value.type !== 'viewport-updated') return
+      frames.push(value.viewport.data)
+      setTimeout(() => {
+        clearTimeout(timeout)
+        socket.close()
+        resolve(frames)
+      }, 50)
+    })
+  })
+  expect(replayedViewports).toEqual(['latest-frame'])
+
   const pagePaths = [
     '/',
     '/specifications/checkout',
@@ -142,6 +183,7 @@ test('serves the Runs index, active lifecycle, compatibility alias, and deep lin
     '/runs',
     '/runs/run-live',
     '/runs/run-live/results/features%2Fcheckout.feature/scenarios/scenario/profiles/chrome/attempts/1?tab=timeline',
+    '/runs/run-live/results/features%2Fcheckout.feature/scenarios/scenario/profiles/chrome/attempts/1?tab=viewport',
     '/runs/run-live/results/features%2Fcheckout.feature/scenarios/scenario/examples/row-1/profiles/chrome/attempts/1',
     '/runs/run-live/results/features%2Fcheckout.feature/scenarios/scenario/profiles/chrome/attempts/1/artifacts/0',
   ]
@@ -178,6 +220,9 @@ test('serves the Runs index, active lifecycle, compatibility alias, and deep lin
   expect(indexAsset.status).toBe(200)
   expect(indexAsset.headers.get('content-type')).toContain('text/html')
   expect(indexAsset.headers.get('set-cookie')).toContain('pickle_studio_token')
+  expect(indexAsset.headers.get('content-security-policy')).toContain(
+    "frame-src 'self' https://browserbase.com https://*.browserbase.com",
+  )
   const unauthorizedDeepLink = await fetch(
     `${origin}/specifications/checkout/scenarios/scenario`,
   )

--- a/packages/studio/src/server/server.ts
+++ b/packages/studio/src/server/server.ts
@@ -25,6 +25,10 @@ import {
   DocumentConflictError,
   type SpecificationWorkspace,
 } from '../authoring/documents'
+import {
+  liveViewportTargetKey,
+  type StudioLiveViewportEvent,
+} from '../live-viewport'
 import { requiredValue } from '../required-value'
 import { createGitWorkspace, type GitWorkspace } from './git'
 import { resolveStudioArtifactPath } from './studio-artifact-path'
@@ -195,6 +199,7 @@ export type StudioLiveDiagnosticEvent = {
 
 export type StudioRunStreamEvent =
   | RunEvent
+  | StudioLiveViewportEvent
   | StudioLiveDiagnosticEvent
   | { type: 'run-scheduled'; schedule: readonly ScheduledTestResult[] }
   | { type: 'run-finished'; run: { id: string } }
@@ -303,6 +308,24 @@ type HtmlAsset = {
 
 type StudioStreamEvent = StudioRunStreamEvent
 
+type RetainedViewportEvent = Extract<
+  StudioLiveViewportEvent,
+  { type: 'viewport-updated' }
+>
+
+function isViewportEvent(
+  event: StudioStreamEvent,
+): event is StudioLiveViewportEvent {
+  return event.type === 'viewport-updated' || event.type === 'viewport-closed'
+}
+
+function appendBufferedEvent(
+  retained: readonly StudioStreamEvent[] | undefined,
+  event: StudioStreamEvent,
+): StudioStreamEvent[] {
+  return [...(retained ?? []), event]
+}
+
 type WorkspaceStreamEvent = DiskChangeEvent & { type: 'disk-changed' }
 
 type StudioSocketData =
@@ -377,6 +400,7 @@ function secureResponse(response: Response, origin: string): Response {
       `connect-src 'self' ${websocketOrigin}`,
       "font-src 'self' data:",
       "form-action 'self'",
+      "frame-src 'self' https://browserbase.com https://*.browserbase.com",
       "frame-ancestors 'none'",
       "img-src 'self' data: blob:",
       "media-src 'self'",
@@ -483,14 +507,28 @@ export async function startStudio(
   const git = options.git ?? createGitWorkspace(options.project.root)
   const listeners = new Map<string, Set<(event: StudioStreamEvent) => void>>()
   const buffers = new Map<string, StudioStreamEvent[]>()
+  const liveViewports = new Map<string, Map<string, RetainedViewportEvent>>()
   const workspaceListeners = new Set<(event: WorkspaceStreamEvent) => void>()
   const activeRuns = new Set<string>()
 
+  function updateLiveViewport(
+    id: string,
+    event: StudioLiveViewportEvent,
+  ): void {
+    const retained = new Map(liveViewports.get(id) ?? [])
+    const key = liveViewportTargetKey(event.target)
+    if (event.type === 'viewport-updated') retained.set(key, event)
+    else retained.delete(key)
+    liveViewports.set(id, retained)
+  }
+
   function publish(id: string, event: StudioStreamEvent): void {
     if (!id) return
-    const events = buffers.get(id) ?? []
-    events.push(event)
-    buffers.set(id, events)
+    if (isViewportEvent(event)) {
+      updateLiveViewport(id, event)
+    } else {
+      buffers.set(id, appendBufferedEvent(buffers.get(id), event))
+    }
     for (const listener of listeners.get(id) ?? []) listener(event)
   }
 
@@ -544,6 +582,9 @@ export async function startStudio(
         }
         const runId = socket.data.runId
         for (const event of buffers.get(runId) ?? []) {
+          ws.send(JSON.stringify(event))
+        }
+        for (const event of liveViewports.get(runId)?.values() ?? []) {
           ws.send(JSON.stringify(event))
         }
         const listener = (event: StudioStreamEvent) => {
@@ -939,6 +980,7 @@ export async function startStudio(
               type: 'run-finished',
               run: { id: state.runId },
             })
+            liveViewports.delete(state.runId)
           }
           void started.done
             .then(finishRun, finishRun)

--- a/packages/studio/src/specifications/specification-results.tsx
+++ b/packages/studio/src/specifications/specification-results.tsx
@@ -1,5 +1,8 @@
 import type { StudioApi } from '../app/studio-api'
-import type { LiveResultInspection } from '../runs/result/live-result-inspection'
+import {
+  type LiveResultInspection,
+  liveViewportFor,
+} from '../runs/result/live-result-inspection'
 import type { ResultInspectorTab } from '../runs/result/result-inspection'
 import { ResultInspector } from '../runs/result/result-inspector'
 import type { MatrixCell } from '../runs/result/run-view'
@@ -67,6 +70,7 @@ export function SpecificationResults(props: SpecificationResultsProps) {
           location={props.live.location}
           snapshot={props.live.snapshot}
           connection={props.live.connection}
+          liveViewport={liveViewportFor(props.live, props.live.location)}
           following={props.live.following}
           followedEntryId={props.live.followedEntryId}
           onResumeFollowing={props.onResumeFollowing}

--- a/packages/web/index.ts
+++ b/packages/web/index.ts
@@ -16,6 +16,8 @@ export type {
   WebBrowserProcess,
   WebDirectExecutionResult,
   WebIsolationState,
+  WebLiveViewportTarget,
+  WebLiveViewportUpdate,
   WebObservedAction,
 } from './src/adapter/web-adapter'
 export {

--- a/packages/web/src/adapter/live-viewport.test.ts
+++ b/packages/web/src/adapter/live-viewport.test.ts
@@ -1,0 +1,81 @@
+import { expect, test } from 'bun:test'
+import type { Page, StagehandBrowser } from '@browserbasehq/stagehand'
+import { startCdpScreencast } from './live-viewport'
+
+test('streams CDP frames, acknowledges them, and stops the target session', async () => {
+  const methods: string[] = []
+  const frame = Promise.withResolvers<string>()
+  const acknowledged = Promise.withResolvers<void>()
+  const stopped = Promise.withResolvers<void>()
+  const server = Bun.serve({
+    port: 0,
+    fetch(request, webServer) {
+      return webServer.upgrade(request)
+        ? undefined
+        : new Response('Upgrade failed', { status: 400 })
+    },
+    websocket: {
+      message(socket, data) {
+        const command = JSON.parse(String(data)) as {
+          id: number
+          method: string
+          sessionId?: string
+        }
+        methods.push(command.method)
+        if (command.method === 'Target.attachToTarget') {
+          socket.send(
+            JSON.stringify({ id: command.id, result: { sessionId: 'cdp-1' } }),
+          )
+        }
+        if (command.method === 'Page.startScreencast') {
+          socket.send(
+            JSON.stringify({
+              id: command.id,
+              sessionId: command.sessionId,
+              result: {},
+            }),
+          )
+          socket.send(
+            JSON.stringify({
+              method: 'Page.screencastFrame',
+              sessionId: 'cdp-1',
+              params: { data: 'jpeg-frame', sessionId: 7 },
+            }),
+          )
+        }
+        if (command.method === 'Page.screencastFrameAck') {
+          acknowledged.resolve()
+        }
+        if (command.method === 'Target.detachFromTarget') stopped.resolve()
+      },
+    },
+  })
+  const browser = {
+    context: {
+      rpcClient: {
+        browserWebSocketDebuggerUrl: `ws://127.0.0.1:${server.port}`,
+      },
+    },
+  } as unknown as StagehandBrowser
+  const page = { pageId: 'page-1' } as Page
+
+  try {
+    const controller = await startCdpScreencast({
+      browser,
+      page,
+      onViewport(viewport) {
+        if (viewport.kind === 'frame') frame.resolve(viewport.data)
+      },
+    })
+    expect(await frame.promise).toBe('jpeg-frame')
+    await acknowledged.promise
+    expect(methods).toContain('Page.screencastFrameAck')
+
+    await controller.close()
+    await stopped.promise
+    expect(methods).toContain('Page.stopScreencast')
+    expect(methods).toContain('Target.detachFromTarget')
+  } finally {
+    server.stop(true)
+  }
+})

--- a/packages/web/src/adapter/live-viewport.ts
+++ b/packages/web/src/adapter/live-viewport.ts
@@ -1,0 +1,312 @@
+import type { Page, StagehandBrowser } from '@browserbasehq/stagehand'
+import { z } from 'zod'
+import { requiredValue } from '../required-value'
+import type { BrowserOptions } from './web-options'
+
+export type WebLiveViewportTarget = {
+  scenarioId: string
+  examplesRowId?: string
+  profileId: string
+  attempt?: number
+}
+
+export type WebLiveViewport =
+  | {
+      kind: 'frame'
+      data: string
+      mimeType: 'image/jpeg'
+      width?: number
+      height?: number
+    }
+  | { kind: 'browserbase'; sessionId: string; url: string }
+  | { kind: 'closed' }
+
+export type WebLiveViewportUpdate = WebLiveViewport & {
+  target: WebLiveViewportTarget
+}
+
+export type WebLiveViewportController = {
+  close(): Promise<void>
+}
+
+type CdpResponse = {
+  id?: number
+  result?: unknown
+  error?: { message?: string }
+  method?: string
+  sessionId?: string
+  params?: unknown
+}
+
+const attachedTargetSchema = z.object({ sessionId: z.string() })
+const screencastFrameSchema = z.object({
+  data: z.string(),
+  sessionId: z.number(),
+  metadata: z
+    .object({
+      deviceWidth: z.number().optional(),
+      deviceHeight: z.number().optional(),
+    })
+    .optional(),
+})
+const browserbaseDebugSchema = z.object({
+  debuggerFullscreenUrl: z.string().url(),
+})
+
+function browserbaseApiKey(options: BrowserOptions): string {
+  return (
+    options.browserbaseApiKey ?? requiredValue(process.env.BROWSERBASE_API_KEY)
+  )
+}
+
+type BrowserContextWithDebuggerUrl = {
+  rpcClient: {
+    browserWebSocketDebuggerUrl?: string
+  }
+}
+
+function browserDebuggerUrl(browser: StagehandBrowser): string {
+  const debuggerUrl = (browser.context as BrowserContextWithDebuggerUrl)
+    .rpcClient.browserWebSocketDebuggerUrl
+  if (!debuggerUrl) throw new Error('Browser does not expose a CDP endpoint')
+  return debuggerUrl
+}
+
+function validateBrowserbaseLiveUrl(value: string): string {
+  const url = new URL(value)
+  const browserbaseHost =
+    url.hostname === 'browserbase.com' ||
+    url.hostname.endsWith('.browserbase.com')
+  if (url.protocol !== 'https:' || !browserbaseHost) {
+    throw new Error('Browserbase returned an invalid live session URL')
+  }
+  return url.href
+}
+
+export async function loadBrowserbaseLiveViewport(
+  sessionId: string,
+  options: BrowserOptions,
+  signal?: AbortSignal,
+): Promise<WebLiveViewport> {
+  const response = await fetch(
+    `https://api.browserbase.com/v1/sessions/${encodeURIComponent(sessionId)}/debug`,
+    {
+      headers: { 'X-BB-API-Key': browserbaseApiKey(options) },
+      signal,
+    },
+  )
+  if (!response.ok) {
+    throw new Error(
+      `Browserbase live session request failed with ${response.status}`,
+    )
+  }
+  const debug = browserbaseDebugSchema.parse(await response.json())
+  return {
+    kind: 'browserbase',
+    sessionId,
+    url: validateBrowserbaseLiveUrl(debug.debuggerFullscreenUrl),
+  }
+}
+
+class CdpConnection {
+  private nextId = 1
+  private readonly pending = new Map<
+    number,
+    { resolve: (value: unknown) => void; reject: (error: Error) => void }
+  >()
+
+  private constructor(
+    private readonly socket: WebSocket,
+    private readonly onEvent: (message: CdpResponse) => void,
+  ) {
+    socket.addEventListener('message', this.handleMessage)
+    socket.addEventListener('close', this.handleClose)
+  }
+
+  static async connect(
+    url: string,
+    onEvent: (message: CdpResponse) => void,
+  ): Promise<CdpConnection> {
+    const socket = new WebSocket(url)
+    await new Promise<void>((resolve, reject) => {
+      const timeout = setTimeout(
+        () => reject(new Error('CDP connection timed out')),
+        3_000,
+      )
+      socket.addEventListener(
+        'open',
+        () => {
+          clearTimeout(timeout)
+          resolve()
+        },
+        { once: true },
+      )
+      socket.addEventListener(
+        'error',
+        () => {
+          clearTimeout(timeout)
+          reject(new Error('Could not open the browser viewport stream'))
+        },
+        { once: true },
+      )
+    }).catch((error) => {
+      socket.close()
+      throw error
+    })
+    return new CdpConnection(socket, onEvent)
+  }
+
+  async command(
+    method: string,
+    params: Record<string, unknown> = {},
+    sessionId?: string,
+  ): Promise<unknown> {
+    const id = this.nextId++
+    const response = new Promise<unknown>((resolve, reject) => {
+      this.pending.set(id, { resolve, reject })
+    })
+    this.socket.send(JSON.stringify({ id, method, params, sessionId }))
+    return response
+  }
+
+  send(method: string, params: Record<string, unknown>, sessionId?: string) {
+    this.socket.send(
+      JSON.stringify({ id: this.nextId++, method, params, sessionId }),
+    )
+  }
+
+  close(): void {
+    this.socket.removeEventListener('message', this.handleMessage)
+    this.socket.removeEventListener('close', this.handleClose)
+    this.socket.close()
+    this.rejectPending(new Error('Browser viewport stream closed'))
+  }
+
+  private readonly handleMessage = (event: MessageEvent) => {
+    let message: CdpResponse
+    try {
+      message = JSON.parse(String(event.data)) as CdpResponse
+    } catch {
+      return
+    }
+    if (message.id !== undefined) {
+      const pending = this.pending.get(message.id)
+      if (!pending) return
+      this.pending.delete(message.id)
+      if (message.error) {
+        pending.reject(new Error(message.error.message ?? 'CDP command failed'))
+      } else {
+        pending.resolve(message.result)
+      }
+      return
+    }
+    this.onEvent(message)
+  }
+
+  private readonly handleClose = () => {
+    this.rejectPending(new Error('Browser viewport stream closed'))
+  }
+
+  private rejectPending(error: Error): void {
+    for (const pending of this.pending.values()) pending.reject(error)
+    this.pending.clear()
+  }
+}
+
+export async function startCdpScreencast(input: {
+  browser: StagehandBrowser
+  page: Page
+  onViewport: (viewport: WebLiveViewport) => void
+}): Promise<WebLiveViewportController> {
+  let attachedSessionId: string | undefined
+  const connection = await CdpConnection.connect(
+    browserDebuggerUrl(input.browser),
+    (message) => {
+      if (
+        message.method !== 'Page.screencastFrame' ||
+        message.sessionId !== attachedSessionId
+      ) {
+        return
+      }
+      const frame = screencastFrameSchema.safeParse(message.params)
+      if (!frame.success || !attachedSessionId) return
+      connection.send(
+        'Page.screencastFrameAck',
+        { sessionId: frame.data.sessionId },
+        attachedSessionId,
+      )
+      input.onViewport({
+        kind: 'frame',
+        data: frame.data.data,
+        mimeType: 'image/jpeg',
+      })
+    },
+  )
+
+  try {
+    const attached = attachedTargetSchema.parse(
+      await connection.command('Target.attachToTarget', {
+        targetId: input.page.pageId,
+        flatten: true,
+      }),
+    )
+    attachedSessionId = attached.sessionId
+    await connection.command(
+      'Page.startScreencast',
+      {
+        format: 'jpeg',
+        quality: 70,
+        maxWidth: 1280,
+        maxHeight: 720,
+        everyNthFrame: 1,
+      },
+      attachedSessionId,
+    )
+  } catch (error) {
+    connection.close()
+    throw error
+  }
+
+  let closed = false
+  return {
+    async close() {
+      if (closed) return
+      closed = true
+      if (attachedSessionId) {
+        connection.send('Page.stopScreencast', {}, attachedSessionId)
+        connection.send('Target.detachFromTarget', {
+          sessionId: attachedSessionId,
+        })
+      }
+      connection.close()
+    },
+  }
+}
+
+export async function startStagehandLiveViewport(input: {
+  browser: StagehandBrowser
+  options: BrowserOptions
+  onViewport: (viewport: WebLiveViewport) => void
+  signal?: AbortSignal
+}): Promise<WebLiveViewportController> {
+  if (input.browser.provider === 'browserbase') {
+    if (!input.browser.sessionId) {
+      throw new Error('Browserbase session did not expose a session ID')
+    }
+    input.onViewport(
+      await loadBrowserbaseLiveViewport(
+        input.browser.sessionId,
+        input.options,
+        input.signal,
+      ),
+    )
+    return { close: async () => {} }
+  }
+  const page = await input.browser.context.activePage()
+  if (!page) throw new Error('No active browser page')
+  return startCdpScreencast({
+    browser: input.browser,
+    page,
+    onViewport: input.onViewport,
+  })
+}

--- a/packages/web/src/adapter/stagehand-automation.ts
+++ b/packages/web/src/adapter/stagehand-automation.ts
@@ -17,6 +17,11 @@ import {
 } from '../execution-cache/web-execution-cache'
 import { withAbort } from './abort'
 import { createDirectBrowser } from './direct-browser'
+import {
+  startStagehandLiveViewport,
+  type WebLiveViewport,
+  type WebLiveViewportController,
+} from './live-viewport'
 import { stabilizeSelector } from './stable-selector'
 import type {
   WebAutomation,
@@ -24,6 +29,7 @@ import type {
   WebObservedAction,
   WebScreenshotCapture,
 } from './web-automation'
+import type { BrowserOptions } from './web-options'
 
 const verificationSchema = z.object({
   meetsExpectation: z
@@ -61,6 +67,8 @@ async function readStagehandIsolation(
 
 class StagehandAutomation implements WebAutomation {
   private readonly direct
+  private viewportHandle: WebLiveViewportController | undefined
+  private viewportClosed = false
   private recording: WebRecording | undefined
 
   constructor(
@@ -68,6 +76,11 @@ class StagehandAutomation implements WebAutomation {
     private readonly stagehand: Stagehand,
     private readonly timeouts: StagehandTimeouts,
     private readonly evidence: ReturnType<typeof createWebEvidenceCollector>,
+    private readonly viewport?: {
+      options: BrowserOptions
+      onViewport: (viewport: WebLiveViewport) => void
+      signal?: AbortSignal
+    },
   ) {
     this.direct = createDirectBrowser(browser.context, {
       actionTimeoutMs: timeouts.actTimeoutMs,
@@ -77,12 +90,23 @@ class StagehandAutomation implements WebAutomation {
 
   async initialize(): Promise<this> {
     await this.instrumentPages()
+    await this.initializeViewport()
     return this
   }
 
   private async instrumentPages() {
     const pages = await this.browser.context.pages()
     return instrumentWebEvidencePages(pages, this.evidence)
+  }
+
+  private async initializeViewport() {
+    if (!this.viewport) return
+    try {
+      this.viewportHandle = await startStagehandLiveViewport({
+        browser: this.browser,
+        ...this.viewport,
+      })
+    } catch {}
   }
 
   async screenshot(options: WebScreenshotCapture): Promise<Uint8Array> {
@@ -218,6 +242,13 @@ class StagehandAutomation implements WebAutomation {
     const active = this.recording
     this.recording = undefined
     if (active) await active.discard()
+    const viewport = this.viewportHandle
+    this.viewportHandle = undefined
+    if (viewport) await viewport.close()
+    if (!this.viewportClosed) {
+      this.viewportClosed = true
+      this.viewport?.onViewport({ kind: 'closed' })
+    }
   }
 }
 
@@ -226,11 +257,17 @@ export async function createStagehandAutomation(
   stagehand: Stagehand,
   timeouts: StagehandTimeouts,
   evidence: ReturnType<typeof createWebEvidenceCollector>,
+  viewport?: {
+    options: BrowserOptions
+    onViewport: (viewport: WebLiveViewport) => void
+    signal?: AbortSignal
+  },
 ): Promise<WebAutomation> {
   return new StagehandAutomation(
     browser,
     stagehand,
     timeouts,
     evidence,
+    viewport,
   ).initialize()
 }

--- a/packages/web/src/adapter/stagehand-factory.ts
+++ b/packages/web/src/adapter/stagehand-factory.ts
@@ -189,6 +189,25 @@ async function closeQuietly(close: () => Promise<void>): Promise<void> {
   } catch {}
 }
 
+function stagehandViewport(context: WebClientContext) {
+  if (!context.onLiveViewport) return
+  return {
+    options: context.browser,
+    onViewport: context.onLiveViewport,
+    signal: context.signal,
+  }
+}
+
+async function closeStagehandClient(
+  browser: StagehandBrowser,
+  stagehand: Stagehand | undefined,
+): Promise<void> {
+  await Promise.all([
+    stagehand ? closeQuietly(() => stagehand.close()) : Promise.resolve(),
+    closeQuietly(() => browser.close()),
+  ])
+}
+
 function stagehandClient(
   browser: StagehandBrowser,
   options: BrowserOptions,
@@ -237,6 +256,7 @@ function stagehandClient(
       activeStagehand,
       stagehandTimeouts(context, options),
       evidence,
+      stagehandViewport(context),
     )
   }
 
@@ -244,12 +264,7 @@ function stagehandClient(
     closed = true
     const activeStagehand = stagehand
     stagehand = undefined
-    await Promise.all([
-      activeStagehand
-        ? closeQuietly(() => activeStagehand.close())
-        : Promise.resolve(),
-      closeQuietly(() => browser.close()),
-    ])
+    await closeStagehandClient(browser, activeStagehand)
   }
 
   return { openContext, close }

--- a/packages/web/src/adapter/web-adapter.test.ts
+++ b/packages/web/src/adapter/web-adapter.test.ts
@@ -3,14 +3,20 @@ import { mkdtemp, rm } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { runScenario } from '@pickle-spec/runner'
-import type { Scenario, Specification } from '@pickle-spec/spec'
+import {
+  resolveScenarioId,
+  type Scenario,
+  type Specification,
+} from '@pickle-spec/spec'
 import {
   createWebAdapter,
   validateWebAdapterOptions,
   type WebAutomation,
   type WebAutomationFactory,
+  type WebLiveViewportUpdate,
 } from '../../index'
 import { requiredValue } from '../required-value'
+import type { WebClientContext } from './web-automation'
 
 function stubAutomation(overrides: Partial<WebAutomation> = {}): WebAutomation {
   return {
@@ -954,6 +960,58 @@ describe('createWebAdapter', () => {
     await adapter.dispose?.()
 
     expect(launch).toHaveBeenCalledTimes(1)
+  })
+
+  test('forwards live viewport updates with canonical Scenario target identity', async () => {
+    const updates: WebLiveViewportUpdate[] = []
+    const launch: WebAutomationFactory['launch'] = mock(async () => ({
+      async openContext(context: WebClientContext) {
+        context.onLiveViewport?.({
+          kind: 'frame',
+          data: 'latest-frame',
+          mimeType: 'image/jpeg',
+        })
+        return stubAutomation({
+          async close() {
+            context.onLiveViewport?.({ kind: 'closed' })
+          },
+        })
+      },
+      async close() {},
+    }))
+    const adapter = createWebAdapter(
+      { baseUrl: 'https://example.test' },
+      { launch },
+      { onLiveViewport: (update) => updates.push(update) },
+    )
+
+    const session = await adapter.openSession({
+      executionTargetProfile: { id: 'attached-chrome' },
+      specification,
+      scenario: { ...scenario, examplesRowId: 'row-card' },
+    })
+    await session.close()
+    await adapter.dispose?.()
+
+    const target = {
+      scenarioId: resolveScenarioId(
+        specification.source.uri,
+        specification.name,
+        scenario.name,
+        scenario.tags,
+      ),
+      examplesRowId: 'row-card',
+      profileId: 'attached-chrome',
+    }
+    expect(updates).toEqual([
+      {
+        kind: 'frame',
+        data: 'latest-frame',
+        mimeType: 'image/jpeg',
+        target,
+      },
+      { kind: 'closed', target },
+    ])
   })
 
   test('surfaces isolation verification failure when opening a logical session', async () => {

--- a/packages/web/src/adapter/web-adapter.ts
+++ b/packages/web/src/adapter/web-adapter.ts
@@ -3,6 +3,7 @@ import type {
   StepExecutionTargetAdapter,
   StepTargetSession,
 } from '@pickle-spec/runner'
+import { resolveScenarioId } from '@pickle-spec/spec'
 import { createWebStepFinalizer } from '../evidence/web-step-finalizer'
 import { createWebCacheSession } from '../execution-cache/web-cache-session'
 import {
@@ -13,6 +14,11 @@ import {
 import { requiredValue } from '../required-value'
 import { abortError, isAbortError, withAbort } from './abort'
 import { type ResolvedFidelity, resolveFidelityPolicy } from './fidelity'
+import type {
+  WebLiveViewport,
+  WebLiveViewportTarget,
+  WebLiveViewportUpdate,
+} from './live-viewport'
 import { stagehandFactory } from './stagehand-factory'
 import type { WebAutomation, WebAutomationFactory } from './web-automation'
 import { createWebLiveSession } from './web-live-session'
@@ -23,6 +29,11 @@ import {
   type WebAdapterOptions,
 } from './web-options'
 import { WebProcessPool } from './web-pool'
+
+export type {
+  WebLiveViewportTarget,
+  WebLiveViewportUpdate,
+} from './live-viewport'
 
 export type {
   WebActResult,
@@ -167,6 +178,7 @@ async function closeWebSession(input: CloseWebSessionInput): Promise<void> {
 
 export interface WebAdapterBehavior {
   navigationPolicy?: 'delayed' | 'eager'
+  onLiveViewport?: (update: WebLiveViewportUpdate) => void
 }
 
 type LogicalWebSession = Awaited<
@@ -179,6 +191,30 @@ interface OpenWebSessionContext {
   requireProviderApiKey: boolean
   fidelity: ResolvedFidelity
   pool: WebProcessPool
+}
+
+function liveViewportTarget(input: OpenSessionInput): WebLiveViewportTarget {
+  return {
+    scenarioId:
+      input.scenario.id ??
+      resolveScenarioId(
+        input.specification.source.uri,
+        input.specification.name,
+        input.scenario.template?.name ?? input.scenario.name,
+        input.scenario.tags,
+      ),
+    examplesRowId: input.scenario.examplesRowId,
+    profileId: input.executionTargetProfile.id,
+  }
+}
+
+function liveViewportSink(
+  behavior: WebAdapterBehavior,
+  input: OpenSessionInput,
+): ((viewport: WebLiveViewport) => void) | undefined {
+  if (!behavior.onLiveViewport) return
+  const target = liveViewportTarget(input)
+  return (viewport) => behavior.onLiveViewport?.({ ...viewport, target })
 }
 
 function webSessionCloser(
@@ -291,6 +327,7 @@ async function openWebSession(
     input.signal,
     context.fidelity,
     executionMode,
+    liveViewportSink(context.behavior, input),
   )
   const automation = logicalSession.automation
   const { close, markInterrupted } = webSessionCloser(

--- a/packages/web/src/adapter/web-automation.ts
+++ b/packages/web/src/adapter/web-automation.ts
@@ -6,6 +6,7 @@ import type {
   WebInstruction,
 } from '../execution-cache/web-execution-cache'
 import type { ResolvedFidelity } from './fidelity'
+import type { WebLiveViewport } from './live-viewport'
 import type { BrowserOptions } from './web-options'
 
 export interface WebObservedAction {
@@ -38,6 +39,7 @@ export interface WebClientContext {
   mode?: 'adaptive' | 'replay'
   fidelity?: ResolvedFidelity
   signal?: AbortSignal
+  onLiveViewport?: (viewport: WebLiveViewport) => void
 }
 
 export interface WebDirectExecutionResult {

--- a/packages/web/src/adapter/web-pool.ts
+++ b/packages/web/src/adapter/web-pool.ts
@@ -4,6 +4,7 @@ import type {
   WebAutomation,
   WebAutomationFactory,
   WebBrowserProcess,
+  WebClientContext,
   WebIsolationState,
 } from './web-automation'
 import type { BrowserOptions } from './web-options'
@@ -67,6 +68,7 @@ export class WebProcessPool {
     signal?: AbortSignal,
     fidelity?: ResolvedFidelity,
     mode?: 'adaptive' | 'replay',
+    onLiveViewport?: WebClientContext['onLiveViewport'],
   ): Promise<WebLogicalSession> {
     if (this.disposed) {
       throw new Error('Web process pool is disposed')
@@ -85,6 +87,7 @@ export class WebProcessPool {
             mode,
             fidelity,
             signal,
+            onLiveViewport,
           }),
         signal,
         (lateAutomation) => lateAutomation.close(),


### PR DESCRIPTION
## Summary

- Stream live browser viewport frames and Browserbase sessions from web runs.
- Retain and replay the latest viewport per scenario and profile.
- Add a Viewport tab to Studio result inspection with secure iframe support.
- Cover CDP streaming, event replay, state handling, and viewport rendering with tests.

## Testing

- `bun run lint`
- `bun run typecheck`
- `bun run test`