### PR TITLE
feat: add shared evidence observations to run events

### DIFF
--- a/packages/cli/src/studio/studio.test.ts
+++ b/packages/cli/src/studio/studio.test.ts
@@ -8,7 +8,7 @@ import {
   resolveLocalProjectStorage,
   serializeExecutionCacheEnvelope,
 } from '@pickle-spec/runner'
-import type { Browser, Page } from 'playwright'
+import type { Browser, Locator, Page } from 'playwright'
 import { StudioBrowserFixture } from '../../test/studio-browser-fixture'
 import { registerStudioHardeningTests } from '../../test/studio-hardening-suite'
 import { requiredValue } from '../required-value'
@@ -92,6 +92,15 @@ async function expectRunningStatusCleared(page: Page) {
   const running = page.getByRole('status').filter({ hasText: 'running' })
   await running.waitFor({ state: 'hidden', timeout: 20_000 })
   expect(await running.count()).toBe(0)
+}
+
+async function openAttemptFromRunRow(row: Locator) {
+  await row.getByRole('button', { name: /^Open attempt for / }).click()
+}
+
+async function openRunDetailsFromRow(page: Page, row: Locator) {
+  await openAttemptFromRunRow(row)
+  await page.getByRole('button', { name: 'Back to run' }).click()
 }
 
 async function saveExecutionTargetProfile(
@@ -553,12 +562,13 @@ export default {
       expect(await cache.read(before.key)).toContain('v2')
 
       await page.getByRole('button', { name: 'Runs', exact: true }).click()
-      await page
-        .getByRole('table', { name: 'Test run history' })
-        .getByRole('row')
-        .nth(1)
-        .getByRole('button', { name: 'Review run' })
-        .click()
+      await openRunDetailsFromRow(
+        page,
+        page
+          .getByRole('table', { name: 'Test run history' })
+          .getByRole('row')
+          .nth(1),
+      )
       await page.getByRole('table', { name: 'Test run results' }).waitFor()
       expect(await page.getByText('adaptive').count()).toBeGreaterThan(0)
       expect(await page.getByText('refresh').count()).toBeGreaterThan(0)
@@ -1382,11 +1392,21 @@ Feature: Search
       expect(await comparison.textContent()).toContain('Pay for the order')
       expect(await comparison.textContent()).toContain('chrome')
 
-      await history
-        .getByRole('row')
-        .nth(2)
-        .getByRole('button', { name: 'Review run' })
-        .click()
+      expect(
+        await history.getByRole('button', { name: 'Review run' }).count(),
+      ).toBe(0)
+      await openAttemptFromRunRow(history.getByRole('row').nth(2))
+      await page
+        .getByRole('heading', {
+          name: 'Pay for the order · chrome',
+        })
+        .waitFor()
+      expect(
+        await page
+          .getByRole('tab', { name: 'Timeline' })
+          .getAttribute('aria-selected'),
+      ).toBe('true')
+      await page.getByRole('button', { name: 'Back to run' }).click()
       const results = page.getByRole('table', { name: 'Test run results' })
       await page.getByText('app-42').waitFor()
       expect(await results.textContent()).toContain('Pay for the order')
@@ -1484,12 +1504,10 @@ Feature: Search
       expect(await history.getByRole('row').nth(1).textContent()).toContain(
         '2 results',
       )
-      await history
-        .getByRole('row')
-        .filter({ hasText: '6 results' })
-        .first()
-        .getByRole('button', { name: 'Review run' })
-        .click()
+      await openRunDetailsFromRow(
+        page,
+        history.getByRole('row').filter({ hasText: '6 results' }).first(),
+      )
       const targetResults = page.getByRole('table', {
         name: 'Test run results',
       })
@@ -1504,12 +1522,10 @@ Feature: Search
       )
 
       expect(await page.getByText('14 days · 1 B').count()).toBe(1)
-      await history
-        .getByRole('row')
-        .filter({ hasText: '6 results' })
-        .first()
-        .getByRole('button', { name: 'Review run' })
-        .click()
+      await openRunDetailsFromRow(
+        page,
+        history.getByRole('row').filter({ hasText: '6 results' }).first(),
+      )
       const exportButton = page.locator('[data-slot="dropdown-menu-trigger"]')
       await exportButton.click()
       await Bun.sleep(100)
@@ -1655,11 +1671,7 @@ Feature: Checkout
       await waitForScenarioResult(page, 'Complete a purchase chrome passed')
       await page.getByRole('button', { name: 'Runs', exact: true }).click()
       const history = page.getByRole('table', { name: 'Test run history' })
-      await history
-        .getByRole('row')
-        .nth(1)
-        .getByRole('button', { name: 'Review run' })
-        .click()
+      await openRunDetailsFromRow(page, history.getByRole('row').nth(1))
       const results = page.getByRole('table', { name: 'Test run results' })
       await results.waitFor()
       expect(await results.getByRole('row').count()).toBe(5)

--- a/packages/cli/test/studio-hardening-suite.ts
+++ b/packages/cli/test/studio-hardening-suite.ts
@@ -423,7 +423,9 @@ Feature: Fixture ${suffix}
       )
 
       const searchRuns = page.getByRole('searchbox', { name: 'Search Runs' })
-      await searchRuns.fill('run-large-results')
+      await searchRuns.pressSequentially('run-large-results')
+      expect(await searchRuns.inputValue()).toBe('run-large-results')
+      expect(await page.locator(':focus').getAttribute('id')).toBe('run-search')
       expect(new URL(page.url()).searchParams.get('q')).toBe(
         'run-large-results',
       )
@@ -450,8 +452,14 @@ Feature: Fixture ${suffix}
       await page.keyboard.press('Home')
       await largeRun.waitFor()
 
-      const reviewRun = largeRun.getByRole('button', { name: 'Review run' })
-      await tabTo(page, reviewRun)
+      const openAttempt = largeRun.getByRole('button', {
+        name: /^Open attempt for /,
+      })
+      await tabTo(page, openAttempt)
+      await page.keyboard.press('Enter')
+      const backToRun = page.getByRole('button', { name: 'Back to run' })
+      await backToRun.waitFor()
+      await tabTo(page, backToRun)
       await page.keyboard.press('Enter')
       const results = page.getByRole('table', { name: 'Test run results' })
       await results.getByText('Scenario 000').waitFor()

--- a/packages/cli/test/studio-routing.test.ts
+++ b/packages/cli/test/studio-routing.test.ts
@@ -78,8 +78,12 @@ Feature: Search
       await history
         .getByRole('row')
         .nth(1)
-        .getByRole('button', { name: 'Review run' })
+        .getByRole('button', { name: /^Open attempt for / })
         .click()
+      await page
+        .getByRole('heading', { name: 'Pay for the order · chrome' })
+        .waitFor()
+      await page.getByRole('button', { name: 'Back to run' }).click()
       const runPath = new URL(page.url()).pathname
       expect(runPath).toMatch(/^\/runs\/[^/]+$/)
       await page.reload()

