### PR TITLE
ci: enable Turborepo remote cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,14 @@ jobs:
         with:
           bun-version: 1.3.11
 
+      - name: Restore Turbo cache
+        uses: actions/cache@v4
+        with:
+          path: .turbo
+          key: ${{ runner.os }}-turbo-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-turbo-
+
       - run: bun install --frozen-lockfile
 
       - name: Lint and format


### PR DESCRIPTION
## Summary

- Cache the `.turbo` directory in CI using GitHub Actions cache.
- Simplify timeline evidence presentation with essential and verbose modes.
- Remove obsolete artifact evidence-linking and timeline filter APIs.
- Update runner, web, Studio, and CLI tests for the revised behavior.

## Testing

- Updated focused CLI, runner, web, and Studio tests.
- Added coverage for verbose timeline switching and transition behavior.
- Not run: full lint, typecheck, and test suites.