### PR TITLE
feat(web): capture and link diagnostic evidence artifacts

### DIFF
--- a/packages/cli/src/studio/studio.test.ts
+++ b/packages/cli/src/studio/studio.test.ts
@@ -774,12 +774,17 @@ export default {
           .getAttribute('aria-selected'),
       ).toBe('true')
       const timeline = page.getByRole('list', { name: 'Execution timeline' })
+      const timelineFilters = page.getByRole('list', {
+        name: 'Filter timeline by entry type',
+      })
       expect(await timeline.textContent()).toContain('Then payment is captured')
+      expect(await timeline.textContent()).not.toContain('Payment was declined')
+      await timelineFilters
+        .getByRole('button', { name: 'Diagnostic entry' })
+        .click()
       expect(await timeline.textContent()).toContain('Payment was declined')
       expect(await timeline.textContent()).not.toContain('Run event')
-      expect(
-        await page.getByRole('list', { name: 'Timeline legend' }).count(),
-      ).toBe(1)
+      expect(await timelineFilters.count()).toBe(1)
       expect(
         await page.getByRole('img', { name: 'Execution time ruler' }).count(),
       ).toBe(1)
@@ -790,9 +795,11 @@ export default {
         name: /Step Then payment is captured/,
       })
       await page.getByRole('tab', { name: 'Timeline' }).focus()
