### PR TITLE
feat(cli): add project environment doctor

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -32,6 +32,8 @@
         "@pickle-spec/web": "workspace:*",
         "@types/bun": "catalog:",
         "@typescript/typescript6": "catalog:",
+        "chalk": "5",
+        "ora": "8",
         "zod": "catalog:",
       },
       "devDependencies": {
@@ -369,6 +371,8 @@
 
     "agentkeepalive": ["agentkeepalive@4.6.0", "", { "dependencies": { "humanize-ms": "^1.2.1" } }, "sha512-kja8j7PjmncONqaTsB8fQ+wE2mSU2DJ9D4XKoJ5PFWIdRMa6SLSN1ff4mOr4jCbfRSsxR4keIiySJU0N9T5hIQ=="],
 
+    "ansi-regex": ["ansi-regex@6.3.0", "", {}, "sha512-WpDfL7NO6j7tH88IDBNVdUJxDh9nmCteAVW9dsep846XdwF4naCBK+/tGLX3KJgcpgMRXCFlTM2hKGoK9FsdrQ=="],
+
     "aria-hidden": ["aria-hidden@1.2.6", "", { "dependencies": { "tslib": "^2.0.0" } }, "sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA=="],
 
     "asynckit": ["asynckit@0.4.0", "", {}, "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="],
@@ -395,11 +399,17 @@
 
     "call-bind-apply-helpers": ["call-bind-apply-helpers@1.0.2", "", { "dependencies": { "es-errors": "^1.3.0", "function-bind": "^1.1.2" } }, "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ=="],
 
+    "chalk": ["chalk@5.6.2", "", {}, "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA=="],
+
     "chrome-launcher": ["chrome-launcher@1.2.1", "", { "dependencies": { "@types/node": "*", "escape-string-regexp": "^4.0.0", "is-wsl": "^2.2.0", "lighthouse-logger": "^2.0.1" }, "bin": { "print-chrome-path": "bin/print-chrome-path.cjs" } }, "sha512-qmFR5PLMzHyuNJHwOloHPAHhbaNglkfeV/xDtt5b7xiFFyU1I+AZZX0PYseMuhenJSSirgxELYIbswcoc+5H4A=="],
 
     "class-transformer": ["class-transformer@0.5.1", "", {}, "sha512-SQa1Ws6hUbfC98vKGxZH3KFY0Y1lm5Zm0SY8XX9zbK7FJCyVEac3ATW0RIpwzW+oOfmHE5PMPufDG9hCfoEOMw=="],
 
     "class-variance-authority": ["class-variance-authority@0.7.1", "", { "dependencies": { "clsx": "^2.1.1" } }, "sha512-Ka+9Trutv7G8M6WT6SeiRWz792K5qEqIGEGzXKhAE6xOWAY6pPH8U+9IY3oCMv6kqTmLsv7Xh/2w2RigkePMsg=="],
+
+    "cli-cursor": ["cli-cursor@5.0.0", "", { "dependencies": { "restore-cursor": "^5.0.0" } }, "sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw=="],
+
+    "cli-spinners": ["cli-spinners@2.9.2", "", {}, "sha512-ywqV+5MmyL4E7ybXgKys4DugZbX0FC6LnwrhjuykIjnK9k8OQacQ7axGKnjDXWNhns0xot3bZI5h55H8yo9cJg=="],
 
     "clsx": ["clsx@2.1.1", "", {}, "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA=="],
 
@@ -418,6 +428,8 @@
     "dompurify": ["dompurify@3.4.8", "", { "optionalDependencies": { "@types/trusted-types": "^2.0.7" } }, "sha512-yb1cEmaOum7wFvOCSQxyfgVlv5D47Rc30iZWoMpbDIWTnJ6grDDQyu2KFJzB2k7u0pMuJcQ1zphH//fFnw2tjQ=="],
 
     "dunder-proto": ["dunder-proto@1.0.1", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.1", "es-errors": "^1.3.0", "gopd": "^1.2.0" } }, "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A=="],
+
+    "emoji-regex": ["emoji-regex@10.6.0", "", {}, "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A=="],
 
     "es-define-property": ["es-define-property@1.0.1", "", {}, "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g=="],
 
@@ -449,6 +461,8 @@
 
     "function-bind": ["function-bind@1.1.2", "", {}, "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="],
 
+    "get-east-asian-width": ["get-east-asian-width@1.6.0", "", {}, "sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA=="],
+
     "get-intrinsic": ["get-intrinsic@1.3.0", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.2", "es-define-property": "^1.0.1", "es-errors": "^1.3.0", "es-object-atoms": "^1.1.1", "function-bind": "^1.1.2", "get-proto": "^1.0.1", "gopd": "^1.2.0", "has-symbols": "^1.1.0", "hasown": "^2.0.2", "math-intrinsics": "^1.1.0" } }, "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ=="],
 
     "get-nonce": ["get-nonce@1.0.1", "", {}, "sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q=="],
@@ -473,9 +487,15 @@
 
     "is-docker": ["is-docker@2.2.1", "", { "bin": { "is-docker": "cli.js" } }, "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ=="],
 
+    "is-interactive": ["is-interactive@2.0.0", "", {}, "sha512-qP1vozQRI+BMOPcjFzrjXuQvdak2pHNUMZoeG2eRbiSqyvbEf/wQtEOTOX1guk6E3t36RkaqiSt8A/6YElNxLQ=="],
+
+    "is-unicode-supported": ["is-unicode-supported@2.1.0", "", {}, "sha512-mE00Gnza5EEB3Ds0HfMyllZzbBrmLOX3vfWoj9A9PEnTfratQ/BcaJOuMhnkhjXvb2+FkY3VuHqtAGpTPmglFQ=="],
+
     "is-wsl": ["is-wsl@2.2.0", "", { "dependencies": { "is-docker": "^2.0.0" } }, "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww=="],
 
     "lighthouse-logger": ["lighthouse-logger@2.0.2", "", { "dependencies": { "debug": "^4.4.1", "marky": "^1.2.2" } }, "sha512-vWl2+u5jgOQuZR55Z1WM0XDdrJT6mzMP8zHUct7xTlWhuQs+eV0g+QL0RQdFjT54zVmbhLCP8vIVpy1wGn/gCg=="],
+
+    "log-symbols": ["log-symbols@6.0.0", "", { "dependencies": { "chalk": "^5.3.0", "is-unicode-supported": "^1.3.0" } }, "sha512-i24m8rpwhmPIS4zscNzK6MSEhk0DUWa/8iYQWxhffV8jkI4Phvs3F+quL5xvS0gdQR0FyTCMMH33Y78dDTzzIw=="],
 
     "marked": ["marked@14.0.0", "", { "bin": { "marked": "bin/marked.js" } }, "sha512-uIj4+faQ+MgHgwUW1l2PsPglZLOLOT1uErt06dAPtx2kjteLAkbsd/0FiYg/MGS+i7ZKLb7w2WClxHkzOOuryQ=="],
 
@@ -487,6 +507,8 @@
 
     "mime-types": ["mime-types@2.1.35", "", { "dependencies": { "mime-db": "1.52.0" } }, "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw=="],
 
+    "mimic-function": ["mimic-function@5.0.1", "", {}, "sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA=="],
+
     "monaco-editor": ["monaco-editor@0.56.0", "", { "dependencies": { "dompurify": "3.4.8", "marked": "14.0.0" } }, "sha512-sXboRm3BeBeLm938eaiyLMe0OxzfXIlZvbv4ir/jVgQy1zDhWjgmny0WoN45fuDKhCCQsYMbBJrv/A6jd8aCUg=="],
 
     "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
@@ -494,6 +516,10 @@
     "node-domexception": ["node-domexception@1.0.0", "", {}, "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ=="],
 
     "node-fetch": ["node-fetch@2.7.0", "", { "dependencies": { "whatwg-url": "^5.0.0" }, "peerDependencies": { "encoding": "^0.1.0" }, "optionalPeers": ["encoding"] }, "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A=="],
+
+    "onetime": ["onetime@7.0.0", "", { "dependencies": { "mimic-function": "^5.0.0" } }, "sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ=="],
+
+    "ora": ["ora@8.2.0", "", { "dependencies": { "chalk": "^5.3.0", "cli-cursor": "^5.0.0", "cli-spinners": "^2.9.2", "is-interactive": "^2.0.0", "is-unicode-supported": "^2.0.0", "log-symbols": "^6.0.0", "stdin-discarder": "^0.2.2", "string-width": "^7.2.0", "strip-ansi": "^7.1.0" } }, "sha512-weP+BZ8MVNnlCm8c0Qdc1WSWq4Qn7I+9CJGm7Qali6g44e/PUzbjNqJX5NJ9ljlNMosfJvg1fKEGILklK9cwnw=="],
 
     "pend": ["pend@1.2.0", "", {}, "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg=="],
 
@@ -517,9 +543,19 @@
 
     "reselect": ["reselect@5.2.0", "", {}, "sha512-AgZ3UOZm3YndfrJ4OYjgrT7bmCm/1iqkjvEfH/oYjzh6PD2qw4QuT3jjnXIrpdt4MTpMXclMT3lXbmRY+XRakw=="],
 
+    "restore-cursor": ["restore-cursor@5.1.0", "", { "dependencies": { "onetime": "^7.0.0", "signal-exit": "^4.1.0" } }, "sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA=="],
+
     "scheduler": ["scheduler@0.27.0", "", {}, "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q=="],
 
+    "signal-exit": ["signal-exit@4.1.0", "", {}, "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw=="],
+
+    "stdin-discarder": ["stdin-discarder@0.2.2", "", {}, "sha512-UhDfHmA92YAlNnCfhmq0VeNL5bDbiZGg7sZ2IvPsXubGkiNa9EC+tUTsjBRsYUAz87btI6/1wf4XoVvQ3uRnmQ=="],
+
     "streamx": ["streamx@2.28.0", "", { "dependencies": { "events-universal": "^1.0.0", "fast-fifo": "^1.3.2", "text-decoder": "^1.1.0" } }, "sha512-1Yowhzjf0ivGMrTIkY9hav5TxobO9qIVqUE41fiCGMGgc3CLlf4MY+9AHmZqBWgDTue0fY9zWjYFVyf6Diuobw=="],
+
+    "string-width": ["string-width@7.2.0", "", { "dependencies": { "emoji-regex": "^10.3.0", "get-east-asian-width": "^1.0.0", "strip-ansi": "^7.1.0" } }, "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ=="],
+
+    "strip-ansi": ["strip-ansi@7.2.0", "", { "dependencies": { "ansi-regex": "^6.2.2" } }, "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w=="],
 
     "tailwind-merge": ["tailwind-merge@3.6.0", "", {}, "sha512-uxL7qAVQriqRQPAyK3pj66VqskWqoZ37PW94jwOTwNfq/z9oyu1V+eqrZqtR2+fCiXdYOZe/Modt8GtvqNzu+w=="],
 
@@ -586,6 +622,8 @@
     "@pickle-spec/studio/@types/bun": ["@types/bun@1.4.0", "", { "dependencies": { "bun-types": "1.4.0" } }, "sha512-K+lZULY23vRgK/CfTjFIV+tyifaNdSMlPh9j+6mQ/cLfpOznLyAuzgV/JQysyECpkBQLVMSyvjlr2fBUSA9wFQ=="],
 
     "@pickle-spec/web/@types/bun": ["@types/bun@1.4.0", "", { "dependencies": { "bun-types": "1.4.0" } }, "sha512-K+lZULY23vRgK/CfTjFIV+tyifaNdSMlPh9j+6mQ/cLfpOznLyAuzgV/JQysyECpkBQLVMSyvjlr2fBUSA9wFQ=="],
+
+    "log-symbols/is-unicode-supported": ["is-unicode-supported@1.3.0", "", {}, "sha512-43r2mRvz+8JRIKnWJ+3j8JtjRKZ6GmjzfaE/qiBJnikNnYv/6bagRJ1kUhNk8R5EX/GkobD+r+sfxCPJsiKBLQ=="],
 
     "@browserbasehq/sdk/@types/node/undici-types": ["undici-types@5.26.5", "", {}, "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="],
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -31,6 +31,8 @@
     "@pickle-spec/web": "workspace:*",
     "@types/bun": "catalog:",
     "@typescript/typescript6": "catalog:",
+    "chalk": "5",
+    "ora": "8",
     "zod": "catalog:"
   },
   "devDependencies": {

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -14,7 +14,6 @@ import type {
   StudioAuthoringModel,
   StudioManagementGateway,
   StudioRunGateway,
-  StudioRunReadinessCheck,
 } from '@pickle-spec/studio'
 import { createCredentialStore, startStudio } from '@pickle-spec/studio'
 import {
@@ -33,6 +32,8 @@ import {
   initializeProject,
   migrateProject,
 } from './configuration/project'
+import { runDoctorCommand } from './doctor/doctor'
+import { diagnoseProjectEnvironment } from './doctor/project-environment'
 import { runCacheCommand } from './execution-cache/cache'
 import { requiredValue } from './required-value'
 import type { ApplicationOutputOptions } from './run/application-output'
@@ -63,6 +64,7 @@ import { createStudioExecutionCacheGateway } from './studio/studio-cache'
 import { createStudioHistoryGateway } from './studio/studio-history'
 import {
   discoverStudioMobileTargets,
+  studioMobileEnvironmentAdapterFactory,
   validateStudioMobileTargetCapabilities,
 } from './studio/studio-mobile-targets'
 import {
@@ -71,7 +73,7 @@ import {
   resolveConfigSecrets,
   saveStudioCredential,
   studioRunReadiness,
-  studioRunReadinessFromChecks,
+  studioRunReadinessWithEnvironment,
   studioRunSelection,
 } from './studio/studio-project'
 import { errorMessage, withRecoveryFailure } from './terminal/command-error'
@@ -751,46 +753,14 @@ function studioManagementGateway(
         config,
         specifications,
       )
-      if (!readiness.ready) return readiness
-      try {
-        const discoveries = await discoverStudioMobileTargets(
-          config,
-          undefined,
-          extensions.adapters,
-          request?.profiles,
-        )
-        validateStudioMobileTargetCapabilities(
-          config,
-          discoveries,
-          request?.profiles,
-        )
-        return withMobileReadiness(
-          readiness,
-          discoveries.length === 0
-            ? { id: 'mobile-target', status: 'not-applicable' }
-            : { id: 'mobile-target', status: 'ready' },
-        )
-      } catch (reason) {
-        const message =
-          reason instanceof Error ? reason.message : String(reason)
-        return withMobileReadiness(readiness, {
-          id: 'mobile-target',
-          status: 'blocked',
-          reasons: [message],
-        })
-      }
+      const environment = await diagnoseProjectEnvironment(config, {
+        profileIds: request?.profiles,
+        mobileAdapterFactory: (profileId) =>
+          studioMobileEnvironmentAdapterFactory(extensions.adapters, profileId),
+      })
+      return studioRunReadinessWithEnvironment(readiness, environment)
     },
   }
-}
-
-function withMobileReadiness(
-  readiness: Awaited<ReturnType<typeof studioRunReadiness>>,
-  mobileCheck: StudioRunReadinessCheck,
-) {
-  return studioRunReadinessFromChecks([
-    ...(readiness.checks ?? []).filter((check) => check.id !== 'mobile-target'),
-    mobileCheck,
-  ])
 }
 
 async function waitForStudioStop(
@@ -935,6 +905,8 @@ async function studio(argv: string[]): Promise<number> {
 }
 
 async function main(argv: string[]): Promise<number> {
+  const directCommand = directCommands[String(argv[0])]
+  if (directCommand) return directCommand(argv)
   if (argv[0] === 'init') {
     if (argv.length > 1) throw new Error('Usage: pickle init')
     await initializeProject()
@@ -942,9 +914,6 @@ async function main(argv: string[]): Promise<number> {
   }
   if (argv[0] === 'studio') {
     return studio(argv)
-  }
-  if (argv[0] === 'cache') {
-    return runCacheCommand(argv)
   }
   if (argv[0] === 'check') {
     await checkProject({ ...projectOptions(argv), report: console.log })
@@ -964,6 +933,13 @@ async function main(argv: string[]): Promise<number> {
     return exportRun(argv)
   }
   return run(argv)
+}
+
+const directCommands: Readonly<
+  Record<string, (argv: string[]) => Promise<number>>
+> = {
+  cache: runCacheCommand,
+  doctor: runDoctorCommand,
 }
 
 try {

--- a/packages/cli/src/doctor/doctor-output.test.ts
+++ b/packages/cli/src/doctor/doctor-output.test.ts
@@ -1,0 +1,46 @@
+import { expect, test } from 'bun:test'
+import { Writable } from 'node:stream'
+import { createDoctorProgress } from './doctor-output'
+
+function outputStream() {
+  let output = ''
+  const stream = new Writable({
+    write(chunk, _encoding, done) {
+      output += String(chunk)
+      done()
+    },
+  })
+  return { read: () => output, stream }
+}
+
+test('uses Ora for interactive progress', async () => {
+  const output = outputStream()
+  const progress = createDoctorProgress({
+    color: true,
+    enabled: true,
+    stream: output.stream,
+  })
+
+  progress.start('Checking project files')
+  progress.update('Checking configured environments')
+  await Bun.sleep(100)
+  progress.stop()
+
+  expect(output.read()).toContain('Checking project files')
+  expect(output.read()).toContain('Checking configured environments')
+})
+
+test('keeps Ora silent when terminal animation is unavailable', () => {
+  const output = outputStream()
+  const progress = createDoctorProgress({
+    color: false,
+    enabled: false,
+    stream: output.stream,
+  })
+
+  progress.start('Checking project files')
+  progress.update('Checking configured environments')
+  progress.stop()
+
+  expect(output.read()).toBe('')
+})

--- a/packages/cli/src/doctor/doctor-output.ts
+++ b/packages/cli/src/doctor/doctor-output.ts
@@ -1,0 +1,191 @@
+import { Chalk, type ChalkInstance } from 'chalk'
+import ora from 'ora'
+import type { ProjectEnvironmentReport } from './project-environment'
+
+export interface DoctorProgress {
+  start(label: string): void
+  update(label: string): void
+  stop(): void
+}
+
+interface DoctorProgressOptions {
+  color: boolean
+  enabled: boolean
+  stream?: NodeJS.WritableStream
+}
+
+export interface DoctorReportOptions {
+  color: boolean
+  verbose: boolean
+}
+
+type DoctorCheck =
+  | {
+      kind: 'passed'
+      title: string
+      detail: string
+      profileIds?: readonly string[]
+    }
+  | {
+      kind: 'failed'
+      title: string
+      detail: string
+      advice: readonly string[]
+      profileIds: readonly string[]
+    }
+  | {
+      kind: 'skipped'
+      title: string
+      detail: string
+    }
+
+const diagnosticTitles: Readonly<Record<string, string>> = {
+  'web.local-browser': 'Local browser',
+  'web.browserbase': 'Browserbase configuration',
+  'web.cdp': 'CDP configuration',
+  'mobile.android-emulator': 'Android Emulator',
+  'mobile.ios-simulator': 'iOS Simulator',
+}
+
+function checkWord(count: number): string {
+  return count === 1 ? 'check' : 'checks'
+}
+
+function issueWord(count: number): string {
+  return count === 1 ? 'issue' : 'issues'
+}
+
+function profileLabel(profileIds: readonly string[]): string {
+  const label = profileIds.length === 1 ? 'profile' : 'profiles'
+  return `[${label}: ${profileIds.join(', ')}]`
+}
+
+function diagnosticTitle(id: string): string {
+  return diagnosticTitles[id] ?? id
+}
+
+function doctorChecks(report: ProjectEnvironmentReport): DoctorCheck[] {
+  const checks: DoctorCheck[] = [
+    {
+      kind: 'passed',
+      title: 'Project files',
+      detail: 'Configuration, extensions, and Specifications are valid.',
+    },
+  ]
+  for (const item of report.diagnostics) {
+    const title = diagnosticTitle(item.diagnostic.id)
+    if (item.diagnostic.kind === 'ready') {
+      checks.push({
+        kind: 'passed',
+        title,
+        detail: item.diagnostic.message,
+        profileIds: item.profileIds,
+      })
+    } else {
+      checks.push({
+        kind: 'failed',
+        title,
+        detail: item.diagnostic.message,
+        advice: item.diagnostic.remediation.map(({ summary }) => summary),
+        profileIds: item.profileIds,
+      })
+    }
+  }
+  for (const profileId of report.uncheckedProfileIds) {
+    checks.push({
+      kind: 'skipped',
+      title: `Profile "${profileId}"`,
+      detail:
+        'Automatic environment checks are not available for this profile.',
+    })
+  }
+  return checks
+}
+
+function summaryLines(
+  checks: readonly DoctorCheck[],
+  options: DoctorReportOptions,
+): string[] {
+  const passed = checks.filter(({ kind }) => kind === 'passed').length
+  const failed = checks.filter(({ kind }) => kind === 'failed').length
+  const skipped = checks.filter(({ kind }) => kind === 'skipped').length
+  const checked = passed + failed
+  const lines = [
+    failed > 0
+      ? `${passed}/${checked} ${checkWord(checked)} passed. ${failed} ${checkWord(failed)} failed. Possible ${issueWord(failed)} detected:`
+      : `${passed}/${checked} ${checkWord(checked)} passed. No issues detected.`,
+  ]
+  if (skipped > 0) {
+    lines.push(
+      `${skipped} automatic ${checkWord(skipped)} skipped because no probe is available.`,
+    )
+  }
+  if (!options.verbose && passed > 0) {
+    lines.push('Use the --verbose flag to see details about passed checks.')
+  }
+  return lines
+}
+
+function checkLines(
+  check: DoctorCheck,
+  options: DoctorReportOptions,
+  chalk: ChalkInstance,
+): string[] {
+  if (check.kind === 'passed') {
+    if (!options.verbose) return []
+    const profiles = check.profileIds
+      ? ` ${profileLabel(check.profileIds)}`
+      : ''
+    return [
+      `${chalk.green('✔')} ${check.title}${profiles}`,
+      `  ${check.detail}`,
+    ]
+  }
+  if (check.kind === 'skipped') {
+    return [`${chalk.yellow('○')} ${check.title}`, `  ${check.detail}`]
+  }
+  const lines = [
+    `${chalk.red('✖')} ${check.title} ${profileLabel(check.profileIds)}`,
+    `  ${check.detail}`,
+    chalk.yellow('Advice:'),
+  ]
+  for (const advice of check.advice) lines.push(`  ${advice}`)
+  return lines
+}
+
+export function formatDoctorReport(
+  report: ProjectEnvironmentReport,
+  options: DoctorReportOptions = { color: false, verbose: false },
+): string[] {
+  const checks = doctorChecks(report)
+  const chalk = new Chalk({ level: options.color ? 1 : 0 })
+  const details = checks.flatMap((check) => checkLines(check, options, chalk))
+  return [
+    ...summaryLines(checks, options),
+    ...(details.length ? ['', ...details] : []),
+  ]
+}
+
+export function createDoctorProgress(
+  options: DoctorProgressOptions,
+): DoctorProgress {
+  const spinner = ora({
+    color: options.color ? 'cyan' : false,
+    discardStdin: false,
+    isEnabled: options.enabled,
+    isSilent: !options.enabled,
+    stream: options.stream ?? process.stderr,
+  })
+
+  return {
+    start(label) {
+      spinner.start(label)
+    },
+    update(label) {
+      spinner.text = label
+    },
+    stop() {
+      spinner.stop()
+    },
+  }
+}

--- a/packages/cli/src/doctor/doctor.test.ts
+++ b/packages/cli/src/doctor/doctor.test.ts
@@ -1,0 +1,192 @@
+import { expect, test } from 'bun:test'
+import type { PickleConfig } from '../configuration/config'
+import {
+  formatDoctorReport,
+  parseDoctorArguments,
+  runDoctorCommand,
+} from './doctor'
+
+const customConfig: PickleConfig = {
+  schemaVersion: 1,
+  executionTargetProfiles: {
+    custom: { adapter: 'company-device-lab' },
+  },
+}
+
+const silentProgress = {
+  start() {},
+  update() {},
+  stop() {},
+}
+
+test('parses only Doctor project options', () => {
+  expect(
+    parseDoctorArguments([
+      'doctor',
+      '--config',
+      'custom.jsonc',
+      '--extensions',
+      'extensions.ts',
+    ]),
+  ).toEqual({
+    configPath: 'custom.jsonc',
+    extensionsPath: 'extensions.ts',
+    verbose: false,
+  })
+  expect(parseDoctorArguments(['doctor', '--verbose'])).toEqual({
+    verbose: true,
+  })
+  expect(() => parseDoctorArguments(['doctor', '--profile', 'chrome'])).toThrow(
+    'Usage: pickle doctor [--config <path>] [--extensions <path>] [--verbose]',
+  )
+})
+
+test('validates statically before diagnosing and reports unchecked custom adapters', async () => {
+  const calls: string[] = []
+  const output: string[] = []
+  const exitCode = await runDoctorCommand(['doctor'], {
+    cwd: '/project',
+    async check() {
+      calls.push('check')
+    },
+    async load() {
+      calls.push('load')
+      return customConfig
+    },
+    async diagnose() {
+      calls.push('diagnose')
+      return {
+        ready: true,
+        diagnostics: [],
+        uncheckedProfileIds: ['custom'],
+      }
+    },
+    color: false,
+    progress: {
+      start() {
+        calls.push('progress:start')
+      },
+      update() {
+        calls.push('progress:update')
+      },
+      stop() {
+        calls.push('progress:stop')
+      },
+    },
+    report(message) {
+      output.push(message)
+    },
+  })
+
+  expect(exitCode).toBe(0)
+  expect(calls).toEqual([
+    'progress:start',
+    'check',
+    'load',
+    'progress:update',
+    'diagnose',
+    'progress:stop',
+  ])
+  expect(output).toEqual([
+    '1/1 check passed. No issues detected.',
+    '1 automatic check skipped because no probe is available.',
+    'Use the --verbose flag to see details about passed checks.',
+    '',
+    '○ Profile "custom"',
+    '  Automatic environment checks are not available for this profile.',
+  ])
+})
+
+test('renders remediation and returns 2 for blocked environments', async () => {
+  const report = {
+    ready: false,
+    diagnostics: [
+      {
+        profileIds: ['android'],
+        diagnostic: {
+          id: 'mobile.android-emulator',
+          kind: 'blocked' as const,
+          message: 'Android Emulator is not ready',
+          remediation: [{ summary: 'Boot an Android Emulator' }] as const,
+        },
+      },
+    ],
+    uncheckedProfileIds: [],
+  }
+  const output: string[] = []
+  const exitCode = await runDoctorCommand(['doctor'], {
+    cwd: '/project',
+    async check() {},
+    async load() {
+      return customConfig
+    },
+    async diagnose() {
+      return report
+    },
+    color: false,
+    progress: silentProgress,
+    report(message) {
+      output.push(message)
+    },
+  })
+
+  expect(exitCode).toBe(2)
+  expect(output).toEqual(formatDoctorReport(report))
+  expect(output).toContain('Advice:')
+  expect(output).toContain('  Boot an Android Emulator')
+})
+
+test('shows passed checks and semantic colors only when requested', () => {
+  const report = {
+    ready: true,
+    diagnostics: [
+      {
+        profileIds: ['web'],
+        diagnostic: {
+          id: 'web.local-browser',
+          kind: 'ready' as const,
+          message: 'Local Chrome launched and closed successfully',
+        },
+      },
+    ],
+    uncheckedProfileIds: [],
+  }
+
+  expect(formatDoctorReport(report)).toEqual([
+    '2/2 checks passed. No issues detected.',
+    'Use the --verbose flag to see details about passed checks.',
+  ])
+  const verbose = formatDoctorReport(report, { color: true, verbose: true })
+  expect(verbose.join('\n')).toContain('\u001b[32m✔\u001b[39m Local browser')
+  expect(verbose.join('\n')).toContain('[profile: web]')
+  expect(verbose.join('\n')).not.toContain('--verbose')
+})
+
+test('stops terminal progress when project validation fails', async () => {
+  let stopped = false
+
+  await expect(
+    runDoctorCommand(['doctor'], {
+      cwd: '/project',
+      async check() {
+        throw new Error('Invalid project')
+      },
+      async load() {
+        return customConfig
+      },
+      async diagnose() {
+        throw new Error('Environment checks must not run')
+      },
+      color: false,
+      progress: {
+        start() {},
+        update() {},
+        stop() {
+          stopped = true
+        },
+      },
+      report() {},
+    }),
+  ).rejects.toThrow('Invalid project')
+  expect(stopped).toBe(true)
+})

--- a/packages/cli/src/doctor/doctor.ts
+++ b/packages/cli/src/doctor/doctor.ts
@@ -1,0 +1,117 @@
+import { loadConfig, type PickleConfig } from '../configuration/config'
+import { checkProject } from '../configuration/project'
+import { terminalReporterCapabilities } from '../run/run-reporter'
+import {
+  createDoctorProgress,
+  type DoctorProgress,
+  formatDoctorReport,
+} from './doctor-output'
+import {
+  diagnoseProjectEnvironment,
+  type ProjectEnvironmentReport,
+} from './project-environment'
+
+const usage =
+  'Usage: pickle doctor [--config <path>] [--extensions <path>] [--verbose]'
+
+interface DoctorArguments {
+  configPath?: string
+  extensionsPath?: string
+  verbose: boolean
+}
+
+interface DoctorDependencies {
+  cwd: string
+  check(input: {
+    cwd: string
+    configPath?: string
+    extensionsPath?: string
+  }): Promise<void>
+  load(configPath: string | undefined, cwd: string): Promise<PickleConfig>
+  diagnose(config: PickleConfig): Promise<ProjectEnvironmentReport>
+  color: boolean
+  progress: DoctorProgress
+  report(message: string): void
+}
+
+const terminalCapabilities = terminalReporterCapabilities(
+  process.stdout.isTTY,
+  process.stdout.columns,
+  process.env.NO_COLOR,
+  process.env.TERM,
+)
+const progressTerminalCapabilities = terminalReporterCapabilities(
+  process.stderr.isTTY,
+  process.stderr.columns,
+  process.env.NO_COLOR,
+  process.env.TERM,
+)
+
+const defaultDependencies: DoctorDependencies = {
+  cwd: process.cwd(),
+  check: checkProject,
+  load: loadConfig,
+  diagnose: diagnoseProjectEnvironment,
+  color: terminalCapabilities.color ?? false,
+  progress: createDoctorProgress({
+    color: progressTerminalCapabilities.color ?? false,
+    enabled:
+      (progressTerminalCapabilities.interactive ?? false) &&
+      (process.stderr.columns ?? 0) > 0,
+  }),
+  report: console.log,
+}
+
+function optionValue(argv: readonly string[], index: number): string {
+  const value = argv[index + 1]
+  if (!value || value.startsWith('--')) throw new Error(usage)
+  return value
+}
+
+export function parseDoctorArguments(argv: readonly string[]): DoctorArguments {
+  if (argv[0] !== 'doctor') throw new Error(usage)
+  const args: DoctorArguments = { verbose: false }
+  for (let index = 1; index < argv.length; index++) {
+    const option = argv[index]
+    if (option === '--config') {
+      args.configPath = optionValue(argv, index++)
+    } else if (option === '--extensions') {
+      args.extensionsPath = optionValue(argv, index++)
+    } else if (option === '--verbose') {
+      args.verbose = true
+    } else {
+      throw new Error(usage)
+    }
+  }
+  return args
+}
+
+export async function runDoctorCommand(
+  argv: readonly string[],
+  dependencies: DoctorDependencies = defaultDependencies,
+): Promise<number> {
+  const args = parseDoctorArguments(argv)
+  let report: ProjectEnvironmentReport
+  dependencies.progress.start('Checking project files')
+  try {
+    await dependencies.check({
+      cwd: dependencies.cwd,
+      configPath: args.configPath,
+      extensionsPath: args.extensionsPath,
+    })
+    const config = await dependencies.load(args.configPath, dependencies.cwd)
+    dependencies.progress.update('Checking configured environments')
+    report = await dependencies.diagnose(config)
+  } finally {
+    dependencies.progress.stop()
+  }
+  for (const line of formatDoctorReport(report, {
+    color: dependencies.color,
+    verbose: args.verbose,
+  })) {
+    dependencies.report(line)
+  }
+  return report.ready ? 0 : 2
+}
+
+export { formatDoctorReport } from './doctor-output'

--- a/packages/cli/src/doctor/project-environment.test.ts
+++ b/packages/cli/src/doctor/project-environment.test.ts
@@ -1,0 +1,103 @@
+import { expect, mock, test } from 'bun:test'
+import type { PickleConfig } from '../configuration/config'
+import {
+  diagnoseProjectEnvironment,
+  type ProjectEnvironmentProbeFunctions,
+  planProjectEnvironment,
+} from './project-environment'
+
+const config: PickleConfig = {
+  schemaVersion: 1,
+  executionTargetProfiles: {
+    chrome: {
+      adapter: 'web',
+      web: { baseUrl: 'https://one.example.test' },
+    },
+    edge: {
+      adapter: 'web',
+      web: { baseUrl: 'https://two.example.test' },
+    },
+    android: {
+      adapter: 'mobile',
+      capabilities: ['android'],
+      mobile: {
+        executionTarget: 'android-emulator',
+        application: {
+          id: 'com.example.checkout',
+          binaryPath: '/apps/checkout.apk',
+        },
+      },
+    },
+    custom: { adapter: 'company-device-lab' },
+  },
+}
+
+test('plans configured built-ins and deduplicates equivalent local browsers', () => {
+  const plan = planProjectEnvironment(config)
+
+  expect(plan.probes).toHaveLength(2)
+  expect(plan.probes[0]).toMatchObject({
+    kind: 'web',
+    profileIds: ['chrome', 'edge'],
+  })
+  expect(plan.probes[1]).toMatchObject({
+    kind: 'mobile',
+    profileIds: ['android'],
+  })
+  expect(plan.uncheckedProfileIds).toEqual(['custom'])
+})
+
+test('leaves incomplete built-in environments unchecked', () => {
+  const plan = planProjectEnvironment({
+    schemaVersion: 1,
+    executionTargetProfiles: {
+      web: { adapter: 'web' },
+      mobile: { adapter: 'mobile' },
+    },
+  })
+
+  expect(plan).toEqual({
+    probes: [],
+    uncheckedProfileIds: ['web', 'mobile'],
+  })
+})
+
+test('aggregates adapter diagnostics with profile ownership', async () => {
+  const web = mock(async () => ({
+    id: 'web.local-browser',
+    kind: 'ready' as const,
+    message: 'browser ready',
+  }))
+  const mobile = mock(async () => ({
+    id: 'mobile.android-emulator',
+    kind: 'blocked' as const,
+    message: 'emulator missing',
+    remediation: [{ summary: 'Boot an Emulator' }] as const,
+  }))
+  const probes: ProjectEnvironmentProbeFunctions = { web, mobile }
+
+  const report = await diagnoseProjectEnvironment(config, { probes })
+
+  expect(web).toHaveBeenCalledTimes(1)
+  expect(mobile).toHaveBeenCalledTimes(1)
+  expect(report.ready).toBe(false)
+  expect(report.diagnostics).toEqual([
+    {
+      profileIds: ['chrome', 'edge'],
+      diagnostic: {
+        id: 'web.local-browser',
+        kind: 'ready',
+        message: 'browser ready',
+      },
+    },
+    {
+      profileIds: ['android'],
+      diagnostic: {
+        id: 'mobile.android-emulator',
+        kind: 'blocked',
+        message: 'emulator missing',
+        remediation: [{ summary: 'Boot an Emulator' }],
+      },
+    },
+  ])
+})

--- a/packages/cli/src/doctor/project-environment.ts
+++ b/packages/cli/src/doctor/project-environment.ts
@@ -1,0 +1,203 @@
+import {
+  type DiagnoseMobileEnvironmentInput,
+  diagnoseMobileEnvironment,
+  type MobileEnvironmentAdapterFactory,
+} from '@pickle-spec/mobile'
+import type { EnvironmentDiagnostic } from '@pickle-spec/runner'
+import {
+  diagnoseWebEnvironment,
+  type WebAdapterOptions,
+  webEnvironmentProbeKey,
+} from '@pickle-spec/web'
+import type {
+  PickleConfig,
+  ProjectExecutionTargetProfile,
+} from '../configuration/config'
+
+type ProfileIdList = [string, ...string[]]
+
+type UncheckedProfile = {
+  kind: 'unchecked'
+  profileId: string
+}
+
+export type EnvironmentProbe =
+  | {
+      key: string
+      kind: 'web'
+      profileIds: ProfileIdList
+      options: WebAdapterOptions
+    }
+  | {
+      key: string
+      kind: 'mobile'
+      profileIds: ProfileIdList
+      input: DiagnoseMobileEnvironmentInput
+    }
+
+export interface ProjectEnvironmentPlan {
+  probes: readonly EnvironmentProbe[]
+  uncheckedProfileIds: readonly string[]
+}
+
+export interface ProfileEnvironmentDiagnostic {
+  profileIds: readonly string[]
+  diagnostic: EnvironmentDiagnostic
+}
+
+export interface ProjectEnvironmentReport {
+  ready: boolean
+  diagnostics: readonly ProfileEnvironmentDiagnostic[]
+  uncheckedProfileIds: readonly string[]
+}
+
+export interface ProjectEnvironmentProbeFunctions {
+  web: typeof diagnoseWebEnvironment
+  mobile: typeof diagnoseMobileEnvironment
+}
+
+export interface DiagnoseProjectEnvironmentOptions {
+  profileIds?: readonly string[]
+  probes?: ProjectEnvironmentProbeFunctions
+  mobileAdapterFactory?: (
+    profileId: string,
+  ) => MobileEnvironmentAdapterFactory | undefined
+}
+
+const defaultProbeFunctions: ProjectEnvironmentProbeFunctions = {
+  web: diagnoseWebEnvironment,
+  mobile: diagnoseMobileEnvironment,
+}
+
+interface ConfiguredProfile {
+  id: string
+  profile: ProjectExecutionTargetProfile
+}
+
+function configuredProfiles(config: PickleConfig): ConfiguredProfile[] {
+  if (config.executionTargetProfiles) {
+    return Object.entries(config.executionTargetProfiles).map(
+      ([id, profile]) => ({ id, profile }),
+    )
+  }
+  const configured = config.executionTargetProfile
+  const adapter = configured?.adapter ?? (config.web ? 'web' : 'custom')
+  return [
+    {
+      id: configured?.id ?? (config.web ? 'web' : 'custom'),
+      profile: { adapter },
+    },
+  ]
+}
+
+function selectedProfiles(
+  config: PickleConfig,
+  profileIds?: readonly string[],
+): ConfiguredProfile[] {
+  const profiles = configuredProfiles(config)
+  if (!profileIds?.length) return profiles
+  const selected = new Set(profileIds)
+  return profiles.filter(({ id }) => selected.has(id))
+}
+
+function webProbe(
+  config: PickleConfig,
+  profileId: string,
+  profile: ProjectExecutionTargetProfile,
+): EnvironmentProbe | undefined {
+  const options = profile.web ?? config.web
+  if (!options) return
+  return {
+    key: `web:${webEnvironmentProbeKey(options)}`,
+    kind: 'web',
+    profileIds: [profileId],
+    options,
+  }
+}
+
+function mobileProbe(
+  profileId: string,
+  profile: ProjectExecutionTargetProfile,
+): EnvironmentProbe | undefined {
+  if (!profile.mobile) return
+  const requiredCapabilities = [...(profile.capabilities ?? [])].sort()
+  const { executionTarget, nodePath, targetId } = profile.mobile
+  return {
+    key: `mobile:${profileId}:${executionTarget}:${nodePath ?? ''}:${targetId ?? ''}:${requiredCapabilities.join(',')}`,
+    kind: 'mobile',
+    profileIds: [profileId],
+    input: { options: profile.mobile, requiredCapabilities },
+  }
+}
+
+function addProbe(
+  probes: Map<string, EnvironmentProbe>,
+  probe: EnvironmentProbe,
+): void {
+  const existing = probes.get(probe.key)
+  if (!existing) {
+    probes.set(probe.key, probe)
+    return
+  }
+  existing.profileIds.push(...probe.profileIds)
+}
+
+function planProfile(
+  config: PickleConfig,
+  configured: ConfiguredProfile,
+): EnvironmentProbe | UncheckedProfile | undefined {
+  const { id, profile } = configured
+  if (profile.adapter === 'web') {
+    return webProbe(config, id, profile) ?? { kind: 'unchecked', profileId: id }
+  }
+  if (profile.adapter === 'mobile') {
+    return mobileProbe(id, profile) ?? { kind: 'unchecked', profileId: id }
+  }
+  return { kind: 'unchecked', profileId: id }
+}
+
+export function planProjectEnvironment(
+  config: PickleConfig,
+  profileIds?: readonly string[],
+): ProjectEnvironmentPlan {
+  const probes = new Map<string, EnvironmentProbe>()
+  const uncheckedProfileIds: string[] = []
+  for (const configured of selectedProfiles(config, profileIds)) {
+    const item = planProfile(config, configured)
+    if (!item) continue
+    if (item.kind === 'unchecked') uncheckedProfileIds.push(item.profileId)
+    else addProbe(probes, item)
+  }
+  return { probes: [...probes.values()], uncheckedProfileIds }
+}
+
+async function runProbe(
+  probe: EnvironmentProbe,
+  functions: ProjectEnvironmentProbeFunctions,
+  options: DiagnoseProjectEnvironmentOptions,
+): Promise<ProfileEnvironmentDiagnostic> {
+  const diagnostic =
+    probe.kind === 'web'
+      ? await functions.web(probe.options)
+      : await functions.mobile(
+          probe.input,
+          options.mobileAdapterFactory?.(probe.profileIds[0]),
+        )
+  return { profileIds: probe.profileIds, diagnostic }
+}
+
+export async function diagnoseProjectEnvironment(
+  config: PickleConfig,
+  options: DiagnoseProjectEnvironmentOptions = {},
+): Promise<ProjectEnvironmentReport> {
+  const plan = planProjectEnvironment(config, options.profileIds)
+  const functions = options.probes ?? defaultProbeFunctions
+  const diagnostics = await Promise.all(
+    plan.probes.map((probe) => runProbe(probe, functions, options)),
+  )
+  return {
+    ready: diagnostics.every(({ diagnostic }) => diagnostic.kind === 'ready'),
+    diagnostics,
+    uncheckedProfileIds: plan.uncheckedProfileIds,
+  }
+}

--- a/packages/cli/src/studio/studio-mobile-targets.test.ts
+++ b/packages/cli/src/studio/studio-mobile-targets.test.ts
@@ -7,6 +7,7 @@ import type { PickleConfig } from '../configuration/config'
 import { requiredValue } from '../required-value'
 import {
   discoverStudioMobileTargets,
+  studioMobileEnvironmentAdapterFactory,
   validateStudioMobileTargetCapabilities,
 } from './studio-mobile-targets'
 
@@ -209,6 +210,21 @@ test('does not dispose a shared extension adapter after discovery', async () => 
       mobile: adapterNameFallback,
     },
   )
+
+  const environmentFactory = requiredValue(
+    studioMobileEnvironmentAdapterFactory(
+      { android: sharedAdapter, mobile: adapterNameFallback },
+      'android',
+    ),
+  )
+  const environmentAdapter = environmentFactory(
+    requiredValue(
+      requiredValue(requiredValue(androidOnly.executionTargetProfiles).android)
+        .mobile,
+    ),
+  )
+  await environmentAdapter.discoverTargets()
+  await environmentAdapter.dispose?.()
 
   expect(disposed).toBe(false)
 })

--- a/packages/cli/src/studio/studio-mobile-targets.ts
+++ b/packages/cli/src/studio/studio-mobile-targets.ts
@@ -1,6 +1,7 @@
 import {
   createMobileAdapter,
   type MobileAdapterOptions,
+  type MobileEnvironmentAdapterFactory,
   type MobileExecutionTargetAdapter,
 } from '@pickle-spec/mobile'
 import type { ExecutionTargetAdapter } from '@pickle-spec/runner'
@@ -28,6 +29,27 @@ function discoverableMobileAdapter(
   throw new Error(
     `Execution target profile "${profileId}" does not support mobile target discovery`,
   )
+}
+
+export function studioMobileEnvironmentAdapterFactory(
+  extensionAdapters:
+    | Readonly<Record<string, ExecutionTargetAdapter>>
+    | undefined,
+  profileId: string,
+): MobileEnvironmentAdapterFactory | undefined {
+  const adapter = extensionAdapters?.[profileId] ?? extensionAdapters?.mobile
+  if (!adapter) return
+  return () => {
+    const mobileAdapter = discoverableMobileAdapter(adapter, profileId)
+    if (!mobileAdapter) {
+      throw new Error(
+        `Execution target profile "${profileId}" has no mobile adapter`,
+      )
+    }
+    return {
+      discoverTargets: () => mobileAdapter.discoverTargets(),
+    }
+  }
 }
 
 function errorMessage(reason: unknown): string {

--- a/packages/cli/src/studio/studio-project.test.ts
+++ b/packages/cli/src/studio/studio-project.test.ts
@@ -2,7 +2,10 @@ import { expect, test } from 'bun:test'
 import { parseSpecification } from '@pickle-spec/spec'
 import type { CredentialStore } from '@pickle-spec/studio'
 import type { PickleConfig } from '../configuration/config'
-import { studioRunReadiness } from './studio-project'
+import {
+  studioRunReadiness,
+  studioRunReadinessWithEnvironment,
+} from './studio-project'
 
 const credentials: CredentialStore = {
   async get() {},
@@ -49,7 +52,7 @@ test('derives aggregate readiness from structured checks', async () => {
     ['selection', 'ready'],
     ['execution-target', 'blocked'],
     ['model-credential', 'not-applicable'],
-    ['mobile-target', 'not-applicable'],
+    ['environment', 'not-applicable'],
   ])
   const blockedReasons = (readiness.checks ?? []).flatMap((check) =>
     check.status === 'blocked' ? check.reasons : [],
@@ -80,4 +83,39 @@ test('validates only the durable scenarioId while preserving scenarioName select
 
   expect(exactReadiness.ready).toBe(true)
   expect(namedReadiness.ready).toBe(false)
+})
+
+test('maps blocked environment diagnostics into actionable Studio readiness', async () => {
+  const readiness = await studioRunReadiness(
+    { root: '/project', credentials },
+    { paths: [specification.source.uri], scenarioId: 'scnreadybbbbbbbbb' },
+    config,
+    [specification],
+  )
+
+  const mapped = studioRunReadinessWithEnvironment(readiness, {
+    ready: false,
+    diagnostics: [
+      {
+        profileIds: ['android'],
+        diagnostic: {
+          id: 'mobile.android-emulator',
+          kind: 'blocked',
+          message: 'Android Emulator is not ready',
+          remediation: [{ summary: 'Boot an Android Emulator' }],
+        },
+      },
+    ],
+    uncheckedProfileIds: [],
+  })
+
+  expect(mapped.ready).toBe(false)
+  expect(mapped.checks?.at(-1)).toEqual({
+    id: 'environment',
+    status: 'blocked',
+    reasons: ['Android Emulator is not ready. Boot an Android Emulator'],
+  })
+  expect(mapped.reasons).toContain(
+    'Android Emulator is not ready. Boot an Android Emulator',
+  )
 })

--- a/packages/cli/src/studio/studio-project.ts
+++ b/packages/cli/src/studio/studio-project.ts
@@ -29,6 +29,7 @@ import {
   runConfigurationFrom,
   saveConfig,
 } from '../configuration/config'
+import type { ProjectEnvironmentReport } from '../doctor/project-environment'
 import {
   loadProjectSpecifications,
   scenarioSelectionId,
@@ -278,6 +279,42 @@ export function studioRunReadinessFromChecks(
   return { ready: reasons.length === 0, reasons, checks }
 }
 
+function environmentReason(
+  diagnostic: Extract<
+    ProjectEnvironmentReport['diagnostics'][number]['diagnostic'],
+    { kind: 'blocked' }
+  >,
+): string {
+  const remediation = diagnostic.remediation
+    .map((item) => item.summary)
+    .join(' ')
+  return `${diagnostic.message}. ${remediation}`
+}
+
+export function studioRunReadinessWithEnvironment(
+  readiness: StudioRunReadiness,
+  report: ProjectEnvironmentReport,
+): StudioRunReadiness {
+  const reasons = report.diagnostics.flatMap(({ diagnostic }) =>
+    diagnostic.kind === 'blocked' ? [environmentReason(diagnostic)] : [],
+  )
+  const firstReason = reasons[0]
+  const environmentCheck: StudioRunReadinessCheck = firstReason
+    ? {
+        id: 'environment',
+        status: 'blocked',
+        reasons: [firstReason, ...reasons.slice(1)],
+      }
+    : {
+        id: 'environment',
+        status: report.diagnostics.length > 0 ? 'ready' : 'not-applicable',
+      }
+  return studioRunReadinessFromChecks([
+    ...(readiness.checks ?? []).filter((check) => check.id !== 'environment'),
+    environmentCheck,
+  ])
+}
+
 export async function studioRunReadiness(
   context: StudioProjectContext,
   request: StudioRunRequest | undefined,
@@ -319,7 +356,7 @@ export async function studioRunReadiness(
     readinessCheck('selection', selectionReasons),
     readinessCheck('execution-target', targetReasons),
     readinessCheck('model-credential', credentialReasons, usesWeb),
-    readinessCheck('mobile-target', [], false),
+    readinessCheck('environment', [], false),
   ])
 }
 

--- a/packages/cli/src/workspace/workspace.test.ts
+++ b/packages/cli/src/workspace/workspace.test.ts
@@ -418,6 +418,43 @@ export default {}
     expect(await Bun.file(marker).exists()).toBe(false)
   })
 
+  test('doctor validates custom extensions statically without evaluating them', async () => {
+    const projectName = 'side-effect-free-doctor'
+    const projectPath = join(workspace, projectName)
+    const marker = join(projectPath, 'extension-evaluated.txt')
+    const project = await createCheckProject(projectName, {
+      config: {
+        schemaVersion: 1,
+        specifications: 'features/**/*.feature',
+        executionTargetProfile: { id: 'custom' },
+      },
+      specification: validSpecification,
+      extensions: `
+await Bun.write(${JSON.stringify(marker)}, 'executed')
+export default {
+  adapter: {
+    async openSession() {
+      throw new Error('Doctor must not open a custom adapter')
+    },
+  },
+}
+`,
+    })
+
+    const doctor = Bun.spawnSync({
+      cmd: [pickleCommand, 'doctor'],
+      cwd: project,
+      env: { ...Bun.env },
+    })
+
+    expect(doctor.exitCode).toBe(0)
+    expect(doctor.stderr.toString()).toBe('')
+    expect(doctor.stdout.toString()).toContain(
+      'Automatic environment checks are not available for this profile.',
+    )
+    expect(await Bun.file(marker).exists()).toBe(false)
+  })
+
   test('check rejects invalid imported bindings without evaluating extension code', async () => {
     const projectName = 'invalid-extension-binding'
     const projectPath = join(workspace, projectName)

--- a/packages/mobile/index.ts
+++ b/packages/mobile/index.ts
@@ -15,3 +15,8 @@ export {
   createMobileAdapter,
   iosCapabilities,
 } from './src/adapter/mobile-adapter'
+export type {
+  DiagnoseMobileEnvironmentInput,
+  MobileEnvironmentAdapterFactory,
+} from './src/adapter/mobile-environment'
+export { diagnoseMobileEnvironment } from './src/adapter/mobile-environment'

--- a/packages/mobile/src/adapter/mobile-environment.test.ts
+++ b/packages/mobile/src/adapter/mobile-environment.test.ts
@@ -1,0 +1,91 @@
+import { expect, mock, test } from 'bun:test'
+import {
+  diagnoseMobileEnvironment,
+  type MobileEnvironmentAdapterFactory,
+} from '../../index'
+
+const androidOptions = {
+  executionTarget: 'android-emulator' as const,
+  application: {
+    id: 'com.example.checkout',
+    binaryPath: '/apps/checkout.apk',
+  },
+}
+
+test('discovers a booted Android Emulator and disposes the adapter', async () => {
+  const dispose = mock(async () => {})
+  const createAdapter: MobileEnvironmentAdapterFactory = () => ({
+    async discoverTargets() {
+      return [
+        {
+          id: 'emulator-5554',
+          name: 'Pixel 9',
+          state: 'booted',
+          capabilities: ['android', 'android-emulator'],
+        },
+      ]
+    },
+    dispose,
+  })
+
+  await expect(
+    diagnoseMobileEnvironment(
+      { options: androidOptions, requiredCapabilities: ['android'] },
+      createAdapter,
+    ),
+  ).resolves.toEqual({
+    id: 'mobile.android-emulator',
+    kind: 'ready',
+    message: 'Android Emulator target "Pixel 9" is booted and ready',
+  })
+  expect(dispose).toHaveBeenCalledTimes(1)
+})
+
+test('returns Android setup remediation when discovery fails', async () => {
+  const diagnostic = await diagnoseMobileEnvironment(
+    { options: androidOptions },
+    () => ({
+      async discoverTargets() {
+        throw new Error('adb was not found')
+      },
+    }),
+  )
+
+  expect(diagnostic).toMatchObject({
+    id: 'mobile.android-emulator',
+    kind: 'blocked',
+    message: 'Android Emulator is not ready: adb was not found',
+  })
+  expect(
+    diagnostic.kind === 'blocked' && diagnostic.remediation[0].summary,
+  ).toContain('Install Android Studio and the Android SDK')
+})
+
+test('returns iOS setup remediation when no Simulator is booted', async () => {
+  const diagnostic = await diagnoseMobileEnvironment(
+    {
+      options: {
+        executionTarget: 'ios-simulator',
+        application: {
+          id: 'com.example.checkout',
+          binaryPath: '/apps/Checkout.app',
+        },
+      },
+    },
+    () => ({
+      async discoverTargets() {
+        return []
+      },
+    }),
+  )
+
+  expect(diagnostic).toMatchObject({
+    id: 'mobile.ios-simulator',
+    kind: 'blocked',
+    message:
+      'iOS Simulator is not ready: no compatible booted target was found',
+  })
+  expect(
+    diagnostic.kind === 'blocked' && diagnostic.remediation[0].summary,
+  ).toContain('install Xcode and its Command Line Tools')
+})

--- a/packages/mobile/src/adapter/mobile-environment.ts
+++ b/packages/mobile/src/adapter/mobile-environment.ts
@@ -1,0 +1,119 @@
+import type { EnvironmentDiagnostic } from '@pickle-spec/runner'
+import {
+  createMobileAdapter,
+  type MobileAdapterOptions,
+  type MobileExecutionTargetAdapter,
+} from './mobile-adapter'
+
+type EnvironmentAdapter = Pick<
+  MobileExecutionTargetAdapter,
+  'discoverTargets' | 'dispose'
+>
+
+export type MobileEnvironmentAdapterFactory = (
+  options: MobileAdapterOptions,
+) => EnvironmentAdapter
+
+export interface DiagnoseMobileEnvironmentInput {
+  options: MobileAdapterOptions
+  requiredCapabilities?: readonly string[]
+}
+
+const defaultAdapterFactory: MobileEnvironmentAdapterFactory = (options) =>
+  createMobileAdapter(options)
+
+function platformDetails(options: MobileAdapterOptions) {
+  if (options.executionTarget === 'ios-simulator') {
+    return {
+      id: 'mobile.ios-simulator',
+      name: 'iOS Simulator',
+      remediation:
+        'Use macOS, install Xcode and its Command Line Tools, boot an iOS Simulator, and ensure Node 22.12 or newer is available.',
+    }
+  }
+  return {
+    id: 'mobile.android-emulator',
+    name: 'Android Emulator',
+    remediation:
+      'Install Android Studio and the Android SDK, add adb to PATH, boot an Android Emulator, and ensure Node 22.12 or newer is available.',
+  }
+}
+
+function blockedEnvironment(
+  input: DiagnoseMobileEnvironmentInput,
+  reason: string,
+): EnvironmentDiagnostic {
+  const platform = platformDetails(input.options)
+  return {
+    id: platform.id,
+    kind: 'blocked',
+    message: `${platform.name} is not ready: ${reason}`,
+    remediation: [
+      {
+        summary: `${platform.remediation} Then run pickle doctor again.`,
+      },
+    ],
+  }
+}
+
+function selectedTarget(
+  targets: Awaited<ReturnType<EnvironmentAdapter['discoverTargets']>>,
+  targetId: string | undefined,
+) {
+  return targets.find(
+    (target) =>
+      target.state === 'booted' &&
+      (targetId === undefined || target.id === targetId),
+  )
+}
+
+function targetDiagnostic(
+  input: DiagnoseMobileEnvironmentInput,
+  targets: Awaited<ReturnType<EnvironmentAdapter['discoverTargets']>>,
+): EnvironmentDiagnostic {
+  const target = selectedTarget(targets, input.options.targetId)
+  if (!target) {
+    const reason = input.options.targetId
+      ? `booted target "${input.options.targetId}" was not found`
+      : 'no compatible booted target was found'
+    return blockedEnvironment(input, reason)
+  }
+  const available = new Set(target.capabilities)
+  const missing = (input.requiredCapabilities ?? []).filter(
+    (capability) => !available.has(capability),
+  )
+  if (missing.length > 0) {
+    return blockedEnvironment(
+      input,
+      `target "${target.name}" lacks configured capabilities: ${missing.join(', ')}`,
+    )
+  }
+  const platform = platformDetails(input.options)
+  return {
+    id: platform.id,
+    kind: 'ready',
+    message: `${platform.name} target "${target.name}" is booted and ready`,
+  }
+}
+
+export async function diagnoseMobileEnvironment(
+  input: DiagnoseMobileEnvironmentInput,
+  createAdapter: MobileEnvironmentAdapterFactory = defaultAdapterFactory,
+): Promise<EnvironmentDiagnostic> {
+  let adapter: EnvironmentAdapter | undefined
+  let diagnostic: EnvironmentDiagnostic
+  try {
+    adapter = createAdapter(input.options)
+    diagnostic = targetDiagnostic(input, await adapter.discoverTargets())
+  } catch (reason) {
+    const message = reason instanceof Error ? reason.message : String(reason)
+    diagnostic = blockedEnvironment(input, message)
+  }
+  try {
+    await adapter?.dispose?.()
+  } catch (reason) {
+    const message = reason instanceof Error ? reason.message : String(reason)
+    return blockedEnvironment(input, `cleanup failed: ${message}`)
+  }
+  return diagnostic
+}

--- a/packages/runner/index.ts
+++ b/packages/runner/index.ts
@@ -14,6 +14,10 @@ export {
 } from './src/configuration/configuration'
 export { persistedEvidenceKinds } from './src/evidence/evidence'
 export type {
+  EnvironmentDiagnostic,
+  EnvironmentRemediation,
+} from './src/execution/environment-diagnostic'
+export type {
   ApplicationOutputEvidenceAvailability,
   DiagnosticEntry,
   DiagnosticLevel,

--- a/packages/runner/src/execution/environment-diagnostic.ts
+++ b/packages/runner/src/execution/environment-diagnostic.ts
@@ -1,0 +1,19 @@
+export interface EnvironmentRemediation {
+  summary: string
+}
+
+export type EnvironmentDiagnostic =
+  | {
+      id: string
+      kind: 'ready'
+      message: string
+    }
+  | {
+      id: string
+      kind: 'blocked'
+      message: string
+      remediation: readonly [
+        EnvironmentRemediation,
+        ...EnvironmentRemediation[],
+      ]
+    }

--- a/packages/studio/src/onboarding/first-run-onboarding.test.tsx
+++ b/packages/studio/src/onboarding/first-run-onboarding.test.tsx
@@ -19,7 +19,10 @@ const project: StudioProject = {
           name: 'Pay',
           readiness: {
             ready: false,
-            reasons: ['Execution target profile "chrome" lacks geolocation'],
+            reasons: [
+              'Execution target profile "chrome" lacks geolocation',
+              'Local browser is missing. Install Chrome or configure Browserbase.',
+            ],
             checks: [
               { id: 'selection', status: 'ready' },
               {
@@ -30,7 +33,13 @@ const project: StudioProject = {
                 ],
               },
               { id: 'model-credential', status: 'not-applicable' },
-              { id: 'mobile-target', status: 'not-applicable' },
+              {
+                id: 'environment',
+                status: 'blocked',
+                reasons: [
+                  'Local browser is missing. Install Chrome or configure Browserbase.',
+                ],
+              },
             ],
           },
         },
@@ -53,6 +62,8 @@ test('renders an accessible checklist with structured setup blockers', () => {
   expect(markup).toContain('aria-label="First-run readiness"')
   expect(markup).toContain('Execution target ready')
   expect(markup).toContain('lacks geolocation')
+  expect(markup).toContain('Local environment ready')
+  expect(markup).toContain('Install Chrome or configure Browserbase')
   expect(markup).toContain('Open Settings')
   expect(markup).toContain('Persist one passed Test run')
 })

--- a/packages/studio/src/onboarding/first-run-onboarding.tsx
+++ b/packages/studio/src/onboarding/first-run-onboarding.tsx
@@ -44,7 +44,7 @@ const checkLabels: Record<StudioRunReadinessCheckId, string> = {
   selection: 'Scenario selected',
   'execution-target': 'Execution target ready',
   'model-credential': 'Model credential ready',
-  'mobile-target': 'Mobile target ready',
+  environment: 'Local environment ready',
 }
 
 function checkState(check: StudioRunReadinessCheck) {

--- a/packages/studio/src/server/server.ts
+++ b/packages/studio/src/server/server.ts
@@ -104,7 +104,7 @@ export type StudioRunReadinessCheckId =
   | 'selection'
   | 'execution-target'
   | 'model-credential'
-  | 'mobile-target'
+  | 'environment'
 
 export type StudioRunReadinessCheck =
   | {

--- a/packages/web/index.ts
+++ b/packages/web/index.ts
@@ -24,6 +24,11 @@ export {
   validateWebAdapterOptions,
   webAdapterOptionsSchema,
 } from './src/adapter/web-adapter'
+export type { WebEnvironmentRuntime } from './src/adapter/web-environment'
+export {
+  diagnoseWebEnvironment,
+  webEnvironmentProbeKey,
+} from './src/adapter/web-environment'
 export { defaultModelName, webProfiles } from './src/adapter/web-options'
 export type { WebLogicalSession } from './src/adapter/web-pool'
 export {

--- a/packages/web/src/adapter/web-environment.test.ts
+++ b/packages/web/src/adapter/web-environment.test.ts
@@ -1,0 +1,91 @@
+import { expect, mock, test } from 'bun:test'
+import {
+  diagnoseWebEnvironment,
+  type WebEnvironmentRuntime,
+  webEnvironmentProbeKey,
+} from '../../index'
+
+function runtime(
+  launchLocalBrowser: WebEnvironmentRuntime['launchLocalBrowser'],
+): WebEnvironmentRuntime {
+  return { launchLocalBrowser }
+}
+
+test('launches and closes the configured local browser', async () => {
+  const close = mock(async () => {})
+  const launch = mock(async () => ({ close }))
+
+  await expect(
+    diagnoseWebEnvironment(
+      { baseUrl: 'https://example.test', browser: { headless: false } },
+      runtime(launch),
+    ),
+  ).resolves.toEqual({
+    id: 'web.local-browser',
+    kind: 'ready',
+    message: 'Local Chrome or Chromium launched and closed successfully',
+  })
+  expect(launch).toHaveBeenCalledWith({ headless: false })
+  expect(close).toHaveBeenCalledTimes(1)
+})
+
+test('returns actionable remediation when the local browser cannot launch', async () => {
+  const diagnostic = await diagnoseWebEnvironment(
+    { baseUrl: 'https://example.test' },
+    runtime(async () => {
+      throw new Error('browser executable is missing')
+    }),
+  )
+
+  expect(diagnostic).toMatchObject({
+    id: 'web.local-browser',
+    kind: 'blocked',
+    message:
+      'Local Chrome or Chromium could not launch: browser executable is missing',
+  })
+  expect(
+    diagnostic.kind === 'blocked' && diagnostic.remediation[0].summary,
+  ).toContain('Install a Stagehand-compatible Chrome or Chromium browser')
+})
+
+test('does not contact Browserbase or CDP endpoints', async () => {
+  const launch = mock(async () => ({ close: async () => {} }))
+  const controlledRuntime = runtime(launch)
+  const browserbase = await diagnoseWebEnvironment(
+    {
+      baseUrl: 'https://example.test',
+      browser: {
+        environment: 'browserbase',
+        browserbaseApiKey: 'secret-browserbase-key',
+      },
+    },
+    controlledRuntime,
+  )
+  const cdp = await diagnoseWebEnvironment(
+    {
+      baseUrl: 'https://example.test',
+      browser: { cdpUrl: 'wss://secret.example/session?token=secret' },
+    },
+    controlledRuntime,
+  )
+
+  expect(launch).not.toHaveBeenCalled()
+  expect(browserbase).toMatchObject({ id: 'web.browserbase', kind: 'ready' })
+  expect(cdp).toMatchObject({ id: 'web.cdp', kind: 'ready' })
+  expect(JSON.stringify([browserbase, cdp])).not.toContain('secret')
+  expect(
+    webEnvironmentProbeKey({
+      baseUrl: 'https://example.test',
+      browser: {
+        environment: 'browserbase',
+        browserbaseApiKey: 'secret-browserbase-key',
+      },
+    }),
+  ).toBe('browserbase')
+  expect(
+    webEnvironmentProbeKey({
+      baseUrl: 'https://example.test',
+      browser: { cdpUrl: 'wss://secret.example/session?token=secret' },
+    }),
+  ).toBe('cdp')
+})

--- a/packages/web/src/adapter/web-environment.ts
+++ b/packages/web/src/adapter/web-environment.ts
@@ -1,0 +1,85 @@
+import { localBrowser } from '@browserbasehq/stagehand'
+import type { EnvironmentDiagnostic } from '@pickle-spec/runner'
+import type { WebAdapterOptions } from './web-options'
+import { resolveBrowserConnection } from './web-options'
+
+interface LocalBrowserProcess {
+  close(): Promise<void>
+}
+
+export interface WebEnvironmentRuntime {
+  launchLocalBrowser(options: {
+    headless: boolean
+  }): Promise<LocalBrowserProcess>
+}
+
+const defaultRuntime: WebEnvironmentRuntime = {
+  launchLocalBrowser: (options) => localBrowser.launch(options),
+}
+
+export function webEnvironmentProbeKey(options: WebAdapterOptions): string {
+  const connection = resolveBrowserConnection(options.browser)
+  if (connection.kind === 'local') {
+    return `local:${options.browser?.headless ?? true}`
+  }
+  return connection.kind
+}
+
+function blockedLocalBrowser(reason: unknown): EnvironmentDiagnostic {
+  const detail = reason instanceof Error ? reason.message : String(reason)
+  return {
+    id: 'web.local-browser',
+    kind: 'blocked',
+    message: `Local Chrome or Chromium could not launch: ${detail}`,
+    remediation: [
+      {
+        summary:
+          'Install a Stagehand-compatible Chrome or Chromium browser, or configure Browserbase or CDP, then run pickle doctor again.',
+      },
+    ],
+  }
+}
+
+async function diagnoseLocalBrowser(
+  options: WebAdapterOptions,
+  runtime: WebEnvironmentRuntime,
+): Promise<EnvironmentDiagnostic> {
+  let browser: LocalBrowserProcess | undefined
+  try {
+    browser = await runtime.launchLocalBrowser({
+      headless: options.browser?.headless ?? true,
+    })
+    await browser.close()
+    return {
+      id: 'web.local-browser',
+      kind: 'ready',
+      message: 'Local Chrome or Chromium launched and closed successfully',
+    }
+  } catch (reason) {
+    if (browser) await browser.close().catch(() => {})
+    return blockedLocalBrowser(reason)
+  }
+}
+
+export async function diagnoseWebEnvironment(
+  options: WebAdapterOptions,
+  runtime: WebEnvironmentRuntime = defaultRuntime,
+): Promise<EnvironmentDiagnostic> {
+  const connection = resolveBrowserConnection(options.browser)
+  if (connection.kind === 'local') {
+    return diagnoseLocalBrowser(options, runtime)
+  }
+  if (connection.kind === 'browserbase') {
+    return {
+      id: 'web.browserbase',
+      kind: 'ready',
+      message:
+        'Browserbase configuration is valid; connectivity was not tested',
+    }
+  }
+  return {
+    id: 'web.cdp',
+    kind: 'ready',
+    message: 'CDP configuration is valid; connectivity was not tested',
+  }
+}


### PR DESCRIPTION
## Summary

- Add `pickle doctor` to validate project configuration and configured execution environments.
- Report actionable diagnostics, remediation advice, skipped custom adapters, and exit status.
- Reuse environment probes across CLI and Studio readiness checks.
- Add web/mobile environment diagnostics and comprehensive unit coverage.

## Testing

- Not run.