--- a/packages/runner/index.ts
+++ b/packages/runner/index.ts
@@ -40,6 +40,14 @@ export type {
   ScenarioIdentity,
   ScenarioRun,
   ScenarioTargetSession,
+  SharedEvidenceActivity,
+  SharedEvidenceCacheDecisionType,
+  SharedEvidenceCost,
+  SharedEvidenceExecution,
+  SharedEvidenceObservation,
+  SharedEvidenceOutcome,
+  SharedEvidenceTiming,
+  SharedEvidenceVersionObservation,
   StepEvaluation,
   StepExecution,
   StepExecutionContext,
@@ -60,6 +68,8 @@ export {
   diagnosticOrigins,
   finalScenarioAttempt,
   isEvidenceState,
+  sharedEvidenceCacheDecisionTypes,
+  sharedEvidenceObservationVersion,
   traceActivityKinds,
 } from './src/execution/run-scenario'
 export { runScenario } from './src/execution/run-scenario-entry'

--- a/packages/runner/src/execution-cache/execution-cache-lifecycle.test.ts
+++ b/packages/runner/src/execution-cache/execution-cache-lifecycle.test.ts
@@ -803,6 +803,49 @@ describe('Execution cache lifecycle', () => {
       attempt.startedAt,
       attempt.finishedAt,
     ])
+    const cacheMiss = run.events.find((event) => event.type === 'cache-miss')
+    expect(cacheMiss).toMatchObject({
+      type: 'cache-miss',
+      occurredAt: timestamps[1],
+      observations: [
+        {
+          version: 1,
+          kind: 'cache',
+          summary: 'Cache Miss',
+          timing: {
+            occurredAt: timestamps[1],
+            precision: 'exact',
+          },
+          versions: [
+            {
+              subject: 'contract',
+              label: 'run-event-schema',
+              value: '2',
+            },
+            {
+              subject: 'scenario',
+              label: 'revision',
+              value: scenarioRevision(scenario),
+            },
+            {
+              subject: 'application',
+              label: 'revision',
+              value: 'app-1',
+            },
+            {
+              subject: 'adapter',
+              label: 'cache-schema',
+              value: '1',
+            },
+          ],
+          execution: {
+            cacheDecision: {
+              type: 'cache-miss',
+            },
+          },
+        },
+      ],
+    })
   })
 
   test('explicit cache policies fail without a runtime cache store', async () => {

--- a/packages/runner/src/execution-cache/execution-cache.test.ts
+++ b/packages/runner/src/execution-cache/execution-cache.test.ts
@@ -6,11 +6,13 @@ import {
   type ExecutionCacheEnvelope,
   type ExecutionCachePayloadValidator,
   type ExecutionCacheStore,
+  publicRunEvent,
   type RunEventPayload,
   resolveExecutionCacheKey,
   serializeExecutionCacheEnvelope,
 } from '../../index'
 import type { ScenarioAttempt } from '../execution/run-scenario'
+import { withSharedEvidenceObservations } from '../results/shared-evidence-observations'
 
 const keyInput = {
   projectKey: 'project-fingerprint',
@@ -303,5 +305,56 @@ describe('Execution cache contract', () => {
       cacheOutcome: 'fallback',
       inferenceCount: 2,
     })
+  })
+
+  test('projects normalized cache observations onto public run events', () => {
+    const event = withSharedEvidenceObservations({
+      schemaVersion: 2,
+      sequence: 4,
+      occurredAt: '2026-08-29T12:00:00.000Z',
+      type: 'cache-hit',
+      cacheKey: envelope().key,
+      scope: eventScope,
+    })
+
+    expect(publicRunEvent(event).observations).toEqual([
+      {
+        version: 1,
+        kind: 'cache',
+        summary: 'Cache Hit',
+        timing: {
+          occurredAt: '2026-08-29T12:00:00.000Z',
+          precision: 'exact',
+        },
+        versions: [
+          {
+            subject: 'contract',
+            label: 'run-event-schema',
+            value: '2',
+          },
+          {
+            subject: 'scenario',
+            label: 'revision',
+            value: 'scenario-revision',
+          },
+          {
+            subject: 'application',
+            label: 'revision',
+            value: 'application-revision',
+          },
+          {
+            subject: 'adapter',
+            label: 'cache-schema',
+            value: 'contract-test.1',
+          },
+        ],
+        execution: {
+          cacheDecision: {
+            type: 'cache-hit',
+            cacheKey: envelope().key,
+          },
+        },
+      },
+    ])
   })
 })

--- a/packages/runner/src/execution-cache/run-scenario-cache.ts
+++ b/packages/runner/src/execution-cache/run-scenario-cache.ts
@@ -24,6 +24,7 @@ import {
   stringContainsBinding,
 } from '../execution/scenario-runtime'
 import { requiredValue } from '../required-value'