-      await page.keyboard.press('Tab')
-      await page.keyboard.press('Tab')
-      await page.keyboard.press('Tab')
+      for (let attempt = 0; attempt < 12; attempt += 1) {
+        if (await selectedStep.evaluate((element) => element.matches(':focus')))
+          break
+        await page.keyboard.press('Tab')
+      }
       expect(
         await selectedStep.evaluate((element) =>
           element.matches(':focus-visible'),
@@ -926,66 +933,7 @@ export default {
       expect(
         await page.getByRole('button', { name: 'Resume following' }).count(),
       ).toBe(1)
-      const verboseTimelineSwitch = page.getByRole('switch', {
-        name: 'Verbose timeline',
-      })
-      const switchState = verboseTimelineSwitch.locator(
-        '[data-slot="switch-state"]',
-      )
-      const switchThumb = verboseTimelineSwitch.locator(
-        '[data-slot="switch-thumb"]',
-      )
-      const stateMotion = await switchState.evaluate((element) => {
-        const style =
-          element.ownerDocument.defaultView?.getComputedStyle(element)
-        return {
-          duration: style?.transitionDuration,
-          property: style?.transitionProperty,
-          timing: style?.transitionTimingFunction,
-        }
-      })
-      const thumbMotion = await switchThumb.evaluate((element) => {
-        const style =
-          element.ownerDocument.defaultView?.getComputedStyle(element)
-        return {
-          duration: style?.transitionDuration,
-          property: style?.transitionProperty,
-          timing: style?.transitionTimingFunction,
-        }
-      })
-      expect(stateMotion).toEqual({
-        duration: '0.12s',
-        property: 'opacity',
-        timing: 'cubic-bezier(0.23, 1, 0.32, 1)',
-      })
-      expect(thumbMotion).toEqual({
-        duration: '0.12s',
-        property: 'transform, translate, scale, rotate',
-        timing: 'cubic-bezier(0.23, 1, 0.32, 1)',
-      })
-      expect(
-        await switchState.evaluate(
-          (element) =>
-            element.ownerDocument.defaultView?.getComputedStyle(element)
-              .opacity,
-        ),
-      ).toBe('0')
-      await verboseTimelineSwitch.click()
-      await page.waitForTimeout(150)
-      expect(
-        await switchState.evaluate(
-          (element) =>
-            element.ownerDocument.defaultView?.getComputedStyle(element)
-              .opacity,
-        ),
-      ).toBe('1')
-      expect(
-        await switchThumb.evaluate(
-          (element) =>
-            element.ownerDocument.defaultView?.getComputedStyle(element)
-              .translate,
-        ),
-      ).not.toBe('none')
+      await timelineFilters.getByRole('button', { name: 'Run event' }).click()
       expect(await timeline.textContent()).toContain('Run event')
       await page.setViewportSize({ width: 390, height: 844 })
       const timelineChart = page.getByRole('region', {
@@ -1082,6 +1030,10 @@ export default {
         /^\/runs\/[^/]+\/results\/features%2Fcheckout\.feature\/scenarios\/scnpaybbbbbbbbbb\/profiles\/chrome\/attempts\/1$/,
       )
       expect(await timeline.textContent()).toContain('Then payment is captured')
+      expect(await timeline.textContent()).not.toContain('Payment was declined')
+      await timelineFilters
+        .getByRole('button', { name: 'Diagnostic entry' })
+        .click()
       expect(await timeline.textContent()).toContain('Payment was declined')
       await page.getByRole('tab', { name: 'Artifacts' }).click()
       expect(await page.getByRole('img', { name: /screenshot/ }).count()).toBe(
@@ -1446,13 +1398,23 @@ Feature: Search
       const evidenceTimeline = page.getByRole('list', {
         name: 'Execution timeline',
       })
-      const timelineText = await evidenceTimeline.textContent()
-      expect(timelineText).toContain('Step')
-      expect(timelineText).not.toContain('Run event')
-      expect(timelineText).toContain('Diagnostic entry')
-      expect(timelineText).toContain('Test artifact')
-      expect(timelineText).toContain('Failure context')
-      await page.getByRole('switch', { name: 'Verbose timeline' }).click()
+      const evidenceTimelineFilters = page.getByRole('list', {
+        name: 'Filter timeline by entry type',
+      })
+      expect(await evidenceTimeline.textContent()).toContain('Step')
+      expect(await evidenceTimeline.textContent()).not.toContain('Run event')
+      expect(await evidenceTimeline.textContent()).not.toContain(
+        'Diagnostic entry',
+      )
+      expect(await evidenceTimeline.textContent()).toContain('Test artifact')
+      await evidenceTimelineFilters
+        .getByRole('button', { name: 'Diagnostic entry' })
+        .click()
+      expect(await evidenceTimeline.textContent()).toContain('Diagnostic entry')
+      expect(await evidenceTimeline.textContent()).toContain('Failure context')
+      await evidenceTimelineFilters
+        .getByRole('button', { name: 'Run event' })
+        .click()
       expect(await evidenceTimeline.textContent()).toContain('Run event')
       await page.getByRole('tab', { name: 'Artifacts' }).click()
       expect(

--- a/packages/cli/test/studio-hardening-suite.ts
+++ b/packages/cli/test/studio-hardening-suite.ts
@@ -298,6 +298,10 @@ Feature: Checkout
       const timeline = page.getByRole('list', {
         name: 'Execution timeline',
       })
+      await page
+        .getByRole('list', { name: 'Filter timeline by entry type' })
+        .getByRole('button', { name: 'Diagnostic entry' })
+        .click()
       expect(await timeline.textContent()).toContain('Payment was declined')
       const timelineResults = await new AxeBuilder({ page })
         .withTags(['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa', 'wcag22aa'])

--- a/packages/runner/index.ts
+++ b/packages/runner/index.ts
@@ -19,6 +19,7 @@ export type {
 } from './src/execution/environment-diagnostic'
 export type {
   ApplicationOutputEvidenceAvailability,
+  ArtifactEvidenceLink,
   DiagnosticEntry,
   DiagnosticLevel,
   DiagnosticOrigin,
@@ -38,6 +39,7 @@ export type {
   RetryPolicy,
   RunEvent,
   RunEventPayload,
+  RunEventRange,
   ScenarioAttempt,
   ScenarioExecution,
   ScenarioExecutionCache,

--- a/packages/runner/src/execution/run-scenario-types.ts
+++ b/packages/runner/src/execution/run-scenario-types.ts
@@ -39,6 +39,16 @@ export interface ResolvedAction {
   replay?: Record<string, unknown>
 }
 
+export interface RunEventRange {
+  startSequence: number
+  endSequence: number
+}
+
+export interface ArtifactEvidenceLink {
+  stepIndex: number
+  eventRange: RunEventRange
+}
+
 export interface TestArtifact {
   kind: 'screenshot' | 'trace' | 'recording' | 'device-log'
   path: string
@@ -46,6 +56,7 @@ export interface TestArtifact {
   name?: string
   capturedAt?: string
   sizeBytes?: number
+  evidenceLink?: ArtifactEvidenceLink
 }
 
 export const evidenceKinds = [

--- a/packages/runner/src/results/public-results.ts
+++ b/packages/runner/src/results/public-results.ts
@@ -65,6 +65,12 @@ function publicArtifact(artifact: TestArtifact): TestArtifact {
     name: artifact.name,
     capturedAt: artifact.capturedAt,
     sizeBytes: artifact.sizeBytes,
+    evidenceLink: artifact.evidenceLink
+      ? {
+          stepIndex: artifact.evidenceLink.stepIndex,
+          eventRange: { ...artifact.evidenceLink.eventRange },
+        }
+      : undefined,
   }
 }
 

--- a/packages/runner/src/results/test-run-schema.ts
+++ b/packages/runner/src/results/test-run-schema.ts
@@ -75,6 +75,15 @@ const artifactSchema = z.object({
   name: z.string().min(1).optional(),
   capturedAt: timestampSchema.optional(),
   sizeBytes: nonNegativeIntegerSchema.optional(),
+  evidenceLink: z
+    .object({
+      stepIndex: nonNegativeIntegerSchema,
+      eventRange: z.object({
+        startSequence: nonNegativeIntegerSchema,
+        endSequence: nonNegativeIntegerSchema,
+      }),
+    })
+    .optional(),
 })
 
 const diagnosticEntrySchema = z.object({

--- a/packages/runner/src/results/test-run-store.test.ts
+++ b/packages/runner/src/results/test-run-store.test.ts
@@ -1357,6 +1357,125 @@ function resultWithArtifact(
   }
 }
 
+test('links persisted artifacts to canonical non-adjacent event ranges', async () => {
+  const root = await tempRoot()
+  const screenshot = join(root, 'terminal.png')
+  const recording = join(root, 'scenario.mp4')
+  await Bun.write(screenshot, 'image')
+  await Bun.write(recording, 'video')
+  const run = await openTestRunStore({
+    root,
+    createId: () => 'run-artifact-links',
+  }).create()
+  const result = resultWithArtifact('Linked evidence', 'failed', screenshot)
+  const attempt = requiredValue(result.attempts[0])
+  const terminal = {
+    ...requiredValue(attempt.steps[0]),
+    index: 1,
+    artifacts: [
+      { kind: 'screenshot' as const, path: screenshot },
+      { kind: 'recording' as const, path: recording },
+    ],
+  }
+  const scope = {
+    scenarioId: requiredValue(result.scenario.id),
+    executionTargetProfileId: result.executionTargetProfile.id,
+    attempt: attempt.attempt,
+  }
+  const stepStarted = (stepIndex: number) => ({
+    type: 'step-started' as const,
+    step: terminal.step,
+    scenario: result.scenario,
+    executionTargetProfile: result.executionTargetProfile,
+    scope: { ...scope, stepIndex },
+  })
+
+  await run.append(stepStarted(0))
+  await run.append({
+    type: 'step-finished',
+    result: { ...terminal, index: 0, artifacts: undefined },
+    scenario: result.scenario,
+    executionTargetProfile: result.executionTargetProfile,
+    scope: { ...scope, stepIndex: 0 },
+  })
+  await run.append(stepStarted(1))
+  await run.append({
+    type: 'cache-uncacheable',
+    reason: 'non-deterministic-action',
+    scope: { ...scope, stepIndex: 1 },
+  })
+  const finished = await run.append({
+    type: 'step-finished',
+    result: terminal,
+    scenario: result.scenario,
+    executionTargetProfile: result.executionTargetProfile,
+    scope: { ...scope, stepIndex: 1 },
+  })
+
+  expect(finished).toMatchObject({
+    sequence: 6,
+    result: {
+      artifacts: [
+        {
+          kind: 'screenshot',
+          evidenceLink: {
+            stepIndex: 1,
+            eventRange: { startSequence: 4, endSequence: 6 },
+          },
+        },
+        {
+          kind: 'recording',
+          evidenceLink: {
+            stepIndex: 1,
+            eventRange: { startSequence: 2, endSequence: 6 },
+          },
+        },
+      ],
+    },
+  })
+  await run.append(
+    scenarioFinished({
+      ...result,
+      attempts: [
+        {
+          ...attempt,
+          steps: [{ ...terminal, index: 0, artifacts: undefined }, terminal],
+          evidenceAvailability: attempt.evidenceAvailability.map(
+            (availability) =>
+              availability.kind === 'recording'
+                ? { ...availability, state: 'available' as const }
+                : availability,
+          ),
+        },
+      ],
+    }),
+  )
+  const scenarioFinish = (await run.events()).at(-1)
+  expect(scenarioFinish).toMatchObject({
+    type: 'scenario-finished',
+    sequence: 7,
+    attempt: {
+      steps: [
+        {},
+        {
+          artifacts: [
+            {
+              evidenceLink: {
+                eventRange: { startSequence: 4, endSequence: 6 },
+              },
+            },
+            {
+              evidenceLink: {
+                eventRange: { startSequence: 2, endSequence: 6 },
+              },
+            },
+          ],
+        },
+      ],
+    },
+  })
+})
+
 function withDiagnosticEvidence(result: TestResult): TestResult {
   const attempt = requiredValue(result.attempts[0])
   const diagnostic = {

--- a/packages/runner/src/results/test-run-store.ts
+++ b/packages/runner/src/results/test-run-store.ts
@@ -14,6 +14,7 @@ import type {
   ExecutionMode,
   RunEvent,
   RunEventPayload,
+  RunEventScope,
   ScenarioAttempt,
   TestArtifact,
   TestResult,
@@ -538,6 +539,7 @@ async function appendPersistedEvent(
     current,
     policy,
     state.artifactsDirectory,
+    envelope.sequence,
   )
   const versioned = { ...persisted.event, ...envelope } as RunEvent
   try {
@@ -984,6 +986,7 @@ async function persistEventArtifacts(
   current: readonly RunEvent[],
   policy: EvidencePersistencePolicy,
   artifactsDirectory: string,
+  endSequence: number,
 ): Promise<PersistedEventEvidence> {
   if (event.type === 'scenario-finished') {
     const persisted = await persistAttemptArtifacts(
@@ -994,7 +997,23 @@ async function persistEventArtifacts(
       artifactsDirectory,
     )
     return {
-      event: { ...event, attempt: persisted.attempt },
+      event: {
+        ...event,
+        attempt: {
+          ...persisted.attempt,
+          steps: persisted.attempt.steps.map((step) =>
+            stampArtifactEvidenceLinks(
+              step,
+              { ...event.scope, stepIndex: step.index },
+              current,
+              matchingStepFinishedSequence(current, {
+                ...event.scope,
+                stepIndex: step.index,
+              }) ?? endSequence,
+            ),
+          ),
+        },
+      },
       publishedPaths: persisted.publishedPaths,
     }
   }
@@ -1006,11 +1025,83 @@ async function persistEventArtifacts(
       artifactStepName(event.scope, event.result.index),
     )
     return {
-      event: { ...event, result: persisted.step },
+      event: {
+        ...event,
+        result: stampArtifactEvidenceLinks(
+          persisted.step,
+          event.scope,
+          current,
+          endSequence,
+        ),
+      },
       publishedPaths: persisted.publishedPaths,
     }
   }
   return { event, publishedPaths: [] }
+}
+
+function sameAttemptScope(
+  left: RunEventScope,
+  right: Extract<RunEventPayload, { type: 'step-finished' }>['scope'],
+): boolean {
+  return (
+    left.scenarioId === right.scenarioId &&
+    left.examplesRowId === right.examplesRowId &&
+    left.executionTargetProfileId === right.executionTargetProfileId &&
+    left.attempt === right.attempt
+  )
+}
+
+function artifactStartSequence(
+  artifact: TestArtifact,
+  stepIndex: number,
+  scope: Extract<RunEventPayload, { type: 'step-finished' }>['scope'],
+  current: readonly RunEvent[],
+): number | undefined {
+  const started = current.filter(
+    (event): event is Extract<RunEvent, { type: 'step-started' }> =>
+      event.type === 'step-started' && sameAttemptScope(event.scope, scope),
+  )
+  if (artifact.kind === 'recording') return started[0]?.sequence
+  return started.findLast((event) => event.scope.stepIndex === stepIndex)
+    ?.sequence
+}
+
+function stampArtifactEvidenceLinks(
+  step: TestStepResult,
+  scope: Extract<RunEventPayload, { type: 'step-finished' }>['scope'],
+  current: readonly RunEvent[],
+  endSequence: number,
+): TestStepResult {
+  if (!step.artifacts?.length) return step
+  return {
+    ...step,
+    artifacts: step.artifacts.map((artifact) => {
+      const startSequence = artifactStartSequence(
+        artifact,
+        step.index,
+        scope,
+        current,
+      )
+      if (startSequence === undefined) return artifact
+      return {
+        ...artifact,
+        evidenceLink: {
+          stepIndex: step.index,
+          eventRange: { startSequence, endSequence },
+        },
+      }
+    }),
+  }
+}
+
+function matchingStepFinishedSequence(
+  current: readonly RunEvent[],
+  scope: Extract<RunEventPayload, { type: 'step-finished' }>['scope'],
+): number | undefined {
+  return current.findLast(
+    (event) => event.type === 'step-finished' && sameScope(event.scope, scope),
+  )?.sequence
 }
 
 type EvidenceCaptureFailure = {

--- a/packages/studio/src/runs/result/result-evidence-timeline.test.tsx
+++ b/packages/studio/src/runs/result/result-evidence-timeline.test.tsx
@@ -18,11 +18,15 @@ function entry(
   }
 }
 
-test('default Execution timeline hides Run events and counts visible entries', () => {
+test('default Execution timeline shows Steps, Resolved actions, and Test artifacts', () => {
   const markup = renderToStaticMarkup(
     <ResultEvidenceTimeline
       entries={[
         entry('step-0', 'Step', 'Then payment is captured'),
+        entry('action-1', 'Resolved action', 'Click Pay now'),
+        entry('artifact-1', 'Test artifact', 'Checkout screenshot'),
+        entry('browser-1', 'Browser activity', 'POST /checkout'),
+        entry('diagnostic-1', 'Diagnostic entry', 'Console warning'),
         entry('event-2', 'Run event', 'Scenario Started'),
       ]}
       startedAt="2026-08-22T12:00:00.000Z"
@@ -34,8 +38,16 @@ test('default Execution timeline hides Run events and counts visible entries', (
   )
 
   expect(markup).toContain('Then payment is captured')
-  expect(markup).toContain('Verbose timeline')
-  expect(markup).toContain('1 entry')
+  expect(markup).toContain('Click Pay now')
+  expect(markup).toContain('Checkout screenshot')
+  expect(markup).not.toContain('Verbose timeline')
+  expect(markup).toContain('Filter timeline by entry type')
+  expect(markup.match(/aria-pressed="true"/g)).toHaveLength(4)
+  expect(markup).toMatch(/aria-pressed="false"[^>]*>.*Browser activity/s)
+  expect(markup).toMatch(/aria-pressed="false"[^>]*>.*Diagnostic entry/s)
+  expect(markup).toMatch(/aria-pressed="false"[^>]*>.*Run event/s)
+  expect(markup).toContain('3 entries')
+  expect(markup).not.toContain('POST /checkout')
+  expect(markup).not.toContain('Console warning')
   expect(markup).not.toContain('Scenario Started')
-  expect(markup).not.toContain('2 entries')
 })

--- a/packages/studio/src/runs/result/result-evidence-timeline.tsx
+++ b/packages/studio/src/runs/result/result-evidence-timeline.tsx
@@ -1,5 +1,6 @@
 import type { TestResultState } from '@pickle-spec/runner'
 import { useState } from 'react'
+import { Button } from '../../components/ui/button'
 import {
   Card,
   CardAction,
@@ -8,16 +9,15 @@ import {
   CardHeader,
   CardTitle,
 } from '../../components/ui/card'
-import { Label } from '../../components/ui/label'
-import { Switch } from '../../components/ui/switch'
 import { durationLabel } from '../run-format'
 import {
   causalTimelineEntry,
-  type TimelineDensity,
   type TimelineEntry,
-  visibleTimelineEntries,
+  type TimelineEntryKind,
+  timelineEntriesOfKinds,
 } from './result-evidence'
 import { TimelineEvidenceDetail } from './timeline-evidence-detail'
+import { TimelineKindFilter, timelineEntryKinds } from './timeline-kind'
 import { TimelineWaterfall } from './timeline-waterfall'
 
 type ResultEvidenceTimelineProps = {
@@ -50,14 +50,27 @@ interface TimelineDisplayProps extends ResultEvidenceTimelineProps {
   followedEntryId?: string
   onSelect: (entryId: string) => void
   onPause: () => void
+  onClearFilters: () => void
 }
 
 function TimelineDisplay(props: TimelineDisplayProps) {
   if (props.visibleEntries.length === 0) {
+    if (props.entries.length === 0) {
+      return (
+        <p className="px-4 py-8 text-center text-sm text-muted-foreground">
+          No Test evidence was recorded for this Scenario attempt.
+        </p>
+      )
+    }
     return (
-      <p className="px-4 py-8 text-center text-sm text-muted-foreground">
-        No Test evidence was recorded for this Scenario attempt.
-      </p>
+      <div className="flex flex-col items-center gap-3 px-4 py-8 text-center">
+        <p className="text-sm text-muted-foreground">
+          No timeline entries match these filters.
+        </p>
+        <Button variant="outline" size="sm" onClick={props.onClearFilters}>
+          Clear filters
+        </Button>
+      </div>
     )
   }
   if (!props.selectedEntry) return null
@@ -83,16 +96,45 @@ function TimelineDisplay(props: TimelineDisplayProps) {
   )
 }
 
-export function ResultEvidenceTimeline(props: ResultEvidenceTimelineProps) {
+const defaultTimelineEntryKinds = [
+  'Step',
+  'Resolved action',
+  'Test artifact',
+] satisfies readonly TimelineEntryKind[]
+
+type TimelineKindFiltersProps = {
+  selectedKinds: readonly TimelineEntryKind[]
+  onKindChange: (kind: TimelineEntryKind, selected: boolean) => void
+}
+
+function TimelineKindFilters(props: TimelineKindFiltersProps) {
+  return (
+    <ul
+      aria-label="Filter timeline by entry type"
+      className="flex flex-wrap items-center gap-1.5 border-b border-border px-4 py-3"
+    >
+      {timelineEntryKinds.map((kind) => (
+        <li key={kind}>
+          <TimelineKindFilter
+            kind={kind}
+            selected={props.selectedKinds.includes(kind)}
+            onPressedChange={(selected) => props.onKindChange(kind, selected)}
+          />
+        </li>
+      ))}
+    </ul>
+  )
+}
+
+function useTimelineView(props: ResultEvidenceTimelineProps) {
   const [selectedEntryId, setSelectedEntryId] = useState<string>()
-  const [density, setDensity] = useState<TimelineDensity>('essential')
-  const visibleEntries = visibleTimelineEntries(props.entries, density)
-  const followEntries = visibleTimelineEntries(props.entries, 'essential')
+  const [selectedKinds, setSelectedKinds] = useState<
+    readonly TimelineEntryKind[]
+  >(defaultTimelineEntryKinds)
+  const visibleEntries = timelineEntriesOfKinds(props.entries, selectedKinds)
   const causalEntry = causalTimelineEntry(visibleEntries)
   const followedEntryId =
-    props.followedEntryId ??
-    causalTimelineEntry(followEntries)?.id ??
-    followEntries.at(-1)?.id
+    props.followedEntryId ?? causalEntry?.id ?? visibleEntries.at(-1)?.id
   const activeEntryId =
     props.follow === true
       ? followedEntryId
@@ -102,25 +144,45 @@ export function ResultEvidenceTimeline(props: ResultEvidenceTimelineProps) {
     activeEntryId,
     causalEntry,
   )
+  return {
+    followedEntryId,
+    selectedEntry,
+    selectedKinds,
+    setSelectedEntryId,
+    setSelectedKinds,
+    visibleEntries,
+  }
+}
+
+export function ResultEvidenceTimeline(props: ResultEvidenceTimelineProps) {
+  const view = useTimelineView(props)
   const causalPointUnavailable =
     !props.entries.some((entry) => entry.causalAt) &&
     (props.state === 'failed' || props.state === 'infrastructure-error')
-  const entryCount = visibleEntries.length
+  const entryCount = view.visibleEntries.length
 
   function handleSelect(entryId: string) {
-    setSelectedEntryId(entryId)
+    view.setSelectedEntryId(entryId)
     props.onPauseFollowing?.()
   }
 
   function handlePauseFollowing() {
-    if (props.follow === true && followedEntryId) {
-      setSelectedEntryId(followedEntryId)
+    if (props.follow === true && view.followedEntryId) {
+      view.setSelectedEntryId(view.followedEntryId)
     }
     props.onPauseFollowing?.()
   }
 
-  function handleVerboseChange(verbose: boolean) {
-    setDensity(verbose ? 'verbose' : 'essential')
+  function handleKindChange(kind: TimelineEntryKind, selected: boolean) {
+    view.setSelectedKinds((current) =>
+      selected
+        ? [...current, kind]
+        : current.filter((currentKind) => currentKind !== kind),
+    )
+  }
+
+  function handleClearFilters() {
+    view.setSelectedKinds(timelineEntryKinds)
   }
 
   return (
@@ -131,23 +193,22 @@ export function ResultEvidenceTimeline(props: ResultEvidenceTimelineProps) {
           Steps span their recorded duration. Actions and evidence mark when
           they were recorded.
         </CardDescription>
-        <CardAction className="flex items-center gap-3">
-          <span className="flex items-center gap-2">
-            <Switch
-              id="verbose-timeline"
-              size="sm"
-              checked={density === 'verbose'}
-              onCheckedChange={handleVerboseChange}
-            />
-            <Label htmlFor="verbose-timeline">Verbose timeline</Label>
-          </span>
-          <span className="font-mono text-[0.6875rem] text-muted-foreground tabular-nums">
+        <CardAction>
+          <span
+            role="status"
+            aria-live="polite"
+            className="font-mono text-[0.6875rem] text-muted-foreground tabular-nums"
+          >
             {durationLabel(props.durationMs)} · {entryCount}{' '}
             {entryCount === 1 ? 'entry' : 'entries'}
           </span>
         </CardAction>
       </CardHeader>
       <CardContent className="px-0">
+        <TimelineKindFilters
+          selectedKinds={view.selectedKinds}
+          onKindChange={handleKindChange}
+        />
         {causalPointUnavailable ? (
           <p
             role="status"
@@ -159,11 +220,12 @@ export function ResultEvidenceTimeline(props: ResultEvidenceTimelineProps) {
         ) : null}
         <TimelineDisplay
           {...props}
-          selectedEntry={selectedEntry}
-          visibleEntries={visibleEntries}
-          followedEntryId={followedEntryId}
+          selectedEntry={view.selectedEntry}
+          visibleEntries={view.visibleEntries}
+          followedEntryId={view.followedEntryId}
           onSelect={handleSelect}
           onPause={handlePauseFollowing}
+          onClearFilters={handleClearFilters}
         />
       </CardContent>
     </Card>

--- a/packages/studio/src/runs/result/result-evidence.test.ts
+++ b/packages/studio/src/runs/result/result-evidence.test.ts
@@ -18,6 +18,7 @@ import {
   findInspectedResult,
   recoveryGuidance,
   type TimelineEntry,
+  timelineEntriesOfKinds,
   timelineFor,
   visibleTimelineEntries,
 } from './result-evidence'
@@ -326,7 +327,7 @@ test('projects exact spans and points without replacing occurrence time with cau
   ])
 })
 
-test('puts captured media on timeline entries and links the session recording to every step', () => {
+test('puts captured media on the explicitly linked timeline step', () => {
   const screenshot = {
     kind: 'screenshot' as const,
     path: '/tmp/step-01-passed.png',
@@ -338,6 +339,10 @@ test('puts captured media on timeline entries and links the session recording to
     path: '/tmp/scenario.mp4',
     mediaType: 'video/mp4',
     name: 'scenario.mp4',
+    evidenceLink: {
+      stepIndex: 1,
+      eventRange: { startSequence: 4, endSequence: 5 },
+    },
   }
   const inspectedAttempt: ScenarioAttempt = {
     ...attempt(1, 'failed'),
@@ -390,7 +395,6 @@ test('puts captured media on timeline entries and links the session recording to
 
   expect(firstStep?.artifacts?.map((artifact) => artifact.kind)).toEqual([
     'screenshot',
-    'recording',
   ])
   expect(failedStep?.artifacts?.map((artifact) => artifact.kind)).toEqual([
     'recording',
@@ -446,6 +450,21 @@ test('essential timeline keeps Step, Diagnostic, artifact, and causal Resolved a
     { kind: 'Test artifact', title: 'screenshot' },
   ])
   expect(visibleTimelineEntries(entries, 'verbose')).toBe(entries)
+})
+
+test('filters timeline entries by selected kinds without changing their order', () => {
+  const entries = [
+    timelineEntry('Step', 'Then payment is captured'),
+    timelineEntry('Run event', 'Scenario Started'),
+    timelineEntry('Diagnostic entry', 'Payment was declined'),
+  ]
+
+  expect(
+    timelineEntriesOfKinds(entries, ['Step', 'Diagnostic entry']).map(
+      (entry) => entry.kind,
+    ),
+  ).toEqual(['Step', 'Diagnostic entry'])
+  expect(timelineEntriesOfKinds(entries, [])).toEqual([])
 })
 
 test('marks action timestamps inherited from step completion without downgrading exact artifacts', () => {

--- a/packages/studio/src/runs/result/result-evidence.ts
+++ b/packages/studio/src/runs/result/result-evidence.ts
@@ -156,6 +156,14 @@ export function visibleTimelineEntries<Entry extends TimelineDensityEntry>(
   }
 }
 
+export function timelineEntriesOfKinds<Entry extends TimelineDensityEntry>(
+  entries: readonly Entry[],
+  kinds: readonly TimelineEntryKind[],
+): readonly Entry[] {
+  const includedKinds = new Set(kinds)
+  return entries.filter((entry) => includedKinds.has(entry.kind))
+}
+
 export function causalTimelineEntry(
   entries: readonly TimelineEntry[],
 ): TimelineEntry | undefined {
@@ -531,6 +539,8 @@ function stepTimelineEntries(
       ...own,
       ...context.attemptRecordings.filter(
         (recording) =>
+          (recording.evidenceLink === undefined ||
+            recording.evidenceLink.stepIndex === step.index) &&
           !own.some((artifact) => artifact.path === recording.path),
       ),
     ]

--- a/packages/studio/src/runs/result/timeline-kind.tsx
+++ b/packages/studio/src/runs/result/timeline-kind.tsx
@@ -9,6 +9,7 @@ import {
 import { HugeiconsIcon, type IconSvgElement } from '@hugeicons/react'
 import type { ComponentProps } from 'react'
 import { Badge } from '../../components/ui/badge'
+import { Button } from '../../components/ui/button'
 import { cn } from '../../lib/utils'
 import type { TimelineEntryKind } from './result-evidence'
 
@@ -95,6 +96,33 @@ export function TimelineKindBadge(
       <TimelineKindIcon kind={kind} className="size-3" />
       {kind}
     </Badge>
+  )
+}
+
+type TimelineKindFilterProps = {
+  kind: TimelineEntryKind
+  selected: boolean
+  onPressedChange: (selected: boolean) => void
+}
+
+export function TimelineKindFilter(props: TimelineKindFilterProps) {
+  return (
+    <Button
+      type="button"
+      variant="outline"
+      size="xs"
+      aria-pressed={props.selected}
+      onClick={() => props.onPressedChange(!props.selected)}
+      className={cn(
+        'h-6 rounded-full border normal-case tracking-normal transition-[background-color,border-color,color,opacity]',
+        props.selected
+          ? timelineKindPresentation[props.kind].badgeClassName
+          : 'border-input bg-background text-muted-foreground opacity-60 hover:opacity-100',
+      )}
+    >
+      <TimelineKindIcon kind={props.kind} className="size-3" />
+      {props.kind}
+    </Button>
   )
 }
 

--- a/packages/studio/src/runs/result/timeline-kind.tsx
+++ b/packages/studio/src/runs/result/timeline-kind.tsx
@@ -114,10 +114,10 @@ export function TimelineKindFilter(props: TimelineKindFilterProps) {
       aria-pressed={props.selected}
       onClick={() => props.onPressedChange(!props.selected)}
       className={cn(
-        'h-6 rounded-full border normal-case tracking-normal transition-[background-color,border-color,color,opacity]',
+        'h-6 rounded-full border normal-case tracking-normal transition-[background-color,border-color,color]',
         props.selected
           ? timelineKindPresentation[props.kind].badgeClassName
-          : 'border-input bg-background text-muted-foreground opacity-60 hover:opacity-100',
+          : 'border-input bg-background text-foreground hover:bg-accent',
       )}
     >
       <TimelineKindIcon kind={props.kind} className="size-3" />

--- a/packages/studio/src/runs/result/timeline-waterfall.tsx
+++ b/packages/studio/src/runs/result/timeline-waterfall.tsx
@@ -10,12 +10,7 @@ import { ScrollArea } from '../../components/ui/scroll-area'
 import { cn } from '../../lib/utils'
 import { durationLabel } from '../run-format'
 import { relativeTimeLabel, type TimelineEntry } from './result-evidence'
-import {
-  TimelineKindBadge,
-  TimelineKindIcon,
-  timelineEntryKinds,
-  timelineKindSolidClassName,
-} from './timeline-kind'
+import { TimelineKindIcon, timelineKindSolidClassName } from './timeline-kind'
 
 type TimelineWaterfallProps = {
   entries: readonly TimelineEntry[]
@@ -64,21 +59,6 @@ function elapsedMs(timestamp: string, startedAt: string): number {
 
 function percentage(value: number, total: number): number {
   return Math.min(100, Math.max(0, (value / total) * 100))
-}
-
-function TimelineLegend() {
-  return (
-    <ul
-      aria-label="Timeline legend"
-      className="flex flex-wrap items-center gap-1.5 border-b border-border px-4 py-3"
-    >
-      {timelineEntryKinds.map((kind) => (
-        <li key={kind}>
-          <TimelineKindBadge kind={kind} />
-        </li>
-      ))}
-    </ul>
-  )
 }
 
 type TimelineLabelsProps = TimelineWaterfallProps & {
@@ -566,7 +546,6 @@ export function TimelineWaterfall(props: TimelineWaterfallProps) {
 
   return (
     <section aria-label="Execution timeline chart" className="min-w-0">
-      <TimelineLegend />
       <div
         ref={rowsRef}
         className="grid min-w-0 grid-cols-[minmax(12rem,16rem)_minmax(0,1fr)]"

--- a/packages/web/src/adapter/web-adapter.test.ts
+++ b/packages/web/src/adapter/web-adapter.test.ts
@@ -184,6 +184,7 @@ describe('createWebAdapter', () => {
     )
     artifactDirectories.push(artifactDirectory)
     let recordingPath = ''
+    const lifecycle: string[] = []
     const adapter = createWebAdapter(
       {
         baseUrl: 'https://example.test',
@@ -192,6 +193,7 @@ describe('createWebAdapter', () => {
       factoryFor(
         stubAutomation({
           async observe() {
+            lifecycle.push('step')
             return [
               {
                 description: 'Fill the search field',
@@ -209,6 +211,7 @@ describe('createWebAdapter', () => {
             return new Uint8Array([137, 80, 78, 71])
           },
           async startRecording(path) {
+            lifecycle.push('recording-started')
             recordingPath = path
             await Bun.write(path, 'video-bytes')
           },
@@ -234,6 +237,8 @@ describe('createWebAdapter', () => {
     const action = await session.executeStep(requiredValue(scenario.steps[1]))
     const outcome = await session.executeStep(requiredValue(scenario.steps[2]))
     await session.close()
+
+    expect(lifecycle[0]).toBe('recording-started')
 
     expect(navigation.artifacts?.map((artifact) => artifact.kind)).toEqual([
       'screenshot',
@@ -315,6 +320,46 @@ describe('createWebAdapter', () => {
       'screenshot',
       'recording',
     ])
+  })
+
+  test('reports a recording start failure once', async () => {
+    const adapter = createWebAdapter(
+      {
+        baseUrl: 'https://example.test',
+        screenshots: { mode: 'on-step' },
+      },
+      factoryFor(
+        stubAutomation({
+          async startRecording() {
+            throw new Error('encoder unavailable')
+          },
+        }),
+      ),
+    )
+    const session = await adapter.openSession({
+      executionTargetProfile: { id: 'web' },
+      specification,
+      scenario,
+    })
+
+    const results = []
+    for (const step of scenario.steps) {
+      results.push(await session.executeStep(step))
+    }
+    await session.close()
+
+    expect(
+      results.flatMap((result) => result.evidenceAvailability ?? []),
+    ).toContainEqual({
+      kind: 'recording',
+      state: 'capture-failed',
+      message: 'encoder unavailable',
+    })
+    expect(
+      results
+        .flatMap((result) => result.evidenceAvailability ?? [])
+        .filter((availability) => availability.kind === 'recording'),
+    ).toHaveLength(1)
   })
 
   test('reports a requested screenshot that could not be captured', async () => {

--- a/packages/web/src/adapter/web-adapter.ts
+++ b/packages/web/src/adapter/web-adapter.ts
@@ -346,6 +346,7 @@ async function openWebSession(
     automation,
     stepNumber: () => stepIndex,
   })
+  await finish.start()
   const runtime = await createWebSessionRuntime({
     automation,
     cacheReplay,

--- a/packages/web/src/evidence/web-evidence.test.ts
+++ b/packages/web/src/evidence/web-evidence.test.ts
@@ -12,7 +12,7 @@ function observablePage() {
   return {
     page: {
       async evaluate() {
-        return buffered.splice(0)
+        return { entries: buffered.splice(0), droppedCount: 0 }
       },
     },
     buffer(entries: unknown[]) {
@@ -29,7 +29,9 @@ type BrowserScriptEntry = {
 }
 
 type BrowserScriptContext = {
-  console: Record<string, () => void>
+  // biome-ignore lint/style/useNamingConvention: matches the browser API.
+  URL: typeof URL
+  console: Record<string, (...args: unknown[]) => void>
   location: { href: string }
   addEventListener: () => void
   fetch: (url: string) => Promise<{
@@ -41,16 +43,19 @@ type BrowserScriptContext = {
   XMLHttpRequest: typeof FakeXmlHttpRequest
   // biome-ignore lint/style/useNamingConvention: matches the browser API.
   PerformanceObserver: typeof FakePerformanceObserver
-  __pickleSpecWebEvidenceV1?: BrowserScriptEntry[]
+  __pickleSpecWebEvidenceV1?: {
+    entries: BrowserScriptEntry[]
+    droppedCount: number
+  }
 }
 
 class FakeXmlHttpRequest {
   status = 404
   // biome-ignore lint/style/useNamingConvention: matches the browser API.
-  responseURL = 'https://example.test/xhr'
+  responseURL = ''
   private listeners = new Map<string, (event: { type: string }) => void>()
 
-  open() {}
+  open(_method?: string, _url?: string) {}
 
   addEventListener(type: string, listener: (event: { type: string }) => void) {
     this.listeners.set(type, listener)
@@ -160,6 +165,7 @@ test('keeps browser execution usable when a page cannot be instrumented', async 
 
 test('the browser script records HTTP failures without duplicate navigation', async () => {
   const context: BrowserScriptContext = {
+    URL,
     console: {
       debug() {},
       info() {},
@@ -170,7 +176,8 @@ test('the browser script records HTTP failures without duplicate navigation', as
     location: { href: 'https://example.test/checkout' },
     addEventListener() {},
     async fetch(url) {
-      return { ok: false, status: 503, url }
+      const ok = url.includes('/success')
+      return { ok, status: ok ? 204 : 503, url }
     },
     // biome-ignore lint/style/useNamingConvention: matches the browser API.
     XMLHttpRequest: FakeXmlHttpRequest,
@@ -178,11 +185,14 @@ test('the browser script records HTTP failures without duplicate navigation', as
   }
   runInNewContext(installWebEvidenceScript, context)
 
-  await context.fetch('https://example.test/pay')
+  await context.fetch(
+    'https://user:password@example.test/pay?token=secret&view=summary',
+  )
   const xhr = new context.XMLHttpRequest()
-  xhr.open()
+  xhr.open('POST', 'https://example.test/xhr?api_key=private')
   xhr.send()
-  const firstEntries = context.__pickleSpecWebEvidenceV1?.splice(0) ?? []
+  const firstEntries =
+    context.__pickleSpecWebEvidenceV1?.entries.splice(0) ?? []
 
   expect(
     firstEntries.filter((entry) => entry.description?.startsWith('Navigate ')),
@@ -191,23 +201,80 @@ test('the browser script records HTTP failures without duplicate navigation', as
     firstEntries.filter((entry) => entry.origin === 'network'),
   ).toMatchObject([
     {
-      message: 'https://example.test/pay failed: 503',
+      message:
+        'GET https://example.test/pay?token=%3Credacted%3E&view=summary failed: 503',
     },
     {
-      message: 'https://example.test/xhr failed: 404',
+      message:
+        'POST https://example.test/xhr?api_key=%3Credacted%3E failed: 404',
     },
   ])
 
   await context.fetch('https://example.test/pay')
   expect(
-    context.__pickleSpecWebEvidenceV1?.filter(
+    context.__pickleSpecWebEvidenceV1?.entries.filter(
       (entry) => entry.origin === 'network',
     ),
   ).toMatchObject([
     {
-      message: 'https://example.test/pay failed: 503',
+      message: 'GET https://example.test/pay failed: 503',
     },
   ])
+
+  await context.fetch('https://example.test/success?session=private')
+  expect(
+    context.__pickleSpecWebEvidenceV1?.entries.find((entry) =>
+      entry.message?.includes('/success'),
+    ),
+  ).toMatchObject({
+    message:
+      'GET https://example.test/success?session=%3Credacted%3E completed: 204',
+  })
+})
+
+test('bounds browser evidence and reports truncation', async () => {
+  const context: BrowserScriptContext = {
+    URL,
+    console: {
+      debug() {},
+      info() {},
+      log() {},
+      warn() {},
+      error() {},
+    },
+    location: { href: 'https://example.test/' },
+    addEventListener() {},
+    async fetch(url) {
+      return { ok: true, status: 200, url }
+    },
+    // biome-ignore lint/style/useNamingConvention: matches the browser API.
+    XMLHttpRequest: FakeXmlHttpRequest,
+    PerformanceObserver: FakePerformanceObserver,
+  }
+  runInNewContext(installWebEvidenceScript, context)
+  const log = context.console.log
+  if (!log) throw new Error('Expected an instrumented console logger')
+  for (let index = 0; index < 501; index++) log(index)
+
+  const collector = createWebEvidenceCollector()
+  const collected = await collector.collect([
+    {
+      async evaluate() {
+        const buffer = context.__pickleSpecWebEvidenceV1
+        return {
+          entries: buffer?.entries.splice(0) ?? [],
+          droppedCount: buffer?.droppedCount ?? 0,
+        }
+      },
+    },
+  ])
+
+  expect(collected.diagnostics).toContainEqual(
+    expect.objectContaining({
+      origin: 'adapter',
+      message: 'Browser evidence truncated; 2 entries were dropped',
+    }),
+  )
 })
 
 test('correlates prior resolved actions without rewriting occurrence time', () => {

--- a/packages/web/src/evidence/web-evidence.ts
+++ b/packages/web/src/evidence/web-evidence.ts
@@ -15,39 +15,65 @@ type ObservablePage = {
   evaluate(expression: string): Promise<unknown>
 }
 
-const bufferedEvidenceSchema = z.array(
-  z.discriminatedUnion('kind', [
-    z.object({
-      kind: z.literal('diagnostic'),
-      occurredAt: z.iso.datetime(),
-      level: z.enum(diagnosticLevels),
-      origin: z.enum(['console', 'network']),
-      message: z.string(),
-    }),
-    z.object({
-      kind: z.literal('activity'),
-      occurredAt: z.iso.datetime(),
-      description: z.string(),
-    }),
-  ]),
-)
+const bufferedEvidenceEntrySchema = z.discriminatedUnion('kind', [
+  z.object({
+    kind: z.literal('diagnostic'),
+    occurredAt: z.iso.datetime(),
+    level: z.enum(diagnosticLevels),
+    origin: z.enum(['console', 'network']),
+    message: z.string(),
+  }),
+  z.object({
+    kind: z.literal('activity'),
+    occurredAt: z.iso.datetime(),
+    description: z.string(),
+  }),
+])
+
+const bufferedEvidenceSchema = z.object({
+  entries: z.array(bufferedEvidenceEntrySchema),
+  droppedCount: z.number().int().nonnegative(),
+})
 
 const evidenceBufferKey = '__pickleSpecWebEvidenceV1'
 
 export const installWebEvidenceScript = `(() => {
   const key = '${evidenceBufferKey}'
-  if (Array.isArray(globalThis[key])) return
-  const entries = []
+  if (globalThis[key]?.entries) return
+  const buffer = { entries: [], droppedCount: 0 }
+  const maxEntries = 500
   Object.defineProperty(globalThis, key, {
     configurable: true,
-    value: entries,
+    value: buffer,
   })
-  const record = (entry) => entries.push({
-    occurredAt: new Date().toISOString(),
-    ...entry,
-  })
-  const recordNetworkFailure = (url, detail, level = 'error') => {
-    const message = String(url) + ' failed: ' + String(detail)
+  const record = (entry) => {
+    if (buffer.entries.length >= maxEntries) {
+      buffer.droppedCount++
+      return
+    }
+    buffer.entries.push({ occurredAt: new Date().toISOString(), ...entry })
+  }
+  const sanitizeUrl = (value) => {
+    try {
+      const url = new URL(String(value), location.href)
+      url.username = ''
+      url.password = ''
+      for (const name of url.searchParams.keys()) {
+        if (/token|secret|password|passwd|authorization|api[-_]?key|session|cookie/i.test(name)) {
+          url.searchParams.set(name, '<redacted>')
+        }
+      }
+      return url.toString()
+    } catch {
+      return '<invalid-url>'
+    }
+  }
+  const recordNetwork = (method, url, status, failure) => {
+    const message = String(method).toUpperCase() + ' ' + sanitizeUrl(url) +
+      (failure ? ' failed: ' : ' completed: ') + String(status)
+    const level = failure
+      ? (Number(status) >= 500 ? 'error' : 'warning')
+      : 'info'
     record({ kind: 'diagnostic', level, origin: 'network', message })
   }
   const display = (value) => {
@@ -80,14 +106,14 @@ export const installWebEvidenceScript = `(() => {
       return Reflect.apply(original, this, args)
     }
   }
-  record({ kind: 'activity', description: 'Navigate ' + location.href })
+  record({ kind: 'activity', description: 'Navigate ' + sanitizeUrl(location.href) })
   addEventListener('error', (event) => {
     const target = event.target
     const resourceUrl = target && (
       target.currentSrc || target.src || target.href
     )
     if (resourceUrl) {
-      recordNetworkFailure(resourceUrl, 'load error')
+      recordNetwork('RESOURCE', resourceUrl, 'load error', true)
       return
     }
     record({
@@ -110,18 +136,13 @@ export const installWebEvidenceScript = `(() => {
       const requestUrl = typeof request === 'string'
         ? request
         : String(request?.url ?? request)
+      const method = String(args[1]?.method ?? request?.method ?? 'GET')
       try {
         const response = await Reflect.apply(originalFetch, this, args)
-        if (!response.ok) {
-          recordNetworkFailure(
-            response.url || requestUrl,
-            response.status,
-            response.status >= 500 ? 'error' : 'warning',
-          )
-        }
+        recordNetwork(method, response.url || requestUrl, response.status, !response.ok)
         return response
       } catch (error) {
-        recordNetworkFailure(requestUrl, display(error))
+        recordNetwork(method, requestUrl, display(error), true)
         throw error
       }
     }
@@ -136,18 +157,24 @@ export const installWebEvidenceScript = `(() => {
     }
     XMLHttpRequest.prototype.send = function (...args) {
       const request = this[requestKey] || { method: 'XHR', url: 'request' }
-      const failed = (event) => recordNetworkFailure(request.url, event.type)
+      let recorded = false
+      const failed = (event) => {
+        if (recorded) return
+        recorded = true
+        recordNetwork(request.method, request.url, event.type, true)
+      }
       this.addEventListener('error', failed, { once: true })
       this.addEventListener('abort', failed, { once: true })
       this.addEventListener('timeout', failed, { once: true })
       this.addEventListener('loadend', () => {
-        if (this.status >= 400) {
-          recordNetworkFailure(
-            this.responseURL || request.url,
-            this.status,
-            this.status >= 500 ? 'error' : 'warning',
-          )
-        }
+        if (recorded) return
+        recorded = true
+        recordNetwork(
+          request.method,
+          this.responseURL || request.url,
+          this.status,
+          this.status >= 400,
+        )
       }, { once: true })
       return Reflect.apply(originalSend, this, args)
     }
@@ -155,7 +182,7 @@ export const installWebEvidenceScript = `(() => {
   if (typeof PerformanceObserver !== 'function') return
   const observe = (entry) => {
     const activity = 'Resource ' +
-      (entry.initiatorType || 'request') + ' ' + entry.name
+      (entry.initiatorType || 'request') + ' ' + sanitizeUrl(entry.name)
     record({ kind: 'activity', description: activity })
   }
   const observer = new PerformanceObserver((list) => {
@@ -169,8 +196,14 @@ export const installWebEvidenceScript = `(() => {
 })()`
 
 const consumeWebEvidenceScript = `(() => {
-  const entries = globalThis['${evidenceBufferKey}']
-  return Array.isArray(entries) ? entries.splice(0) : []
+  const buffer = globalThis['${evidenceBufferKey}']
+  if (!buffer?.entries) return { entries: [], droppedCount: 0 }
+  const result = {
+    entries: buffer.entries.splice(0),
+    droppedCount: buffer.droppedCount,
+  }
+  buffer.droppedCount = 0
+  return result
 })()`
 
 function isObservablePage(value: unknown): value is ObservablePage {
@@ -213,7 +246,7 @@ export function createWebEvidenceCollector(
   }
 
   function recordBufferedEntry(
-    entry: z.infer<typeof bufferedEvidenceSchema>[number],
+    entry: z.infer<typeof bufferedEvidenceEntrySchema>,
   ): void {
     if (entry.kind === 'diagnostic') {
       const { kind: _kind, ...diagnostic } = entry
@@ -237,7 +270,13 @@ export function createWebEvidenceCollector(
         )
         return
       }
-      for (const entry of parsed.data) recordBufferedEntry(entry)
+      for (const entry of parsed.data.entries) recordBufferedEntry(entry)
+      if (parsed.data.droppedCount > 0) {
+        recordDiagnostic(
+          'adapter',
+          `Browser evidence truncated; ${parsed.data.droppedCount} entries were dropped`,
+        )
+      }
     } catch (error) {
       recordAdapterFailure('Browser evidence collection failed', error)
     }

--- a/packages/web/src/evidence/web-step-finalizer.ts
+++ b/packages/web/src/evidence/web-step-finalizer.ts
@@ -39,6 +39,7 @@ interface WebStepFinalizerState extends CreateWebStepFinalizerInput {
   examplesRowArtifactId?: string
   previousResolvedActionTrace: StepExecution['trace']
   recordingState: WebRecordingState
+  recordingStartFailure?: EvidenceAvailability
   capture: ReturnType<typeof resolveWebArtifactCapture>
 }
 
@@ -221,13 +222,9 @@ async function finalizeWebStep(
       finalizerState.previousResolvedActionTrace ?? [],
   })
   finalizerState.previousResolvedActionTrace = projected.nextResolvedActionTrace
-  const startFailure = await startWebStepRecording({
-    enabled: state.capture.recording,
-    automation: state.automation,
-    directory: evidenceDirectory(state),
-    state: state.recordingState,
-  })
   const screenshot = await captureScreenshot(state, execution.state)
+  const startFailure = finalizerState.recordingStartFailure
+  finalizerState.recordingStartFailure = undefined
   const recording = await finishWebStepRecording({
     automation: state.automation,
     state: state.recordingState,
@@ -272,6 +269,15 @@ export function createWebStepFinalizer({
       screenshotMode: options.screenshots?.mode ?? 'off',
     }),
   }
-  return (execution: StepExecution, step: ScenarioStep) =>
+  const finalize = (execution: StepExecution, step: ScenarioStep) =>
     finalizeWebStep(state, execution, step)
+  finalize.start = async () => {
+    state.recordingStartFailure = await startWebStepRecording({
+      enabled: state.capture.recording,
+      automation: state.automation,
+      directory: evidenceDirectory(state),
+      state: state.recordingState,
+    })
+  }
+  return finalize
 }


### PR DESCRIPTION
## Summary

- Capture bounded, sanitized browser diagnostics and report truncation.
- Link screenshots and recordings to their canonical run-event ranges.
- Persist evidence links through runner schemas and public results.
- Add Studio timeline filters for steps, actions, and test artifacts.

## Testing

- Added runner persistence coverage for non-adjacent artifact event ranges.
- Added web adapter coverage for recording lifecycle and capture failures.
- Added browser evidence coverage for URL redaction, successful requests, and truncation.
- Added Studio timeline filtering and artifact-linking coverage.