+import { withSharedEvidenceObservations } from '../results/shared-evidence-observations'
 import {
   type AttemptCacheUse,
   attemptCacheUse,
@@ -95,8 +96,9 @@ async function appendEvent(
     sequence: events.length + 1,
     occurredAt,
   } as RunEvent
-  events.push(event)
-  await input.onEvent?.(event)
+  const versioned = withSharedEvidenceObservations(event)
+  events.push(versioned)
+  await input.onEvent?.(versioned)
 }
 
 async function runCachedAttempts(

--- a/packages/runner/src/execution/run-scenario-types.ts
+++ b/packages/runner/src/execution/run-scenario-types.ts
@@ -26,6 +26,7 @@ export function isEvidenceState(state: TestResultState): boolean {
 export type ExecutionMode = 'adaptive' | 'replay'
 
 export const testRunSchemaVersion = 2 as const
+export const sharedEvidenceObservationVersion = 1 as const
 
 export interface ExecutionTargetProfile {
   id: string
@@ -114,6 +115,71 @@ export interface TraceEntry {
   causalAt?: string
   kind: TraceActivityKind
   description: string
+}
+
+export interface SharedEvidenceTiming {
+  occurredAt: string
+  precision: 'exact' | 'step-finish' | 'attempt-finish'
+  startedAt?: string
+  finishedAt?: string
+  durationMs?: number
+  causalAt?: string
+}
+
+export interface SharedEvidenceVersionObservation {
+  subject: 'contract' | 'application' | 'scenario' | 'adapter'
+  label: string
+  value: string
+}
+
+export interface SharedEvidenceActivity {
+  kind: TraceActivityKind
+  description: string
+}
+
+export interface SharedEvidenceOutcome {
+  state?: TestResultState
+  level?: DiagnosticLevel
+  message?: string
+}
+
+export interface SharedEvidenceCost {
+  inferenceCount: number
+}
+
+export const sharedEvidenceCacheDecisionTypes = [
+  'cache-hit',
+  'cache-miss',
+  'cache-refresh',
+  'replay-diverged',
+  'adaptive-fallback-started',
+  'cache-written',
+  'cache-uncacheable',
+] as const
+export type SharedEvidenceCacheDecisionType =
+  (typeof sharedEvidenceCacheDecisionTypes)[number]
+
+export interface SharedEvidenceExecution {
+  mode?: ExecutionMode
+  cacheOutcome?: CacheOutcome
+  cacheDecision?: {
+    type: SharedEvidenceCacheDecisionType
+    reason?: ExecutionCacheUncacheableReason
+    cacheKey?: ExecutionCacheKey
+  }
+}
+
+export interface SharedEvidenceObservation {
+  version: typeof sharedEvidenceObservationVersion
+  kind: 'activity' | 'diagnostic' | 'artifact' | 'outcome' | 'cache'
+  summary: string
+  timing: SharedEvidenceTiming
+  versions?: readonly SharedEvidenceVersionObservation[]
+  activity?: SharedEvidenceActivity
+  outcome?: SharedEvidenceOutcome
+  cost?: SharedEvidenceCost
+  artifact?: TestArtifact
+  execution?: SharedEvidenceExecution
 }
 
 export interface StepExecution {
@@ -292,8 +358,12 @@ export interface RunEventScope {
   stepIndex?: number
 }
 
+type RunEventWithObservations<Event extends { type: string }> = Event & {
+  observations?: SharedEvidenceObservation[]
+}
+
 export type RunEventPayload =
-  | {
+  | RunEventWithObservations<{
       type: 'run-started'
       run: {
         id: string
@@ -303,52 +373,68 @@ export type RunEventPayload =
         applicationRevision?: string
         evidencePersistence?: 'off' | 'on-failure' | 'always'
       }
-    }
-  | {
+    }>
+  | RunEventWithObservations<{
       type: 'scenario-started'
       scenario: TestResult['scenario']
       executionTargetProfile: ExecutionTargetProfile
       scope: RunEventScope
-    }
-  | {
+    }>
+  | RunEventWithObservations<{
       type: 'step-started'
       step: ScenarioStep
       scenario: TestResult['scenario']
       executionTargetProfile: ExecutionTargetProfile
       scope: RunEventScope
-    }
-  | {
+    }>
+  | RunEventWithObservations<{
       type: 'step-finished'
       result: TestStepResult
       scenario: TestResult['scenario']
       executionTargetProfile: ExecutionTargetProfile
       scope: RunEventScope
-    }
-  | { type: 'cache-hit'; cacheKey: ExecutionCacheKey; scope: RunEventScope }
-  | { type: 'cache-miss'; cacheKey: ExecutionCacheKey; scope: RunEventScope }
-  | { type: 'cache-refresh'; cacheKey: ExecutionCacheKey; scope: RunEventScope }
-  | {
+    }>
+  | RunEventWithObservations<{
+      type: 'cache-hit'
+      cacheKey: ExecutionCacheKey
+      scope: RunEventScope
+    }>
+  | RunEventWithObservations<{
+      type: 'cache-miss'
+      cacheKey: ExecutionCacheKey
+      scope: RunEventScope
+    }>
+  | RunEventWithObservations<{
+      type: 'cache-refresh'
+      cacheKey: ExecutionCacheKey
+      scope: RunEventScope
+    }>
+  | RunEventWithObservations<{
       type: 'replay-diverged'
       cacheKey: ExecutionCacheKey
       scope: RunEventScope
-    }
-  | {
+    }>
+  | RunEventWithObservations<{
       type: 'adaptive-fallback-started'
       cacheKey: ExecutionCacheKey
       scope: RunEventScope
-    }
-  | { type: 'cache-written'; cacheKey: ExecutionCacheKey; scope: RunEventScope }
-  | {
+    }>
+  | RunEventWithObservations<{
+      type: 'cache-written'
+      cacheKey: ExecutionCacheKey
+      scope: RunEventScope
+    }>
+  | RunEventWithObservations<{
       type: 'cache-uncacheable'
       reason: ExecutionCacheUncacheableReason
       scope: RunEventScope
-    }
-  | {
+    }>
+  | RunEventWithObservations<{
       type: 'inference-count-updated'
       inferenceCount: number
       scope: RunEventScope
-    }
-  | {
+    }>
+  | RunEventWithObservations<{
       type: 'scenario-finished'
       specification: TestResult['specification']
       scenario: TestResult['scenario']
@@ -356,7 +442,7 @@ export type RunEventPayload =
       scope: RunEventScope
       attempt: ScenarioAttempt
       scheduleIndex?: number
-    }
+    }>
 
 export type RunEvent = RunEventEnvelope & RunEventPayload
 

--- a/packages/runner/src/execution/run-scenario.test.ts
+++ b/packages/runner/src/execution/run-scenario.test.ts
@@ -453,6 +453,252 @@ describe('runScenario', () => {
     ).toBe(false)
   })
 
+  test('emits normalized observations from sanitized step and attempt evidence', async () => {
+    const secret = 'secret@example.test'
+    const observedScenario: Scenario = {
+      ...scenario,
+      steps: [
+        {
+          keyword: 'When',
+          text: 'the customer submits <email>',
+          type: 'action',
+        },
+      ],
+      runtimeBindings: [{ name: 'email', value: secret }],
+    }
+    const adapter: ExecutionTargetAdapter = {
+      async openSession() {
+        return {
+          async executeStep() {
+            return {
+              state: 'failed' as const,
+              resolvedActions: [{ description: `Submit ${secret}` }],
+              message: `Payment failed for ${secret}`,
+              diagnostics: [
+                {
+                  occurredAt: '2026-08-29T12:00:00.000Z',
+                  level: 'error' as const,
+                  origin: 'adapter' as const,
+                  message: `Observed ${secret}`,
+                },
+              ],
+              artifacts: [
+                {
+                  kind: 'trace' as const,
+                  path: `/tmp/${secret}.trace`,
+                },
+              ],
+            }
+          },
+          async close() {},
+        }
+      },
+    }
+
+    const run = await runScenario({
+      specification,
+      scenario: observedScenario,
+      executionTargetProfile: { id: 'web' },
+      adapter,
+    })
+
+    const stepEvent = run.events.find((event) => event.type === 'step-finished')
+    expect(stepEvent).toMatchObject({
+      type: 'step-finished',
+      observations: [
+        {
+          kind: 'outcome',
+          outcome: {
+            state: 'failed',
+            message: 'Payment failed for <email>',
+          },
+        },
+        {
+          kind: 'activity',
+          activity: {
+            kind: 'resolved-action',
+            description: 'Submit <email>',
+          },
+        },
+        {
+          kind: 'diagnostic',
+          outcome: {
+            level: 'error',
+            message: 'Observed <email>',
+          },
+        },
+        {
+          kind: 'artifact',
+          artifact: {
+            kind: 'trace',
+            path: '/tmp/<email>.trace',
+          },
+        },
+      ],
+    })
+    expect(JSON.stringify(run.events)).not.toContain(secret)
+    const finished = requiredValue(run.events.at(-1))
+    expect(finished).toMatchObject({
+      type: 'scenario-finished',
+      observations: [
+        {
+          kind: 'outcome',
+          execution: {
+            mode: 'adaptive',
+          },
+          cost: { inferenceCount: 0 },
+        },
+      ],
+    })
+  })
+
+  test('attaches normalized observations to step and scenario completion events', async () => {
+    const timestamps = [
+      '2026-08-22T13:00:00.000Z',
+      '2026-08-22T13:00:01.000Z',
+      '2026-08-22T13:00:02.000Z',
+      '2026-08-22T13:00:03.000Z',
+    ]
+    let timestampIndex = 0
+    const singleStepScenario: Scenario = {
+      id: 'scn-checkout-receipt',
+      name: 'Capture the receipt',
+      tags: [],
+      steps: [
+        {
+          keyword: 'Then',
+          text: 'the receipt appears',
+          type: 'outcome',
+        },
+      ],
+    }
+    const run = await runScenario({
+      specification,
+      scenario: singleStepScenario,
+      executionTargetProfile: {
+        id: 'chrome',
+        adapter: 'web',
+        capabilities: ['screenshots'],
+      },
+      adapter: {
+        async openSession() {
+          return {
+            async executeStep() {
+              return {
+                state: 'passed',
+                resolvedActions: [{ description: 'Assert receipt on chrome' }],
+                artifacts: [
+                  {
+                    kind: 'screenshot',
+                    path: '/tmp/receipt.png',
+                    mediaType: 'image/png',
+                  },
+                ],
+                trace: [
+                  {
+                    occurredAt: '2026-08-22T13:00:01.500Z',
+                    causalAt: '2026-08-22T13:00:01.250Z',
+                    kind: 'browser-activity',
+                    description: 'Captured receipt screenshot',
+                  },
+                ],
+              }
+            },
+            async complete() {
+              return { inferenceCount: 2 }
+            },
+            async close() {},
+          }
+        },
+      },
+      now: () => new Date(requiredValue(timestamps[timestampIndex++])),
+    })
+
+    const stepFinished = run.events.find(
+      (event) => event.type === 'step-finished',
+    )
+    expect(stepFinished).toMatchObject({
+      type: 'step-finished',
+      observations: [
+        {
+          version: 1,
+          kind: 'outcome',
+          summary: 'Then the receipt appears passed',
+          timing: {
+            occurredAt: timestamps[2],
+            precision: 'step-finish',
+            startedAt: timestamps[1],
+            finishedAt: timestamps[2],
+            durationMs: 1_000,
+          },
+          outcome: { state: 'passed' },
+        },
+        {
+          version: 1,
+          kind: 'activity',
+          summary: 'Captured receipt screenshot',
+          timing: {
+            occurredAt: '2026-08-22T13:00:01.500Z',
+            precision: 'exact',
+            startedAt: timestamps[1],
+            finishedAt: timestamps[2],
+            durationMs: 1_000,
+            causalAt: '2026-08-22T13:00:01.250Z',
+          },
+          activity: {
+            kind: 'browser-activity',
+            description: 'Captured receipt screenshot',
+          },
+        },
+        {
+          version: 1,
+          kind: 'artifact',
+          summary: 'Captured screenshot',
+          timing: {
+            occurredAt: timestamps[2],
+            precision: 'step-finish',
+          },
+          artifact: {
+            kind: 'screenshot',
+            path: '/tmp/receipt.png',
+            mediaType: 'image/png',
+          },
+        },
+      ],
+    })
+
+    const scenarioFinished = run.events.find(
+      (event) => event.type === 'scenario-finished',
+    )
+    expect(scenarioFinished).toMatchObject({
+      type: 'scenario-finished',
+      observations: [
+        {
+          version: 1,
+          kind: 'outcome',
+          summary: 'Capture the receipt passed in adaptive mode',
+          timing: {
+            occurredAt: timestamps[3],
+            precision: 'attempt-finish',
+            startedAt: timestamps[0],
+            finishedAt: timestamps[3],
+            durationMs: 3_000,
+          },
+          versions: [
+            {
+              subject: 'contract',
+              label: 'run-event-schema',
+              value: '2',
+            },
+          ],
+          outcome: { state: 'passed' },
+          cost: { inferenceCount: 2 },
+          execution: { mode: 'adaptive' },
+        },
+      ],
+    })
+  })
+
   test('records a runner Diagnostic entry when a logical session cannot be opened', async () => {
     const run = await runScenario({
       specification,

--- a/packages/runner/src/execution/run-scenario.ts
+++ b/packages/runner/src/execution/run-scenario.ts
@@ -13,6 +13,7 @@ import {
 } from '../execution-cache/cached-step-prefix'
 import type { ExecutionCacheEnvelope } from '../execution-cache/execution-cache'
 import { requiredValue } from '../required-value'
+import { withSharedEvidenceObservations } from '../results/shared-evidence-observations'
 import type {
   DiagnosticEntry,
   EvidenceAvailability,
@@ -826,12 +827,12 @@ function createAttemptEmitter(
 ): EmitAttemptEvent {
   let sequence = 0
   return async (event, occurredAt = now().toISOString()) => {
-    const versionedEvent = {
+    const versionedEvent = withSharedEvidenceObservations({
       ...event,
       schemaVersion: testRunSchemaVersion,
       sequence: ++sequence,
       occurredAt,
-    } as RunEvent
+    } as RunEvent)
     events.push(versionedEvent)
     await input.onEvent?.(versionedEvent)
     return versionedEvent

--- a/packages/runner/src/results/public-results.ts
+++ b/packages/runner/src/results/public-results.ts
@@ -8,6 +8,7 @@ import {
   type RunEventScope,
   type ScenarioAttempt,
   type ScenarioIdentity,
+  type SharedEvidenceObservation,
   type TestArtifact,
   type TestResult,
   type TestStepResult,
@@ -64,6 +65,65 @@ function publicArtifact(artifact: TestArtifact): TestArtifact {
     name: artifact.name,
     capturedAt: artifact.capturedAt,
     sizeBytes: artifact.sizeBytes,
+  }
+}
+
+function publicSharedEvidenceObservation(
+  observation: SharedEvidenceObservation,
+): SharedEvidenceObservation {
+  return {
+    version: observation.version,
+    kind: observation.kind,
+    summary: observation.summary,
+    timing: {
+      occurredAt: observation.timing.occurredAt,
+      precision: observation.timing.precision,
+      startedAt: observation.timing.startedAt,
+      finishedAt: observation.timing.finishedAt,
+      durationMs: observation.timing.durationMs,
+      causalAt: observation.timing.causalAt,
+    },
+    versions: observation.versions?.map((entry) => ({
+      subject: entry.subject,
+      label: entry.label,
+      value: entry.value,
+    })),
+    activity: observation.activity
+      ? {
+          kind: observation.activity.kind,
+          description: observation.activity.description,
+        }
+      : undefined,
+    outcome: observation.outcome
+      ? {
+          state: observation.outcome.state,
+          level: observation.outcome.level,
+          message: observation.outcome.message,
+        }
+      : undefined,
+    cost: observation.cost
+      ? {
+          inferenceCount: observation.cost.inferenceCount,
+        }
+      : undefined,
+    artifact: observation.artifact
+      ? publicArtifact(observation.artifact)
+      : undefined,
+    execution: observation.execution
+      ? {
+          mode: observation.execution.mode,
+          cacheOutcome: observation.execution.cacheOutcome,
+          cacheDecision: observation.execution.cacheDecision
+            ? {
+                type: observation.execution.cacheDecision.type,
+                reason: observation.execution.cacheDecision.reason,
+                cacheKey: observation.execution.cacheDecision.cacheKey
+                  ? publicCacheKey(observation.execution.cacheDecision.cacheKey)
+                  : undefined,
+              }
+            : undefined,
+        }
+      : undefined,
   }
 }
 
@@ -253,62 +313,113 @@ function publicScenarioFinishedEvent(
   }
 }
 
+function publicRunStartedEvent(
+  event: Extract<RunEventPayload, { type: 'run-started' }>,
+): RunEventPayload {
+  return {
+    type: 'run-started',
+    run: {
+      id: event.run.id,
+      startedAt: event.run.startedAt,
+      sourceRunId: event.run.sourceRunId,
+      suite: event.run.suite,
+      applicationRevision: event.run.applicationRevision,
+      evidencePersistence: event.run.evidencePersistence,
+    },
+  }
+}
+
+function publicStepFinishedEvent(
+  event: Extract<RunEventPayload, { type: 'step-finished' }>,
+  mappers: EventResultMappers,
+): RunEventPayload {
+  return {
+    type: 'step-finished',
+    result: mappers.step(event.result),
+    scenario: publicScenarioIdentity(event.scenario),
+    executionTargetProfile: publicExecutionTargetProfile(
+      event.executionTargetProfile,
+    ),
+    scope: publicEventScope(event.scope),
+  }
+}
+
+function publicCacheEvent(
+  event: Extract<
+    RunEventPayload,
+    {
+      type:
+        | 'cache-hit'
+        | 'cache-miss'
+        | 'cache-refresh'
+        | 'replay-diverged'
+        | 'adaptive-fallback-started'
+        | 'cache-written'
+    }
+  >,
+): RunEventPayload {
+  return {
+    type: event.type,
+    cacheKey: publicCacheKey(event.cacheKey),
+    scope: publicEventScope(event.scope),
+  }
+}
+
+function publicInferenceCountUpdatedEvent(
+  event: Extract<RunEventPayload, { type: 'inference-count-updated' }>,
+): RunEventPayload {
+  return {
+    type: 'inference-count-updated',
+    inferenceCount: event.inferenceCount,
+    scope: publicEventScope(event.scope),
+  }
+}
+
+function withObservations(
+  event: RunEvent | RunEventPayload,
+  payload: RunEventPayload,
+): RunEventPayload {
+  return event.observations?.length
+    ? {
+        ...payload,
+        observations: event.observations.map(publicSharedEvidenceObservation),
+      }
+    : payload
+}
+
 function publicEventPayload(
   event: RunEvent | RunEventPayload,
   mappers: EventResultMappers,
 ): RunEventPayload {
   switch (event.type) {
     case 'run-started':
-      return {
-        type: 'run-started',
-        run: {
-          id: event.run.id,
-          startedAt: event.run.startedAt,
-          sourceRunId: event.run.sourceRunId,
-          suite: event.run.suite,
-          applicationRevision: event.run.applicationRevision,
-          evidencePersistence: event.run.evidencePersistence,
-        },
-      }
+      return withObservations(event, publicRunStartedEvent(event))
     case 'scenario-started':
-      return publicScenarioStartedEvent(event)
+      return withObservations(event, publicScenarioStartedEvent(event))
     case 'step-started':
-      return publicStepStartedEvent(event)
+      return withObservations(event, publicStepStartedEvent(event))
     case 'step-finished':
-      return {
-        type: 'step-finished',
-        result: mappers.step(event.result),
-        scenario: publicScenarioIdentity(event.scenario),
-        executionTargetProfile: publicExecutionTargetProfile(
-          event.executionTargetProfile,
-        ),
-        scope: publicEventScope(event.scope),
-      }
+      return withObservations(event, publicStepFinishedEvent(event, mappers))
     case 'cache-hit':
     case 'cache-miss':
     case 'cache-refresh':
     case 'replay-diverged':
     case 'adaptive-fallback-started':
     case 'cache-written':
-      return {
-        type: event.type,
-        cacheKey: publicCacheKey(event.cacheKey),
-        scope: publicEventScope(event.scope),
-      }
+      return withObservations(event, publicCacheEvent(event))
     case 'cache-uncacheable':
-      return {
+      return withObservations(event, {
         type: 'cache-uncacheable',
         reason: event.reason,
         scope: publicEventScope(event.scope),
-      }
+      })
     case 'inference-count-updated':
-      return {
-        type: 'inference-count-updated',
-        inferenceCount: event.inferenceCount,
-        scope: publicEventScope(event.scope),
-      }
+      return withObservations(event, publicInferenceCountUpdatedEvent(event))
     case 'scenario-finished':
-      return publicScenarioFinishedEvent(event, mappers)
+      return withObservations(
+        event,
+        publicScenarioFinishedEvent(event, mappers),
+      )
     default:
       throw new Error('Unsupported run event type')
   }

--- a/packages/runner/src/results/shared-evidence-observations.ts
+++ b/packages/runner/src/results/shared-evidence-observations.ts
@@ -1,0 +1,377 @@
+import type {
+  DiagnosticEntry,
+  RunEvent,
+  SharedEvidenceCacheDecisionType,
+  SharedEvidenceObservation,
+  SharedEvidenceTiming,
+  SharedEvidenceVersionObservation,
+  TestArtifact,
+  TestResultState,
+  TraceEntry,
+} from '../execution/run-scenario-types'
+import {
+  sharedEvidenceObservationVersion,
+  testRunSchemaVersion,
+} from '../execution/run-scenario-types'
+import type {
+  ExecutionCacheKey,
+  ExecutionCacheUncacheableReason,
+} from '../execution-cache/execution-cache'
+
+function contractVersionObservation(): SharedEvidenceVersionObservation {
+  return {
+    subject: 'contract',
+    label: 'run-event-schema',
+    value: String(testRunSchemaVersion),
+  }
+}
+
+function cacheVersionObservations(
+  cacheKey: ExecutionCacheKey | undefined,
+): SharedEvidenceVersionObservation[] | undefined {
+  if (!cacheKey) return undefined
+  return [
+    contractVersionObservation(),
+    {
+      subject: 'scenario',
+      label: 'revision',
+      value: cacheKey.scenarioRevision,
+    },
+    {
+      subject: 'application',
+      label: 'revision',
+      value: cacheKey.applicationRevision,
+    },
+    {
+      subject: 'adapter',
+      label: 'cache-schema',
+      value: cacheKey.adapterCacheSchemaVersion,
+    },
+  ]
+}
+
+function timing(input: SharedEvidenceTiming): SharedEvidenceTiming {
+  return input
+}
+
+function stepOutcomeSummary(stepText: string, state: TestResultState) {
+  return `${stepText} ${state}`
+}
+
+function attemptOutcomeSummary(
+  scenarioName: string,
+  state: TestResultState,
+  executionMode: string | undefined,
+) {
+  if (!executionMode) return `${scenarioName} ${state}`
+  return `${scenarioName} ${state} in ${executionMode} mode`
+}
+
+function cacheDecisionSummary(
+  type: SharedEvidenceCacheDecisionType,
+  reason: ExecutionCacheUncacheableReason | undefined,
+) {
+  if (type === 'cache-uncacheable' && reason) {
+    return `Execution cache uncacheable: ${reason}`
+  }
+  return type
+    .split('-')
+    .map((part) => part[0]?.toUpperCase() + part.slice(1))
+    .join(' ')
+}
+
+function observation(
+  input: Omit<SharedEvidenceObservation, 'version'>,
+): SharedEvidenceObservation {
+  return {
+    version: sharedEvidenceObservationVersion,
+    ...input,
+  }
+}
+
+function diagnosticObservation(
+  diagnostic: DiagnosticEntry,
+  precision: SharedEvidenceTiming['precision'],
+): SharedEvidenceObservation {
+  return observation({
+    kind: 'diagnostic',
+    summary: diagnostic.message,
+    timing: timing({
+      occurredAt: diagnostic.occurredAt,
+      precision,
+      causalAt: diagnostic.causalAt,
+    }),
+    outcome: {
+      level: diagnostic.level,
+      message: diagnostic.message,
+    },
+  })
+}
+
+function traceObservation(
+  entry: TraceEntry,
+  stepTiming: {
+    startedAt: string
+    finishedAt: string
+    durationMs: number
+  },
+): SharedEvidenceObservation {
+  return observation({
+    kind: 'activity',
+    summary: entry.description,
+    timing: timing({
+      occurredAt: entry.occurredAt,
+      precision: 'exact',
+      startedAt: stepTiming.startedAt,
+      finishedAt: stepTiming.finishedAt,
+      durationMs: stepTiming.durationMs,
+      causalAt: entry.causalAt,
+    }),
+    activity: {
+      kind: entry.kind,
+      description: entry.description,
+    },
+  })
+}
+
+function resolvedActionObservation(
+  description: string,
+  stepTiming: {
+    occurredAt: string
+    startedAt: string
+    finishedAt: string
+    durationMs: number
+  },
+): SharedEvidenceObservation {
+  return observation({
+    kind: 'activity',
+    summary: description,
+    timing: timing({
+      occurredAt: stepTiming.occurredAt,
+      precision: 'step-finish',
+      startedAt: stepTiming.startedAt,
+      finishedAt: stepTiming.finishedAt,
+      durationMs: stepTiming.durationMs,
+    }),
+    activity: {
+      kind: 'resolved-action',
+      description,
+    },
+  })
+}
+
+function artifactObservation(
+  artifact: TestArtifact,
+  occurredAt: string,
+  precision: SharedEvidenceTiming['precision'],
+): SharedEvidenceObservation {
+  return observation({
+    kind: 'artifact',
+    summary: `Captured ${artifact.kind}`,
+    timing: timing({
+      occurredAt,
+      precision,
+    }),
+    artifact,
+  })
+}
+
+function stepOutcomeObservation(
+  event: Extract<RunEvent, { type: 'step-finished' }>,
+) {
+  const stepText = `${event.result.step.keyword.trim()} ${event.result.step.text}`
+  return observation({
+    kind: 'outcome',
+    summary: stepOutcomeSummary(stepText, event.result.state),
+    timing: timing({
+      occurredAt: event.result.finishedAt,
+      precision: 'step-finish',
+      startedAt: event.result.startedAt,
+      finishedAt: event.result.finishedAt,
+      durationMs: event.result.durationMs,
+    }),
+    outcome: {
+      state: event.result.state,
+      message: event.result.message,
+    },
+  })
+}
+
+function attemptOutcomeObservation(
+  event: Extract<RunEvent, { type: 'scenario-finished' }>,
+): SharedEvidenceObservation {
+  return observation({
+    kind: 'outcome',
+    summary: attemptOutcomeSummary(
+      event.scenario.name,
+      event.attempt.state,
+      event.attempt.executionMode,
+    ),
+    timing: timing({
+      occurredAt: event.attempt.finishedAt,
+      precision: 'attempt-finish',
+      startedAt: event.attempt.startedAt,
+      finishedAt: event.attempt.finishedAt,
+      durationMs: event.attempt.durationMs,
+    }),
+    versions: [contractVersionObservation()],
+    outcome: {
+      state: event.attempt.state,
+      message: event.attempt.message,
+    },
+    cost: {
+      inferenceCount: event.attempt.inferenceCount ?? 0,
+    },
+    execution: {
+      mode: event.attempt.executionMode,
+      cacheOutcome: event.attempt.cacheOutcome,
+    },
+  })
+}
+
+function cacheObservation(
+  event:
+    | Extract<
+        RunEvent,
+        {
+          type:
+            | 'cache-hit'
+            | 'cache-miss'
+            | 'cache-refresh'
+            | 'replay-diverged'
+            | 'adaptive-fallback-started'
+            | 'cache-written'
+        }
+      >
+    | Extract<RunEvent, { type: 'cache-uncacheable' }>,
+): SharedEvidenceObservation {
+  return observation({
+    kind: 'cache',
+    summary: cacheDecisionSummary(
+      event.type,
+      event.type === 'cache-uncacheable' ? event.reason : undefined,
+    ),
+    timing: timing({
+      occurredAt: event.occurredAt,
+      precision: 'exact',
+    }),
+    versions: cacheVersionObservations(
+      'cacheKey' in event ? event.cacheKey : undefined,
+    ),
+    execution: {
+      cacheDecision: {
+        type: event.type,
+        reason: event.type === 'cache-uncacheable' ? event.reason : undefined,
+        cacheKey: 'cacheKey' in event ? event.cacheKey : undefined,
+      },
+    },
+  })
+}
+
+function inferenceObservation(
+  event: Extract<RunEvent, { type: 'inference-count-updated' }>,
+): SharedEvidenceObservation {
+  return observation({
+    kind: 'outcome',
+    summary: `Inference count updated to ${event.inferenceCount}`,
+    timing: timing({
+      occurredAt: event.occurredAt,
+      precision: 'exact',
+    }),
+    versions: [contractVersionObservation()],
+    cost: {
+      inferenceCount: event.inferenceCount,
+    },
+  })
+}
+
+function stepActivityObservations(
+  event: Extract<RunEvent, { type: 'step-finished' }>,
+): SharedEvidenceObservation[] {
+  if (event.result.trace?.length) {
+    return event.result.trace.map((entry) =>
+      traceObservation(entry, {
+        startedAt: event.result.startedAt,
+        finishedAt: event.result.finishedAt,
+        durationMs: event.result.durationMs,
+      }),
+    )
+  }
+  return event.result.resolvedActions.map((action) =>
+    resolvedActionObservation(action.description, {
+      occurredAt: event.result.finishedAt,
+      startedAt: event.result.startedAt,
+      finishedAt: event.result.finishedAt,
+      durationMs: event.result.durationMs,
+    }),
+  )
+}
+
+function stepArtifactObservations(
+  artifacts: readonly TestArtifact[] | undefined,
+  event: Extract<RunEvent, { type: 'step-finished' }>,
+): SharedEvidenceObservation[] {
+  return (artifacts ?? []).map((artifact) =>
+    artifactObservation(
+      artifact,
+      artifact.capturedAt ?? event.result.finishedAt,
+      artifact.capturedAt ? 'exact' : 'step-finish',
+    ),
+  )
+}
+
+function attemptDiagnosticObservations(
+  diagnostics: readonly DiagnosticEntry[] | undefined,
+): SharedEvidenceObservation[] {
+  return (diagnostics ?? []).map((entry) =>
+    diagnosticObservation(entry, 'attempt-finish'),
+  )
+}
+
+function stepDiagnosticObservations(
+  diagnostics: readonly DiagnosticEntry[] | undefined,
+): SharedEvidenceObservation[] {
+  return (diagnostics ?? []).map((entry) =>
+    diagnosticObservation(entry, 'exact'),
+  )
+}
+
+export function sharedEvidenceObservationsForEvent(
+  event: RunEvent,
+): SharedEvidenceObservation[] | undefined {
+  switch (event.type) {
+    case 'step-finished':
+      return [
+        stepOutcomeObservation(event),
+        ...stepActivityObservations(event),
+        ...stepDiagnosticObservations(event.result.diagnostics),
+        ...stepArtifactObservations(event.result.artifacts, event),
+      ]
+    case 'scenario-finished':
+      return [
+        attemptOutcomeObservation(event),
+        ...attemptDiagnosticObservations(event.attempt.diagnostics),
+      ]
+    case 'cache-hit':
+    case 'cache-miss':
+    case 'cache-refresh':
+    case 'replay-diverged':
+    case 'adaptive-fallback-started':
+    case 'cache-written':
+    case 'cache-uncacheable':
+      return [cacheObservation(event)]
+    case 'inference-count-updated':
+      return [inferenceObservation(event)]
+    default:
+      return undefined
+  }
+}
+
+export function withSharedEvidenceObservations(event: RunEvent): RunEvent {
+  const observations = sharedEvidenceObservationsForEvent(event)
+  if (!observations?.length) return event
+  return {
+    ...event,
+    observations,
+  }
+}

--- a/packages/runner/src/results/test-run-schema.test.ts
+++ b/packages/runner/src/results/test-run-schema.test.ts
@@ -1,6 +1,6 @@
 import { expect, test } from 'bun:test'
 import { requiredValue } from '../required-value'
-import { parseTestRunManifest } from './test-run-schema'
+import { parseRunEvent, parseTestRunManifest } from './test-run-schema'
 import type { TestRunManifest } from './test-run-store'
 
 const unavailableEvidence = [
@@ -200,5 +200,75 @@ test('retains adapter-neutral Test artifact capture metadata', () => {
     name: 'receipt.png',
     capturedAt: attempt.finishedAt,
     sizeBytes: 4_096,
+  })
+})
+
+test('parses run events with shared evidence observations', () => {
+  const occurredAt = '2026-08-22T12:00:00.000Z'
+  const parsed = parseRunEvent(
+    {
+      schemaVersion: 2,
+      sequence: 1,
+      occurredAt,
+      type: 'cache-hit',
+      cacheKey: {
+        projectKey: 'project-1',
+        scenarioId: 'scenario-evidence',
+        scenarioRevision: 'revision-1',
+        executionTargetProfileId: 'web',
+        targetConfigurationFingerprint: 'target-config-1',
+        applicationRevision: 'app-1',
+        adapterKind: 'web',
+        adapterCacheSchemaVersion: '1',
+      },
+      scope: {
+        scenarioId: 'scenario-evidence',
+        executionTargetProfileId: 'web',
+        attempt: 1,
+      },
+      observations: [
+        {
+          version: 1,
+          kind: 'cache',
+          summary: 'Cache Hit',
+          timing: {
+            occurredAt,
+            precision: 'exact',
+          },
+          versions: [
+            {
+              subject: 'contract',
+              label: 'run-event-schema',
+              value: '2',
+            },
+            {
+              subject: 'scenario',
+              label: 'revision',
+              value: 'revision-1',
+            },
+          ],
+          execution: {
+            cacheDecision: {
+              type: 'cache-hit',
+            },
+          },
+        },
+      ],
+    },
+    incompatibleSchema,
+  )
+
+  expect(parsed).toMatchObject({
+    type: 'cache-hit',
+    observations: [
+      {
+        kind: 'cache',
+        execution: {
+          cacheDecision: {
+            type: 'cache-hit',
+          },
+        },
+      },
+    ],
   })
 })

--- a/packages/runner/src/results/test-run-schema.ts
+++ b/packages/runner/src/results/test-run-schema.ts
@@ -10,6 +10,8 @@ import {
   diagnosticLevels,
   diagnosticOrigins,
   evidenceKinds,
+  sharedEvidenceCacheDecisionTypes,
+  sharedEvidenceObservationVersion,
   testRunSchemaVersion,
   traceActivityKinds,
 } from '../execution/run-scenario'
@@ -94,6 +96,90 @@ const traceEntrySchema = z.object({
   causalAt: timestampSchema.optional(),
   kind: z.enum(traceActivityKinds),
   description: z.string(),
+})
+
+const executionCacheKeySchema = z.object({
+  projectKey: z.string(),
+  scenarioId: z.string(),
+  scenarioRevision: z.string(),
+  executionTargetProfileId: z.string(),
+  targetConfigurationFingerprint: z.string(),
+  applicationRevision: z.string(),
+  adapterKind: z.string(),
+  adapterCacheSchemaVersion: z.string(),
+})
+
+const sharedEvidenceTimingSchema = z.object({
+  occurredAt: timestampSchema,
+  precision: z.enum(['exact', 'step-finish', 'attempt-finish']),
+  startedAt: timestampSchema.optional(),
+  finishedAt: timestampSchema.optional(),
+  durationMs: nonNegativeIntegerSchema.optional(),
+  causalAt: timestampSchema.optional(),
+})
+
+const sharedEvidenceVersionObservationSchema = z.object({
+  subject: z.enum(['contract', 'application', 'scenario', 'adapter']),
+  label: z.string(),
+  value: z.string(),
+})
+
+const sharedEvidenceActivitySchema = z.object({
+  kind: z.enum(traceActivityKinds),
+  description: z.string(),
+})
+
+const sharedEvidenceOutcomeSchema = z.object({
+  state: resultStateSchema.optional(),
+  level: z.enum(diagnosticLevels).optional(),
+  message: z.string().optional(),
+})
+
+const sharedEvidenceCostSchema = z.object({
+  inferenceCount: nonNegativeIntegerSchema,
+})
+
+const sharedEvidenceObservationSchema = z.object({
+  version: z.literal(sharedEvidenceObservationVersion),
+  kind: z.enum(['activity', 'diagnostic', 'artifact', 'outcome', 'cache']),
+  summary: z.string(),
+  timing: sharedEvidenceTimingSchema,
+  versions: z.array(sharedEvidenceVersionObservationSchema).optional(),
+  activity: sharedEvidenceActivitySchema.optional(),
+  outcome: sharedEvidenceOutcomeSchema.optional(),
+  cost: sharedEvidenceCostSchema.optional(),
+  artifact: artifactSchema.optional(),
+  execution: z
+    .object({
+      mode: z.enum(['adaptive', 'replay']).optional(),
+      cacheOutcome: z
+        .enum([
+          'hit',
+          'partial-hit',
+          'miss',
+          'refresh',
+          'fallback',
+          'uncacheable',
+        ])
+        .optional(),
+      cacheDecision: z
+        .object({
+          type: z.enum(sharedEvidenceCacheDecisionTypes),
+          reason: z
+            .enum([
+              'application-revision-missing',
+              'bound-parameter-value',
+              'non-deterministic-action',
+              'non-deterministic-assertion',
+              'payload-validation-failed',
+              'entry-too-large',
+            ])
+            .optional(),
+          cacheKey: executionCacheKeySchema.optional(),
+        })
+        .optional(),
+    })
+    .optional(),
 })
 
 const testStepResultSchema: z.ZodType<TestStepResult> = z
@@ -370,21 +456,11 @@ const runEventScopeSchema = z.object({
   stepIndex: nonNegativeIntegerSchema.optional(),
 })
 
-const executionCacheKeySchema = z.object({
-  projectKey: z.string(),
-  scenarioId: z.string(),
-  scenarioRevision: z.string(),
-  executionTargetProfileId: z.string(),
-  targetConfigurationFingerprint: z.string(),
-  applicationRevision: z.string(),
-  adapterKind: z.string(),
-  adapterCacheSchemaVersion: z.string(),
-})
-
 const eventEnvelope = {
   schemaVersion: z.literal(testRunSchemaVersion),
   sequence: positiveIntegerSchema,
   occurredAt: timestampSchema,
+  observations: z.array(sharedEvidenceObservationSchema).optional(),
 }
 
 const scopedEvent = {

--- a/packages/runner/src/results/test-run-store.test.ts
+++ b/packages/runner/src/results/test-run-store.test.ts
@@ -6,10 +6,12 @@ import { join } from 'node:path'
 import {
   openTestRunStore as openTestRunStoreBase,
   resolveLocalProjectStorage,
+  runScenario,
   type TestRunStoreOptions,
 } from '../../index'
 import type { TestResult } from '../execution/run-scenario'
 import { requiredValue } from '../required-value'
+import { withSharedEvidenceObservations } from './shared-evidence-observations'
 
 const directories: string[] = []
 
@@ -308,6 +310,115 @@ test('persists public evidence without private replay data', async () => {
       join(storageFor(root).runsDirectory, run.id, 'manifest.json'),
     ).text(),
   ).not.toContain('private-replay-payload')
+})
+
+test('persists runner-emitted observations without replay payloads', async () => {
+  const root = await tempRoot()
+  const store = openTestRunStore({
+    root,
+    createId: () => 'run-shared-observations',
+    now: () => new Date('2026-08-15T12:00:00.000Z'),
+  })
+  const persisted = await store.create()
+  const run = await runScenario({
+    specification: {
+      name: 'Checkout',
+      source: { uri: 'features/checkout.feature', language: 'en' },
+      tags: [],
+      scenarios: [],
+    },
+    scenario: {
+      id: 'scenario-receipt',
+      name: 'Capture the receipt',
+      tags: [],
+      steps: [
+        {
+          keyword: 'Then',
+          text: 'the receipt appears',
+          type: 'outcome',
+        },
+      ],
+    },
+    executionTargetProfile: {
+      id: 'web',
+      adapter: 'web',
+      capabilities: ['screenshots'],
+    },
+    adapter: {
+      async openSession() {
+        return {
+          async executeStep() {
+            return {
+              state: 'passed' as const,
+              resolvedActions: [
+                {
+                  description: 'Assert receipt on chrome',
+                  replay: { raw: 'private-replay-payload' },
+                },
+              ],
+              artifacts: [
+                {
+                  kind: 'screenshot' as const,
+                  path: '/tmp/receipt.png',
+                  mediaType: 'image/png',
+                },
+              ],
+            }
+          },
+          async complete() {
+            return { inferenceCount: 1 }
+          },
+          async close() {},
+        }
+      },
+    },
+    now: (() => {
+      const timestamps = [
+        '2026-08-15T12:00:01.000Z',
+        '2026-08-15T12:00:02.000Z',
+        '2026-08-15T12:00:03.000Z',
+        '2026-08-15T12:00:04.000Z',
+      ]
+      let index = 0
+      return () => new Date(requiredValue(timestamps[index++]))
+    })(),
+  })
+
+  for (const event of run.events) {
+    await persisted.append(event)
+  }
+
+  const storedEvents = await persisted.events()
+  const stepFinished = storedEvents.find(
+    (event) => event.type === 'step-finished',
+  )
+  expect(stepFinished).toMatchObject({
+    type: 'step-finished',
+    observations: [
+      {
+        kind: 'outcome',
+      },
+      {
+        kind: 'activity',
+        activity: {
+          kind: 'resolved-action',
+          description: 'Assert receipt on chrome',
+        },
+      },
+      {
+        kind: 'artifact',
+        artifact: {
+          kind: 'screenshot',
+          path: expect.any(String),
+        },
+      },
+    ],
+  })
+  const eventsSource = await Bun.file(
+    join(storageFor(root).runsDirectory, persisted.id, 'events.ndjson'),
+  ).text()
+  expect(eventsSource).not.toContain('private-replay-payload')
+  expect(eventsSource).toContain('"observations"')
 })
 
 test('an in-progress manifest omits finishedAt until the test run finishes', async () => {
@@ -802,22 +913,28 @@ test('persists Diagnostic entries for failed runs by default and drops them for 
     diagnostics: [diagnostic],
     trace: [trace],
   }
-  const liveEvent = await run.append({
-    type: 'step-finished',
-    result: liveStep,
-    scenario: passed.scenario,
-    executionTargetProfile: passed.executionTargetProfile,
-    scope: {
-      scenarioId: requiredValue(passed.scenario.id),
-      executionTargetProfileId: passed.executionTargetProfile.id,
-      attempt: passedAttempt.attempt,
-      stepIndex: liveStep.index,
-    },
-  })
+  const liveEvent = await run.append(
+    withSharedEvidenceObservations({
+      schemaVersion: 2,
+      sequence: 2,
+      occurredAt: liveStep.finishedAt,
+      type: 'step-finished',
+      result: liveStep,
+      scenario: passed.scenario,
+      executionTargetProfile: passed.executionTargetProfile,
+      scope: {
+        scenarioId: requiredValue(passed.scenario.id),
+        executionTargetProfileId: passed.executionTargetProfile.id,
+        attempt: passedAttempt.attempt,
+        stepIndex: liveStep.index,
+      },
+    }),
+  )
 
   expect(liveEvent).toMatchObject({
     type: 'step-finished',
     result: { diagnostics: [diagnostic], trace: [trace] },
+    observations: expect.any(Array),
   })
   const persistedLiveStep = (await run.events()).at(-1)
   expect(persistedLiveStep?.type).toBe('step-finished')
@@ -826,6 +943,50 @@ test('persists Diagnostic entries for failed runs by default and drops them for 
   }
   expect(persistedLiveStep.result.diagnostics).toBeUndefined()
   expect(persistedLiveStep.result.trace).toBeUndefined()
+  expect(persistedLiveStep.observations).toEqual([
+    {
+      version: 1,
+      kind: 'outcome',
+      summary: 'Then the purchase succeeds passed',
+      timing: {
+        occurredAt: passedAttempt.finishedAt,
+        precision: 'step-finish',
+        startedAt: passedAttempt.startedAt,
+        finishedAt: passedAttempt.finishedAt,
+        durationMs: passedAttempt.durationMs,
+      },
+      outcome: { state: 'passed' },
+    },
+    {
+      version: 1,
+      kind: 'activity',
+      summary: 'Click pay on chrome',
+      timing: {
+        occurredAt: trace.occurredAt,
+        precision: 'exact',
+        startedAt: passedAttempt.startedAt,
+        finishedAt: passedAttempt.finishedAt,
+        durationMs: passedAttempt.durationMs,
+      },
+      activity: {
+        kind: 'resolved-action',
+        description: 'Click pay on chrome',
+      },
+    },
+    {
+      version: 1,
+      kind: 'diagnostic',
+      summary: diagnostic.message,
+      timing: {
+        occurredAt: diagnostic.occurredAt,
+        precision: 'exact',
+      },
+      outcome: {
+        level: diagnostic.level,
+        message: diagnostic.message,
+      },
+    },
+  ])
 
   await run.append(
     scenarioFinished({

--- a/packages/studio/src/runs/result/live-result-follow.ts
+++ b/packages/studio/src/runs/result/live-result-follow.ts
@@ -44,6 +44,20 @@ export function nextLiveLocation(
     : state.location
 }
 
+export function defaultRunAttemptLocation(
+  snapshot: StudioRunSnapshot,
+): ResultInspectionLocation | undefined {
+  return nextLiveLocation(
+    {
+      pinned: false,
+      following: true,
+      specificationUri: '',
+      runId: snapshot.id,
+    },
+    snapshot,
+  )
+}
+
 export function nextFollowedEntryId(
   state: LiveFollowedEntryState,
   snapshot: StudioRunSnapshot,

--- a/packages/studio/src/runs/result/live-result-inspection.test.ts
+++ b/packages/studio/src/runs/result/live-result-inspection.test.ts
@@ -5,6 +5,7 @@ import type {
   TestStepResult,
 } from '@pickle-spec/runner'
 import { requiredValue } from '../../required-value'
+import { defaultRunAttemptLocation } from './live-result-follow'
 import {
   cellsFromLiveInspection,
   disconnectLiveInspection,
@@ -418,6 +419,26 @@ test('selects a failed Scenario attempt when the investigation is not pinned', (
   inspection = receiveLiveStreamEvent(inspection, scenarioStarted(3))
   inspection = receiveLiveStreamEvent(inspection, scenarioFinished(5))
   expect(inspection.location?.scenarioId).toBe(scenario.id)
+})
+
+test('opens a persisted Run at the attempt that needs attention', () => {
+  let inspection = startLiveInspection({
+    specificationUri,
+    runId: 'run-79',
+  })
+  inspection = receiveLiveStreamEvent(inspection, runStarted())
+  inspection = receiveLiveStreamEvent(inspection, passingStarted(2))
+  inspection = receiveLiveStreamEvent(inspection, scenarioStarted(3))
+  inspection = receiveLiveStreamEvent(inspection, scenarioFinished(5))
+
+  expect(
+    defaultRunAttemptLocation(requiredValue(inspection.snapshot)),
+  ).toMatchObject({
+    runId: 'run-79',
+    scenarioId: scenario.id,
+    attempt: 1,
+    tab: 'timeline',
+  })
 })
 
 test('represents event loss instead of silently dropping later Run events', () => {

--- a/packages/studio/src/runs/runs.tsx
+++ b/packages/studio/src/runs/runs.tsx
@@ -26,6 +26,7 @@ import {
 } from '../components/ui/dropdown-menu'
 import { Input } from '../components/ui/input'
 import { ResultMark } from '../components/ui/result-mark'
+import { Spinner } from '../components/ui/spinner'
 import {
   Table,
   TableBody,
@@ -44,8 +45,10 @@ import { useVirtualWindow } from '../hooks/use-virtual-window'
 import type {
   StudioProject,
   StudioRunRequest,
+  StudioRunSnapshot,
   StudioRunsIndex,
 } from '../server/server'
+import { defaultRunAttemptLocation } from './result/live-result-follow'
 import type { LiveResultInspection } from './result/live-result-inspection'
 import { ResultInspector } from './result/result-inspector'
 import { reasonMessage, resultBadgeVariant } from './result/result-presentation'
@@ -95,12 +98,7 @@ export function RunsArea(props: RunsAreaProps) {
     return <SingleRunRoute {...props} inspections={inspections} />
   }
   return (
-    <RunsDashboard
-      key={studioRouteHref(props.route)}
-      {...props}
-      route={props.route}
-      inspections={inspections}
-    />
+    <RunsDashboard {...props} route={props.route} inspections={inspections} />
   )
 }
 
@@ -281,6 +279,7 @@ function RunsLoading() {
 
 function useRunsDashboardState(props: RunsDashboardProps) {
   const [error, setError] = useState<string>()
+  const [openingRunId, setOpeningRunId] = useState<string>()
   const [selectedRunIds, setSelectedRunIds] = useState<string[]>([])
   const [comparison, setComparison] = useState<TestRunComparison>()
   return {
@@ -298,10 +297,36 @@ function useRunsDashboardState(props: RunsDashboardProps) {
     error,
     importArchive: (file?: File) =>
       void importRunArchive(props, file, setError),
+    openingRunId,
+    openRunAttempt: (runId: string) =>
+      void openRunAttempt(props, runId, setOpeningRunId, setError),
     selectedRunIds,
     setPinned: (runId: string, pinned: boolean) =>
       void setRunPinned(props, runId, pinned, setError),
     setSelectedRunIds,
+  }
+}
+
+async function openRunAttempt(
+  props: Pick<RunsDashboardProps, 'api' | 'onNavigate'>,
+  runId: string,
+  setOpeningRunId: React.Dispatch<React.SetStateAction<string | undefined>>,
+  setError: (error?: string) => void,
+) {
+  setError(undefined)
+  setOpeningRunId(runId)
+  try {
+    const snapshot = await props.api<StudioRunSnapshot>(
+      `/api/runs/${encodeURIComponent(runId)}`,
+    )
+    const location = defaultRunAttemptLocation(snapshot)
+    props.onNavigate(
+      location ? { kind: 'result', location } : { kind: 'run', runId },
+    )
+  } catch (reason) {
+    setError(reasonMessage(reason))
+  } finally {
+    setOpeningRunId((current) => (current === runId ? undefined : current))
   }
 }
 
@@ -372,7 +397,8 @@ function RunHistory(
           pinnedRunIds={props.pinnedRunIds}
           specificationNames={props.specificationNames}
           runsBlocked={props.runsBlocked}
-          onOpen={(runId) => props.onNavigate({ kind: 'run', runId })}
+          openingRunId={props.openingRunId}
+          onOpen={props.openRunAttempt}
           onPin={props.setPinned}
           onRerun={props.onRerun}
           onSelect={props.setSelectedRunIds}
@@ -608,6 +634,7 @@ type RunTableProps = {
   pinnedRunIds: ReadonlySet<string>
   specificationNames: ReadonlyMap<string, string>
   runsBlocked: boolean
+  openingRunId?: string
   onOpen: (runId: string) => void
   onPin: (runId: string, pinned: boolean) => void
   onRerun: (request: StudioRunRequest) => Promise<void>
@@ -620,9 +647,7 @@ function RunTableRow(
   const { summary, state } = props
   const selected = props.selectedRunIds.includes(summary.id)
   const pinned = props.pinnedRunIds.has(summary.id)
-  const rerunDisabled =
-    props.runsBlocked ||
-    (summary.state !== 'failed' && summary.state !== 'infrastructure-error')
+  const opening = props.openingRunId === summary.id
 
   function handleSelectionChange(checked: boolean) {
     props.onSelect((current) =>
@@ -634,14 +659,6 @@ function RunTableRow(
 
   function handlePin() {
     props.onPin(summary.id, !pinned)
-  }
-
-  function handleOpen() {
-    props.onOpen(summary.id)
-  }
-
-  function handleRerun() {
-    void props.onRerun({ rerunId: summary.id, failures: true })
   }
 
   return (
@@ -672,10 +689,11 @@ function RunTableRow(
         </Tooltip>
       </TableCell>
       <TableCell>
-        <span className="block">
-          {new Date(summary.startedAt).toLocaleString()}
-        </span>
-        <span className="font-mono text-muted-foreground">{summary.id}</span>
+        <RunIdentity
+          summary={summary}
+          opening={opening}
+          onOpen={props.onOpen}
+        />
       </TableCell>
       <TableCell>
         {summary.specificationUris
@@ -696,32 +714,77 @@ function RunTableRow(
       </TableCell>
       <TableCell>{resultCountLabel(summary.resultCount)}</TableCell>
       <TableCell>
-        <div className="flex items-center gap-2">
-          <Button
-            type="button"
-            variant="outline"
-            size="sm"
-            onClick={handleOpen}
-          >
-            Review run
-          </Button>
-          <Button
-            type="button"
-            variant="outline"
-            size="sm"
-            disabled={rerunDisabled}
-            onClick={handleRerun}
-          >
-            Rerun failures
-          </Button>
-        </div>
-        {summary.sourceRunId ? (
-          <span className="mt-1 block text-muted-foreground">
-            Rerun of {summary.sourceRunId}
-          </span>
-        ) : null}
+        <RunTableActions
+          summary={summary}
+          runsBlocked={props.runsBlocked}
+          onRerun={props.onRerun}
+        />
       </TableCell>
     </TableRow>
+  )
+}
+
+function RunIdentity(props: {
+  summary: TestRunSummary
+  opening: boolean
+  onOpen: (runId: string) => void
+}) {
+  function handleOpen() {
+    props.onOpen(props.summary.id)
+  }
+  return (
+    <div className="flex flex-col items-start gap-0.5">
+      <Button
+        type="button"
+        variant="link"
+        aria-label={`Open attempt for ${props.summary.id}`}
+        aria-busy={props.opening}
+        disabled={props.opening}
+        className="h-auto gap-1.5 p-0 font-mono text-left active:opacity-65"
+        onClick={handleOpen}
+      >
+        {props.summary.id}
+        {props.opening ? <Spinner className="scale-75" /> : null}
+      </Button>
+      <time
+        dateTime={props.summary.startedAt}
+        className="text-muted-foreground"
+      >
+        {new Date(props.summary.startedAt).toLocaleString()}
+      </time>
+    </div>
+  )
+}
+
+function RunTableActions(props: {
+  summary: TestRunSummary
+  runsBlocked: boolean
+  onRerun: (request: StudioRunRequest) => Promise<void>
+}) {
+  const rerunDisabled =
+    props.runsBlocked ||
+    (props.summary.state !== 'failed' &&
+      props.summary.state !== 'infrastructure-error')
+  function handleRerun() {
+    void props.onRerun({ rerunId: props.summary.id, failures: true })
+  }
+  return (
+    <>
+      <Button
+        type="button"
+        variant="outline"
+        size="sm"
+        disabled={rerunDisabled}
+        onClick={handleRerun}
+      >
+        Rerun failures
+      </Button>
+      {props.summary.sourceRunId ? (
+        <span className="mt-1 block text-muted-foreground">
+          Rerun of {props.summary.sourceRunId}
+        </span>
+      ) : null}
+    </>
   )
 }
 
@@ -740,7 +803,7 @@ function RunTable(props: RunTableProps) {
           <TableRow>
             <TableHead>Compare</TableHead>
             <TableHead>Retention</TableHead>
-            <TableHead>Started</TableHead>
+            <TableHead>Run</TableHead>
             <TableHead>Specifications</TableHead>
             <TableHead>Suite</TableHead>
             <TableHead>Targets</TableHead>


### PR DESCRIPTION
## Summary

- Add a versioned shared evidence observation contract to runner events.
- Normalize outcomes, activities, diagnostics, artifacts, cache decisions, timing, versions, and inference costs.
- Sanitize sensitive runtime values in observations and preserve public result projections.
- Simplify Studio and web event handling around run and attempt navigation.
- Expand runner, cache, CLI, and Studio coverage for the new evidence contract.

## Testing

- Added unit coverage for normalized step and scenario observations.
- Added execution-cache coverage for cache-hit and cache-miss observations.
- Updated Studio routing, hardening, search, and checkout browser coverage.
- Run `bun run lint`, `bun run typecheck`, and `bun run test` before merge.