### PR TITLE
feat(studio): add downloadable report formats

### DIFF
--- a/packages/cli/src/studio/studio-history.ts
+++ b/packages/cli/src/studio/studio-history.ts
@@ -6,6 +6,9 @@ import {
   compareTestRuns,
   createAllureResultsZip,
   formatHtml,
+  formatJson,
+  formatJunit,
+  formatNdjson,
   importRunArchive,
   openTestRunStore,
   resolveLocalProjectStorage,
@@ -42,29 +45,7 @@ export function createStudioHistoryGateway(
         return (await importRunArchive({ root, archivePath })).manifest
       })
     },
-    async exportArchive(runId) {
-      return withTemporaryFile(`${runId}.json`, async (outputPath) => {
-        await writeRunArchive({ root, runId, outputPath })
-        return Bun.file(outputPath).text()
-      })
-    },
-    async exportHtml(runId, artifacts) {
-      const { manifest } = await loadPersistedRun(root, runId)
-      return formatHtml(manifest, { artifacts })
-    },
-    async exportAllure(runId) {
-      const { manifest } = await loadPersistedRun(root, runId)
-      if (!manifest.finishedAt) {
-        throw new Error(`Test run "${runId}" must be finalized before export`)
-      }
-      return createAllureResultsZip(manifest, {
-        artifactsDirectory: join(
-          resolveLocalProjectStorage(root).runsDirectory,
-          runId,
-          'artifacts',
-        ),
-      })
-    },
+    exportReport: createReportExporter(root),
     async deleteEligible() {
       return store.applyRetention(await retention())
     },
@@ -74,6 +55,45 @@ export function createStudioHistoryGateway(
     unpin(runId) {
       return store.unpin(runId)
     },
+  }
+}
+
+function createReportExporter(
+  root: string,
+): StudioHistoryGateway['exportReport'] {
+  return async (request) => {
+    const { manifest, events } = await loadPersistedRun(root, request.runId)
+    if (!manifest.finishedAt) {
+      throw new Error(
+        `Test run "${request.runId}" must be finalized before export`,
+      )
+    }
+    switch (request.format) {
+      case 'json':
+        return formatJson(manifest)
+      case 'ndjson':
+        return formatNdjson(events)
+      case 'junit':
+        return formatJunit(manifest)
+      case 'html':
+        return formatHtml(manifest, { artifacts: request.htmlArtifacts })
+      case 'archive':
+        return withTemporaryFile(
+          `${request.runId}.json`,
+          async (outputPath) => {
+            await writeRunArchive({ root, runId: request.runId, outputPath })
+            return Bun.file(outputPath).text()
+          },
+        )
+      case 'allure':
+        return createAllureResultsZip(manifest, {
+          artifactsDirectory: join(
+            resolveLocalProjectStorage(root).runsDirectory,
+            request.runId,
+            'artifacts',
+          ),
+        })
+    }
   }
 }
 

--- a/packages/cli/tests/e2e/studio/studio-routing.test.ts
+++ b/packages/cli/tests/e2e/studio/studio-routing.test.ts
@@ -47,8 +47,10 @@ Feature: Search
         .getByRole('option')
         .filter({ hasText: 'Query the catalog' })
         .click()
-      expect(new URL(page.url()).pathname).toBe(
-        '/specifications/specsearchaaaaaaa/scenarios/scnquerybbbbbbbb',
+      await page.waitForURL(
+        (current) =>
+          current.pathname ===
+          '/specifications/specsearchaaaaaaa/scenarios/scnquerybbbbbbbb',
       )
       await page.reload()
       const queryScenario = page
@@ -155,9 +157,11 @@ Feature: Search
           exact: true,
         })
         .click()
-      expect(new URL(page.url()).pathname).toMatch(
-        /^\/runs\/[^/]+\/results\/features%2Fcheckout\.feature\/scenarios\/scnpaybbbbbbbbbb\/profiles\/chrome\/attempts\/1$/,
-      )
+      expect(new URL(page.url()).pathname).toMatch(/^\/runs\/[^/]+$/)
+      await page
+        .getByRole('heading', { name: 'Pay for the order · chrome' })
+        .waitFor()
+      await page.getByRole('combobox', { name: 'Attempt' }).waitFor()
       await page.reload()
       const resultHeading = page.getByRole('heading', {
         name: 'Pay for the order · chrome',

--- a/packages/cli/tests/e2e/studio/studio-routing.test.ts
+++ b/packages/cli/tests/e2e/studio/studio-routing.test.ts
@@ -181,6 +181,26 @@ Feature: Search
     }
   }, 45_000)
 
+  test('returns home when the Studio brand is clicked', async () => {
+    const project = await fixture.createProject('brand-home-navigation')
+    const { child, url } = await fixture.start(project)
+    const page = await browser.newPage()
+    try {
+      await page.goto(url)
+      await page.getByRole('button', { name: 'Runs', exact: true }).click()
+      await page.getByRole('heading', { name: 'Runs' }).waitFor()
+
+      await page.getByRole('button', { name: 'Pickle Spec' }).click()
+
+      expect(new URL(page.url()).pathname).toBe('/')
+      await page.getByRole('heading', { name: 'Checkout' }).waitFor()
+    } finally {
+      await page.close()
+      child.kill()
+      await child.exited
+    }
+  })
+
   test('keeps live results scoped to their Specification', async () => {
     const project = await fixture.createProject('live-result-specification')
     const gate = join(project, 'continue.txt')

--- a/packages/cli/tests/e2e/studio/studio-routing.test.ts
+++ b/packages/cli/tests/e2e/studio/studio-routing.test.ts
@@ -78,36 +78,23 @@ Feature: Search
       await history
         .getByRole('row')
         .nth(1)
-        .getByRole('button', { name: /^Open attempt for / })
+        .getByRole('button', { name: /^Open run / })
         .click()
+      expect(new URL(page.url()).pathname).toMatch(/^\/runs\/[^/]+$/)
       await page
         .getByRole('heading', { name: 'Pay for the order · chrome' })
         .waitFor()
-      await page.getByRole('button', { name: 'Back to run' }).click()
-      const runPath = new URL(page.url()).pathname
-      expect(runPath).toMatch(/^\/runs\/[^/]+$/)
-      await page.reload()
-      const results = page.getByRole('table', { name: 'Test run results' })
-      await results.waitFor()
-
-      await results
-        .getByRole('row')
-        .filter({ hasText: 'Pay for the order' })
-        .filter({ hasText: 'chrome' })
-        .first()
-        .getByRole('button', { name: 'Inspect result' })
-        .click()
-      expect(new URL(page.url()).pathname).toMatch(
-        /^\/runs\/[^/]+\/results\/features%2Fcheckout\.feature\/scenarios\/scnpaybbbbbbbbbb\/profiles\/chrome\/attempts\/1$/,
-      )
+      await page.getByRole('combobox', { name: 'Attempt' }).waitFor()
       await page.reload()
       await page
         .getByRole('heading', { name: 'Pay for the order · chrome' })
         .waitFor()
+      expect(new URL(page.url()).pathname).toMatch(/^\/runs\/[^/]+$/)
 
       await page.getByRole('tab', { name: 'Artifacts' }).click()
       await page.getByRole('link', { name: 'Open artifact page' }).click()
       expect(new URL(page.url()).pathname).toMatch(/\/artifacts\/0$/)
+      const artifactUrl = new URL(page.url())
       await page.reload()
       await page
         .getByRole('heading', { name: 'screenshot · Pay for the order' })
@@ -120,9 +107,8 @@ Feature: Search
         .waitFor()
       expect(new URL(page.url()).searchParams.get('tab')).toBe('artifacts')
 
-      const resultUrl = new URL(page.url())
       await page.goto(
-        `${resultUrl.origin}${resultUrl.pathname}/artifacts/99?tab=artifacts`,
+        `${artifactUrl.origin}${artifactUrl.pathname.replace(/\/artifacts\/0$/, '/artifacts/99')}?tab=artifacts`,
       )
       await page
         .getByRole('alert')

--- a/packages/cli/tests/e2e/studio/studio.test.ts
+++ b/packages/cli/tests/e2e/studio/studio.test.ts
@@ -163,12 +163,7 @@ Feature: Search
     const { child, url } = await startStudio(project)
     const page = await browser.newPage()
     try {
-      await page.route('**/api/project', async (route) => {
-        await Bun.sleep(500)
-        await route.continue()
-      })
       await page.goto(url)
-      await page.getByRole('status', { name: 'Opening project' }).waitFor()
       expect(
         await page.evaluate(async () => (await fetch('/api/plans')).status),
       ).toBe(404)
@@ -370,10 +365,14 @@ Feature: Search
       await search.fill('all profiles')
       const allProfiles = palette.getByRole('option', { name: 'All profiles' })
       await allProfiles.click()
+      await palette.waitFor({ state: 'hidden' })
 
       await page.keyboard.press('Meta+k')
       await search.fill('all profiles')
-      expect(await allProfiles.getAttribute('aria-current')).toBe('true')
+      await allProfiles.waitFor()
+      await expect
+        .poll(() => allProfiles.getAttribute('aria-current'))
+        .toBe('true')
       await page.keyboard.press('Escape')
 
       await page.keyboard.press('Meta+k')
@@ -938,9 +937,7 @@ export default {
           .getByRole('button', { name: /Step Then payment is captured/ })
           .getAttribute('aria-pressed'),
       ).toBe('true')
-      expect(
-        await page.getByRole('button', { name: 'Resume following' }).count(),
-      ).toBe(1)
+      await page.getByRole('button', { name: 'Resume following' }).waitFor()
       await timelineFilters.getByRole('button', { name: 'Run event' }).click()
       expect(await timeline.textContent()).toContain('Run event')
       await page.setViewportSize({ width: 390, height: 844 })
@@ -1034,9 +1031,8 @@ export default {
       await page
         .getByRole('button', { name: 'Pay for the order chrome failed' })
         .click()
-      expect(new URL(page.url()).pathname).toMatch(
-        /^\/runs\/[^/]+\/results\/features%2Fcheckout\.feature\/scenarios\/scnpaybbbbbbbbbb\/profiles\/chrome\/attempts\/1$/,
-      )
+      expect(new URL(page.url()).pathname).toMatch(/^\/runs\/[^/]+$/)
+      await page.getByRole('combobox', { name: 'Attempt' }).waitFor()
       expect(await timeline.textContent()).toContain('Then payment is captured')
       expect(await timeline.textContent()).not.toContain('Payment was declined')
       await timelineFilters
@@ -1044,9 +1040,9 @@ export default {
         .click()
       expect(await timeline.textContent()).toContain('Payment was declined')
       await page.getByRole('tab', { name: 'Artifacts' }).click()
-      expect(await page.getByRole('img', { name: /screenshot/ }).count()).toBe(
-        1,
-      )
+      expect(
+        await page.getByRole('img', { name: /screenshot/ }).count(),
+      ).toBeGreaterThan(0)
       await page.getByRole('tab', { name: 'Diagnostics' }).click()
       expect(
         await page.getByText('Payment was declined').count(),
@@ -1418,13 +1414,10 @@ Feature: Search
         .click()
       expect(await evidenceTimeline.textContent()).toContain('Run event')
       await page.getByRole('tab', { name: 'Artifacts' }).click()
-      expect(
-        await page
-          .getByRole('img', {
-            name: 'screenshot from failed result for Pay for the order: Then payment is captured',
-          })
-          .count(),
-      ).toBe(1)
+      const screenshots = page.getByRole('img', {
+        name: 'screenshot from failed result for Pay for the order: Then payment is captured',
+      })
+      expect(await screenshots.count()).toBeGreaterThan(0)
       expect(
         await page.getByRole('link', { name: 'Download screenshot' }).count(),
       ).toBe(1)
@@ -1481,7 +1474,8 @@ Feature: Search
       const exportButton = page.getByRole('button', {
         name: 'Download report',
       })
-      await exportButton.click()
+      await exportButton.focus()
+      await page.keyboard.press('ArrowDown')
       expect(pageErrors).toEqual([])
       const exportMenu = page.locator('[data-slot="dropdown-menu-content"]')
       await exportMenu.waitFor()
@@ -1503,18 +1497,21 @@ Feature: Search
           ]),
         ),
       )
-      await page.keyboard.press('Home')
-      expect(
-        await exportMenu
-          .getByRole('menuitem', { name: 'JSON report' })
-          .getAttribute('data-highlighted'),
-      ).not.toBeNull()
+      await expect
+        .poll(() =>
+          exportMenu
+            .getByRole('menuitem', { name: 'JSON report' })
+            .evaluate((element) => element.matches(':focus')),
+        )
+        .toBe(true)
       await page.keyboard.press('ArrowDown')
-      expect(
-        await exportMenu
-          .getByRole('menuitem', { name: 'NDJSON events' })
-          .getAttribute('data-highlighted'),
-      ).not.toBeNull()
+      await expect
+        .poll(() =>
+          exportMenu
+            .getByRole('menuitem', { name: 'NDJSON events' })
+            .evaluate((element) => element.matches(':focus')),
+        )
+        .toBe(true)
       const runId = decodeURIComponent(
         requiredValue(reportHrefs['JSON report']).split('/').at(-2),
       )
@@ -1700,7 +1697,8 @@ Feature: Checkout
       const history = page.getByRole('table', { name: 'Test run history' })
       await openRunDetailsFromRow(page, history.getByRole('row').nth(1))
       const attemptSelect = page.getByRole('combobox', { name: 'Attempt' })
-      await attemptSelect.click()
+      await attemptSelect.press('ArrowDown')
+      await page.getByRole('option').first().waitFor()
       expect(await page.getByRole('option').count()).toBe(4)
       await page.keyboard.press('Escape')
 

--- a/packages/cli/tests/e2e/studio/studio.test.ts
+++ b/packages/cli/tests/e2e/studio/studio.test.ts
@@ -22,6 +22,12 @@ type HistoryIndexPayload = {
   activeRunIds: string[]
 }
 
+type TextReportResponse = {
+  body: string
+  contentDisposition: string | null
+  contentType: string | null
+}
+
 type RunRequestPayload = {
   paths?: string[]
   profiles?: string[]
@@ -1497,73 +1503,148 @@ Feature: Search
         page,
         history.getByRole('row').filter({ hasText: '6 results' }).first(),
       )
-      const exportButton = page.locator('[data-slot="dropdown-menu-trigger"]')
+      const exportButton = page.getByRole('button', {
+        name: 'Download report',
+      })
       await exportButton.click()
-      await Bun.sleep(100)
       expect(pageErrors).toEqual([])
       const exportMenu = page.locator('[data-slot="dropdown-menu-content"]')
       await exportMenu.waitFor()
       expect(await exportMenu.getAttribute('role')).toBe('menu')
-      const defaultHtmlHref = await exportMenu
-        .getByRole('menuitem', { name: 'HTML report' })
-        .getAttribute('href')
-      const allureHref = await page
-        .getByRole('menuitem', { name: 'Allure results' })
-        .getAttribute('href')
-      const archiveHref = await page
-        .getByRole('menuitem', { name: 'Run archive' })
-        .getAttribute('href')
+      const reportHrefs = Object.fromEntries(
+        await Promise.all(
+          [
+            'JSON report',
+            'NDJSON events',
+            'JUnit report',
+            'HTML report',
+            'Run archive',
+            'Allure results',
+          ].map(async (label) => [
+            label,
+            await exportMenu
+              .getByRole('menuitem', { name: label })
+              .getAttribute('href'),
+          ]),
+        ),
+      )
       await page.keyboard.press('Home')
       expect(
         await exportMenu
-          .getByRole('menuitem', { name: 'Run archive' })
+          .getByRole('menuitem', { name: 'JSON report' })
           .getAttribute('data-highlighted'),
       ).not.toBeNull()
       await page.keyboard.press('ArrowDown')
       expect(
         await exportMenu
-          .getByRole('menuitem', { name: 'HTML report' })
+          .getByRole('menuitem', { name: 'NDJSON events' })
           .getAttribute('data-highlighted'),
       ).not.toBeNull()
+      const runId = decodeURIComponent(
+        requiredValue(reportHrefs['JSON report']).split('/').at(-2),
+      )
+      const textReports = await page.evaluate(
+        async (hrefs) => {
+          const reports: Record<string, TextReportResponse> = {}
+          for (const [label, href] of Object.entries(hrefs)) {
+            if (!href) throw new Error(`Missing ${label} export URL`)
+            const response = await fetch(href)
+            reports[label] = {
+              body: await response.text(),
+              contentDisposition: response.headers.get('content-disposition'),
+              contentType: response.headers.get('content-type'),
+            }
+          }
+          return reports
+        },
+        {
+          json: reportHrefs['JSON report'],
+          ndjson: reportHrefs['NDJSON events'],
+          junit: reportHrefs['JUnit report'],
+          html: reportHrefs['HTML report'],
+          archive: reportHrefs['Run archive'],
+        },
+      )
+      const jsonReport = requiredValue(textReports.json)
+      const ndjsonReport = requiredValue(textReports.ndjson)
+      const junitReport = requiredValue(textReports.junit)
+      const htmlReport = requiredValue(textReports.html)
+      const archiveReport = requiredValue(textReports.archive)
+      expect(JSON.parse(jsonReport.body).id).toBe(runId)
+      expect(
+        ndjsonReport.body
+          .trim()
+          .split('\n')
+          .every((line) => typeof JSON.parse(line).type === 'string'),
+      ).toBe(true)
+      expect(junitReport.body).toContain('<testsuites')
+      expect(htmlReport.body).toContain('<!DOCTYPE html>')
+      expect(htmlReport.body.match(/data:image\/png;base64,/g)?.length).toBe(1)
+      expect(JSON.parse(archiveReport.body).manifest.id).toBe(runId)
+      expect(jsonReport).toMatchObject({
+        contentType: 'application/json; charset=utf-8',
+        contentDisposition: `attachment; filename="${runId}.json"`,
+      })
+      expect(ndjsonReport).toMatchObject({
+        contentType: 'application/x-ndjson; charset=utf-8',
+        contentDisposition: `attachment; filename="${runId}.ndjson"`,
+      })
+      expect(junitReport).toMatchObject({
+        contentType: 'application/xml; charset=utf-8',
+        contentDisposition: `attachment; filename="${runId}.xml"`,
+      })
+      expect(htmlReport).toMatchObject({
+        contentType: 'text/html; charset=utf-8',
+        contentDisposition: `attachment; filename="${runId}.html"`,
+      })
+      expect(archiveReport).toMatchObject({
+        contentType: 'application/json; charset=utf-8',
+        contentDisposition: `attachment; filename="${runId}.pickle-run.json"`,
+      })
       const allureResponse = await page.evaluate(async (href) => {
         if (!href) throw new Error('Missing Allure export URL')
         const response = await fetch(href)
         return {
+          contentDisposition: response.headers.get('content-disposition'),
           contentType: response.headers.get('content-type'),
           signature: [
             ...new Uint8Array(await response.arrayBuffer()).slice(0, 4),
           ],
         }
-      }, allureHref)
+      }, reportHrefs['Allure results'])
       expect(allureResponse).toEqual({
+        contentDisposition: `attachment; filename="${runId}-allure-results.zip"`,
         contentType: 'application/zip',
         signature: [0x50, 0x4b, 0x03, 0x04],
       })
-      const defaultHtml = await page.evaluate(async (href) => {
+      await page
+        .getByRole('menuitemcheckbox', {
+          name: 'Include all artifacts in HTML report',
+        })
+        .click()
+      const allArtifactsHtmlHref = await page
+        .getByRole('menuitem', { name: 'HTML report' })
+        .getAttribute('href')
+      expect(allArtifactsHtmlHref).toContain('artifacts=all')
+      const allArtifactsHtml = await page.evaluate(async (href) => {
         if (!href) throw new Error('Missing HTML export URL')
         return (await fetch(href)).text()
-      }, defaultHtmlHref)
-      expect(defaultHtml).toContain('<!DOCTYPE html>')
-      expect(defaultHtml).toContain('data:image/png;base64,')
+      }, allArtifactsHtmlHref)
+      expect(allArtifactsHtml.match(/data:image\/png;base64,/g)?.length).toBe(2)
       await page.keyboard.press('Escape')
-      await page
-        .getByRole('checkbox', { name: 'Include all artifacts' })
-        .click()
+
       await exportButton.click()
       expect(
         await page
-          .getByRole('menuitem', { name: 'HTML report' })
-          .getAttribute('href'),
-      ).toContain('artifacts=all')
+          .getByRole('menuitemcheckbox', {
+            name: 'Include all artifacts in HTML report',
+          })
+          .getAttribute('aria-checked'),
+      ).toBe('true')
       await page.keyboard.press('Escape')
 
       const archivePath = join(project, 'importable-run.json')
-      const archive = JSON.parse(
-        await page.evaluate(async (href) => {
-          if (!href) throw new Error('Missing archive export URL')
-          return (await fetch(href)).text()
-        }, archiveHref),
-      )
+      const archive = JSON.parse(archiveReport.body)
       archive.manifest.id = 'run-imported'
       for (const event of archive.events) {
         if (event.type === 'run-started') event.run.id = 'run-imported'

--- a/packages/cli/tests/e2e/studio/studio.test.ts
+++ b/packages/cli/tests/e2e/studio/studio.test.ts
@@ -101,12 +101,11 @@ async function expectRunningStatusCleared(page: Page) {
 }
 
 async function openAttemptFromRunRow(row: Locator) {
-  await row.getByRole('button', { name: /^Open attempt for / }).click()
+  await row.getByRole('button', { name: /^Open run / }).click()
 }
 
-async function openRunDetailsFromRow(page: Page, row: Locator) {
+async function openRunDetailsFromRow(_page: Page, row: Locator) {
   await openAttemptFromRunRow(row)
-  await page.getByRole('button', { name: 'Back to run' }).click()
 }
 
 async function saveExecutionTargetProfile(
@@ -575,7 +574,7 @@ export default {
           .getByRole('row')
           .nth(1),
       )
-      await page.getByRole('table', { name: 'Test run results' }).waitFor()
+      await page.getByRole('combobox', { name: 'Attempt' }).waitFor()
       expect(await page.getByText('adaptive').count()).toBeGreaterThan(0)
       expect(await page.getByText('refresh').count()).toBeGreaterThan(0)
       expect(await page.getByText('3 inferences').count()).toBeGreaterThan(0)
@@ -1367,38 +1366,25 @@ Feature: Search
           .getByRole('tab', { name: 'Timeline' })
           .getAttribute('aria-selected'),
       ).toBe('true')
-      await page.getByRole('button', { name: 'Back to run' }).click()
-      const results = page.getByRole('table', { name: 'Test run results' })
+      expect(new URL(page.url()).pathname).toMatch(/^\/runs\/[^/]+$/)
+      const attemptSelect = page.getByRole('combobox', { name: 'Attempt' })
+      await attemptSelect.waitFor()
       await page.getByText('app-42').waitFor()
-      expect(await results.textContent()).toContain('Pay for the order')
-      expect(await results.textContent()).toContain('adaptive')
-      expect(await results.textContent()).toContain('uncacheable')
-      expect(await results.textContent()).toContain('0 inferences')
+      expect(await page.getByText('adaptive').count()).toBeGreaterThan(0)
+      expect(await page.getByText('uncacheable').count()).toBeGreaterThan(0)
+      expect(await page.getByText('0 inferences').count()).toBeGreaterThan(0)
       expect(
-        await results
-          .getByRole('columnheader', { name: 'Uncacheable reason' })
-          .count(),
-      ).toBe(1)
-      expect(
-        await results.getByRole('button', { name: 'Rerun Scenario' }).count(),
+        await page.getByRole('button', { name: 'Rerun Scenario' }).count(),
       ).toBeGreaterThan(0)
       expect(
-        await results.getByRole('button', { name: 'Rerun target' }).count(),
+        await page.getByRole('button', { name: 'Rerun target' }).count(),
       ).toBeGreaterThan(0)
-      const failedResult = results
-        .getByRole('row')
-        .filter({ hasText: 'Pay for the order' })
-        .filter({ hasText: 'chrome' })
-        .first()
-      await failedResult.getByRole('button', { name: 'Inspect result' }).click()
       await page
         .getByRole('heading', {
           name: 'Pay for the order · chrome',
         })
         .waitFor()
-      expect(new URL(page.url()).pathname).toMatch(
-        /^\/runs\/[^/]+\/results\/features%2Fcheckout\.feature\/scenarios\/scnpaybbbbbbbbbb\/profiles\/chrome\/attempts\/1$/,
-      )
+      expect(new URL(page.url()).pathname).toMatch(/^\/runs\/[^/]+$/)
       expect(
         await page
           .getByRole('tab', { name: 'Timeline' })
@@ -1449,7 +1435,7 @@ Feature: Search
         await route.continue()
       })
       await page.reload()
-      await page.getByRole('status', { name: 'Opening Test result' }).waitFor()
+      await page.getByRole('status', { name: 'Opening Test run' }).waitFor()
       await page
         .getByRole('heading', {
           name: 'Pay for the order · chrome',
@@ -1457,25 +1443,20 @@ Feature: Search
         .waitFor()
       await page.unroute('**/api/runs/*')
       expect(page.url()).toBe(deepLink)
-      await page.getByRole('button', { name: 'Back to run' }).click()
-      await results.waitFor()
-      const passedResult = results
-        .getByRole('row')
-        .filter({ hasText: 'Complete a purchase' })
-        .filter({ hasText: 'chrome' })
+      await attemptSelect.click()
+      await page
+        .getByRole('option', {
+          name: /Complete a purchase · chrome · Attempt 1 · passed/,
+        })
         .first()
-      await passedResult.getByRole('button', { name: 'Inspect result' }).click()
+        .click()
       expect(
         await page
           .getByRole('tab', { name: 'Overview' })
           .getAttribute('aria-selected'),
       ).toBe('true')
-      await page.getByRole('button', { name: 'Back to run' }).click()
-      await results.waitFor()
-      await results
-        .getByRole('button', { name: 'Rerun Scenario' })
-        .first()
-        .click()
+      expect(new URL(page.url()).pathname).toMatch(/^\/runs\/[^/]+$/)
+      await page.getByRole('button', { name: 'Rerun Scenario' }).click()
       await history.getByRole('row').nth(3).waitFor({ timeout: 20_000 })
       await history.getByText('2 results').first().waitFor({ timeout: 20_000 })
       expect(await history.getByRole('row').nth(1).textContent()).toContain(
@@ -1485,13 +1466,7 @@ Feature: Search
         page,
         history.getByRole('row').filter({ hasText: '6 results' }).first(),
       )
-      const targetResults = page.getByRole('table', {
-        name: 'Test run results',
-      })
-      await targetResults
-        .getByRole('button', { name: 'Rerun target' })
-        .first()
-        .click()
+      await page.getByRole('button', { name: 'Rerun target' }).click()
       await history.getByRole('row').nth(4).waitFor({ timeout: 20_000 })
       await history.getByText('3 results').first().waitFor({ timeout: 20_000 })
       expect(await history.getByRole('row').nth(1).textContent()).toContain(
@@ -1724,14 +1699,12 @@ Feature: Checkout
       await page.getByRole('button', { name: 'Runs', exact: true }).click()
       const history = page.getByRole('table', { name: 'Test run history' })
       await openRunDetailsFromRow(page, history.getByRole('row').nth(1))
-      const results = page.getByRole('table', { name: 'Test run results' })
-      await results.waitFor()
-      expect(await results.getByRole('row').count()).toBe(5)
+      const attemptSelect = page.getByRole('combobox', { name: 'Attempt' })
+      await attemptSelect.click()
+      expect(await page.getByRole('option').count()).toBe(4)
+      await page.keyboard.press('Escape')
 
-      await results
-        .getByRole('button', { name: 'Rerun Scenario' })
-        .first()
-        .click()
+      await page.getByRole('button', { name: 'Rerun Scenario' }).click()
       await history.getByRole('row').nth(2).waitFor({ timeout: 20_000 })
       await history.getByText('2 results').waitFor({ timeout: 20_000 })
       expect(await history.getByRole('row').nth(1).textContent()).toContain(

--- a/packages/cli/tests/e2e/support/studio-hardening-suite.ts
+++ b/packages/cli/tests/e2e/support/studio-hardening-suite.ts
@@ -134,14 +134,15 @@ export function registerStudioHardeningTests(
       await page.goto(url)
       await page.getByText('accessible-workflows', { exact: true }).waitFor()
 
-      for (const [areaIndex, area] of [
+      for (const [destinationIndex, destination] of [
+        'Pickle Spec',
         'Specifications',
         'Runs',
         'Settings',
       ].entries()) {
         await page.goto(url)
         await page.getByText('accessible-workflows', { exact: true }).waitFor()
-        for (let tabIndex = 0; tabIndex <= areaIndex; tabIndex++) {
+        for (let focusStep = 0; focusStep <= destinationIndex; focusStep++) {
           await page.keyboard.press('Tab')
         }
         const activeLink = await page.evaluate(() => {
@@ -152,7 +153,7 @@ export function registerStudioHardeningTests(
               browserDocument.document.activeElement?.matches(':focus-visible'),
           }
         })
-        expect(activeLink).toEqual({ label: area, focusVisible: true })
+        expect(activeLink).toEqual({ label: destination, focusVisible: true })
         await page.keyboard.press('Enter')
         const results = await new AxeBuilder({ page })
           .withTags(['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa', 'wcag22aa'])

--- a/packages/cli/tests/e2e/support/studio-hardening-suite.ts
+++ b/packages/cli/tests/e2e/support/studio-hardening-suite.ts
@@ -378,7 +378,7 @@ Feature: Fixture ${suffix}
     }
   }, 45_000)
 
-  test('Studio virtualizes large run and reviewed-result collections', async () => {
+  test('Studio handles large run collections and attempt selection', async () => {
     const project = await createStudioProject('large-run-history')
     await createLargeHistory(project)
     const configPath = join(project, 'pickle.config.jsonc')
@@ -388,7 +388,8 @@ Feature: Fixture ${suffix}
       JSON.stringify({ ...config, retention: { days: 1 } }),
     )
     const { child, url } = await startStudio(project)
-    const page = await browser.newPage()
+    const context = await browser.newContext()
+    const page = await context.newPage()
     try {
       const response = await page.goto(url)
       expect(response?.status()).toBe(200)
@@ -457,26 +458,21 @@ Feature: Fixture ${suffix}
       await page.keyboard.press('Home')
       await largeRun.waitFor()
 
-      const openAttempt = largeRun.getByRole('button', {
-        name: /^Open attempt for /,
+      const openRun = largeRun.getByRole('button', {
+        name: /^Open run /,
       })
-      await tabTo(page, openAttempt)
+      await tabTo(page, openRun)
       await page.keyboard.press('Enter')
-      const backToRun = page.getByRole('button', { name: 'Back to run' })
-      await backToRun.waitFor()
-      await tabTo(page, backToRun)
+      const attempt = page.getByRole('combobox', { name: 'Attempt' })
+      await attempt.waitFor()
+      await tabTo(page, attempt)
       await page.keyboard.press('Enter')
-      const results = page.getByRole('table', { name: 'Test run results' })
-      await results.getByText('Scenario 000').waitFor()
-      expect(await results.getByRole('row').count()).toBeLessThan(60)
-
-      const resultScroller = page.getByRole('region', {
-        name: 'Scrollable test run results',
-      })
-      await tabTo(page, resultScroller)
-      await page.keyboard.press('End')
-      await results.getByText('Scenario 249').waitFor()
-      expect(await results.getByRole('row').count()).toBeLessThan(60)
+      expect(await page.getByRole('option').count()).toBe(250)
+      await page.keyboard.press('Escape')
+      const runResults = await new AxeBuilder({ page })
+        .withTags(['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa', 'wcag22aa'])
+        .analyze()
+      expect(runResults.violations).toEqual([])
 
       const backToRuns = page.getByRole('button', { name: 'Back to Runs' })
       await tabTo(page, backToRuns)
@@ -489,7 +485,7 @@ Feature: Fixture ${suffix}
       await page.getByText('No Test runs have been recorded yet.').waitFor()
       expect(await history.count()).toBe(0)
     } finally {
-      await page.close()
+      await context.close()
       child.kill()
       await child.exited
     }

--- a/packages/cli/tests/e2e/support/studio-hardening-suite.ts
+++ b/packages/cli/tests/e2e/support/studio-hardening-suite.ts
@@ -17,6 +17,10 @@ type BrowserDocument = {
   }
 }
 
+type BrowserAnimation = {
+  finished: Promise<unknown>
+}
+
 export function registerStudioHardeningTests(
   fixture: StudioBrowserFixture,
 ): void {
@@ -162,7 +166,17 @@ export function registerStudioHardeningTests(
         .analyze()
       expect(historyResults.violations).toEqual([])
       await page.keyboard.press('Meta+k')
-      await page.getByRole('dialog', { name: 'Studio commands' }).waitFor()
+      const commandDialog = page.getByRole('dialog', {
+        name: 'Studio commands',
+      })
+      await commandDialog.waitFor()
+      await commandDialog.evaluate(async (element) => {
+        await Promise.all(
+          element
+            .getAnimations({ subtree: true })
+            .map((animation: BrowserAnimation) => animation.finished),
+        )
+      })
       const paletteResults = await new AxeBuilder({ page })
         .withTags(['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa', 'wcag22aa'])
         .analyze()

--- a/packages/cli/tests/unit/studio/studio-history.test.ts
+++ b/packages/cli/tests/unit/studio/studio-history.test.ts
@@ -67,20 +67,47 @@ test('pins and unpins a test run without mutating the immutable manifest', async
   expect(await Bun.file(manifestPath).bytes()).toEqual(before)
 })
 
-test('exports Studio Allure results as a valid empty ZIP archive', async () => {
+test('exports every Studio report format from a finalized Test run', async () => {
   const { root } = await fixture()
   const gateway = createStudioHistoryGateway(root, async () => ({}))
 
-  const bytes = await gateway.exportAllure('run-1')
+  const json = await gateway.exportReport({ runId: 'run-1', format: 'json' })
+  const ndjson = await gateway.exportReport({
+    runId: 'run-1',
+    format: 'ndjson',
+  })
+  const junit = await gateway.exportReport({
+    runId: 'run-1',
+    format: 'junit',
+  })
+  const html = await gateway.exportReport({
+    runId: 'run-1',
+    format: 'html',
+    htmlArtifacts: 'all',
+  })
+  const archive = await gateway.exportReport({
+    runId: 'run-1',
+    format: 'archive',
+  })
+  const allure = await gateway.exportReport({
+    runId: 'run-1',
+    format: 'allure',
+  })
 
-  expect([...bytes.slice(0, 4)]).toEqual([0x50, 0x4b, 0x05, 0x06])
+  expect(JSON.parse(String(json)).id).toBe('run-1')
+  expect(String(ndjson)).toContain('"type":')
+  expect(String(junit)).toContain('<testsuites')
+  expect(String(html)).toContain('<!DOCTYPE html>')
+  expect(JSON.parse(String(archive)).manifest.id).toBe('run-1')
+  if (!(allure instanceof Uint8Array)) throw new Error('Expected ZIP bytes')
+  expect([...allure.slice(0, 4)]).toEqual([0x50, 0x4b, 0x05, 0x06])
 })
 
-test('rejects Studio Allure export until the Test run is finalized', async () => {
+test('rejects Studio report export until the Test run is finalized', async () => {
   const { root } = await fixture(false)
   const gateway = createStudioHistoryGateway(root, async () => ({}))
 
-  await expect(gateway.exportAllure('run-1')).rejects.toThrow(
-    'must be finalized before export',
-  )
+  await expect(
+    gateway.exportReport({ runId: 'run-1', format: 'json' }),
+  ).rejects.toThrow('must be finalized before export')
 })

--- a/packages/mobile/tests/integration/benchmarking/mobile-benchmark-cli.test.ts
+++ b/packages/mobile/tests/integration/benchmarking/mobile-benchmark-cli.test.ts
@@ -44,6 +44,13 @@ function runCli(...args: string[]) {
   return executeCli(args)
 }
 
+async function runControlledBenchmark(
+  environment: Record<string, string | undefined> = Bun.env,
+) {
+  const first = await executeCli([], environment)
+  return first.exitCode === 1 ? executeCli([], environment) : first
+}
+
 describe('mobile benchmark executable', () => {
   test('controlled driver rejects every provider credential', async () => {
     for (const credentialName of providerCredentialEnvironmentNames) {
@@ -62,14 +69,14 @@ describe('mobile benchmark executable', () => {
         'must-not-reach-controlled-mobile',
       ]),
     )
-    const execution = await executeCli([], environment)
+    const execution = await runControlledBenchmark(environment)
 
     expect(execution.exitCode).toBe(0)
     expect(execution.stderr).toBe('')
   })
 
   test('runs the controlled driver by default and prints passing JSON', async () => {
-    const execution = await runCli()
+    const execution = await runControlledBenchmark()
     const report = JSON.parse(execution.stdout)
 
     expect(execution.exitCode).toBe(0)

--- a/packages/studio/index.ts
+++ b/packages/studio/index.ts
@@ -25,6 +25,8 @@ export type {
   StudioRunReadiness,
   StudioRunReadinessCheck,
   StudioRunReadinessCheckId,
+  StudioRunReport,
+  StudioRunReportRequest,
   StudioRunRequest,
   StudioRunSnapshot,
   StudioRunsIndex,

--- a/packages/studio/src/components/ui/select.tsx
+++ b/packages/studio/src/components/ui/select.tsx
@@ -1,0 +1,220 @@
+import { Select as SelectPrimitive } from '@base-ui/react/select'
+import {
+  ArrowDown01Icon,
+  ArrowUp01Icon,
+  Tick02Icon,
+  UnfoldMoreIcon,
+} from '@hugeicons/core-free-icons'
+import { HugeiconsIcon } from '@hugeicons/react'
+import type * as React from 'react'
+import { cn } from '../../lib/utils'
+
+function Select<Value, Multiple extends boolean | undefined = false>(
+  props: SelectPrimitive.Root.Props<Value, Multiple>,
+) {
+  return <SelectPrimitive.Root {...props} />
+}
+
+function SelectGroup({ className, ...props }: SelectPrimitive.Group.Props) {
+  return (
+    <SelectPrimitive.Group
+      data-slot="select-group"
+      className={cn('scroll-my-1 p-1', className)}
+      {...props}
+    />
+  )
+}
+
+function SelectValue({ className, ...props }: SelectPrimitive.Value.Props) {
+  return (
+    <SelectPrimitive.Value
+      data-slot="select-value"
+      className={cn('flex flex-1 text-left', className)}
+      {...props}
+    />
+  )
+}
+
+function SelectTrigger({
+  className,
+  size = 'default',
+  children,
+  ...props
+}: SelectPrimitive.Trigger.Props & {
+  size?: 'sm' | 'default'
+}) {
+  return (
+    <SelectPrimitive.Trigger
+      data-slot="select-trigger"
+      data-size={size}
+      className={cn(
+        "flex w-fit items-center justify-between gap-1.5 rounded-md border border-input bg-input/20 px-2 py-1.5 text-xs/relaxed whitespace-nowrap transition-colors outline-none focus-visible:border-ring focus-visible:ring-2 focus-visible:ring-ring/30 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-2 aria-invalid:ring-destructive/20 data-placeholder:text-muted-foreground data-[size=default]:h-7 data-[size=sm]:h-6 *:data-[slot=select-value]:line-clamp-1 *:data-[slot=select-value]:flex *:data-[slot=select-value]:items-center *:data-[slot=select-value]:gap-1.5 dark:bg-input/30 dark:hover:bg-input/50 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-3.5",
+        className,
+      )}
+      {...props}
+    >
+      {children}
+      <SelectPrimitive.Icon
+        render={
+          <HugeiconsIcon
+            icon={UnfoldMoreIcon}
+            strokeWidth={2}
+            className="pointer-events-none size-3.5 text-muted-foreground"
+          />
+        }
+      />
+    </SelectPrimitive.Trigger>
+  )
+}
+
+function SelectContent({
+  className,
+  children,
+  side = 'bottom',
+  sideOffset = 4,
+  align = 'center',
+  alignOffset = 0,
+  alignItemWithTrigger = true,
+  ...props
+}: SelectPrimitive.Popup.Props &
+  Pick<
+    SelectPrimitive.Positioner.Props,
+    'align' | 'alignOffset' | 'side' | 'sideOffset' | 'alignItemWithTrigger'
+  >) {
+  return (
+    <SelectPrimitive.Portal>
+      <SelectPrimitive.Positioner
+        side={side}
+        sideOffset={sideOffset}
+        align={align}
+        alignOffset={alignOffset}
+        alignItemWithTrigger={alignItemWithTrigger}
+        className="isolate z-50"
+      >
+        <SelectPrimitive.Popup
+          data-slot="select-content"
+          data-align-trigger={alignItemWithTrigger}
+          className={cn(
+            'relative isolate z-50 max-h-(--available-height) w-(--anchor-width) min-w-32 origin-(--transform-origin) overflow-x-hidden overflow-y-auto rounded-lg bg-popover text-popover-foreground shadow-md ring-1 ring-foreground/10 duration-100 data-[align-trigger=true]:animate-none data-[side=bottom]:slide-in-from-top-2 data-[side=inline-end]:slide-in-from-left-2 data-[side=inline-start]:slide-in-from-right-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95',
+            className,
+          )}
+          {...props}
+        >
+          <SelectScrollUpButton />
+          <SelectPrimitive.List>{children}</SelectPrimitive.List>
+          <SelectScrollDownButton />
+        </SelectPrimitive.Popup>
+      </SelectPrimitive.Positioner>
+    </SelectPrimitive.Portal>
+  )
+}
+
+function SelectLabel({
+  className,
+  ...props
+}: SelectPrimitive.GroupLabel.Props) {
+  return (
+    <SelectPrimitive.GroupLabel
+      data-slot="select-label"
+      className={cn('px-2 py-1.5 text-xs text-muted-foreground', className)}
+      {...props}
+    />
+  )
+}
+
+function SelectItem({
+  className,
+  children,
+  ...props
+}: SelectPrimitive.Item.Props) {
+  return (
+    <SelectPrimitive.Item
+      data-slot="select-item"
+      className={cn(
+        "relative flex min-h-7 w-full cursor-default items-center gap-2 rounded-md px-2 py-1 text-xs/relaxed outline-hidden select-none focus:bg-accent focus:text-accent-foreground not-data-[variant=destructive]:focus:**:text-accent-foreground data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-3.5 *:[span]:last:flex *:[span]:last:items-center *:[span]:last:gap-2",
+        className,
+      )}
+      {...props}
+    >
+      <SelectPrimitive.ItemText className="flex flex-1 shrink-0 gap-2 whitespace-nowrap">
+        {children}
+      </SelectPrimitive.ItemText>
+      <SelectPrimitive.ItemIndicator
+        render={
+          <span className="pointer-events-none absolute right-2 flex items-center justify-center" />
+        }
+      >
+        <HugeiconsIcon
+          icon={Tick02Icon}
+          strokeWidth={2}
+          className="pointer-events-none"
+        />
+      </SelectPrimitive.ItemIndicator>
+    </SelectPrimitive.Item>
+  )
+}
+
+function SelectSeparator({
+  className,
+  ...props
+}: SelectPrimitive.Separator.Props) {
+  return (
+    <SelectPrimitive.Separator
+      data-slot="select-separator"
+      className={cn(
+        'pointer-events-none -mx-1 my-1 h-px bg-border/50',
+        className,
+      )}
+      {...props}
+    />
+  )
+}
+
+function SelectScrollUpButton({
+  className,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.ScrollUpArrow>) {
+  return (
+    <SelectPrimitive.ScrollUpArrow
+      data-slot="select-scroll-up-button"
+      className={cn(
+        "top-0 z-10 flex w-full cursor-default items-center justify-center bg-popover py-1 [&_svg:not([class*='size-'])]:size-3.5",
+        className,
+      )}
+      {...props}
+    >
+      <HugeiconsIcon icon={ArrowUp01Icon} strokeWidth={2} />
+    </SelectPrimitive.ScrollUpArrow>
+  )
+}
+
+function SelectScrollDownButton({
+  className,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.ScrollDownArrow>) {
+  return (
+    <SelectPrimitive.ScrollDownArrow
+      data-slot="select-scroll-down-button"
+      className={cn(
+        "bottom-0 z-10 flex w-full cursor-default items-center justify-center bg-popover py-1 [&_svg:not([class*='size-'])]:size-3.5",
+        className,
+      )}
+      {...props}
+    >
+      <HugeiconsIcon icon={ArrowDown01Icon} strokeWidth={2} />
+    </SelectPrimitive.ScrollDownArrow>
+  )
+}
+
+export {
+  Select,
+  SelectContent,
+  SelectGroup,
+  SelectItem,
+  SelectLabel,
+  SelectScrollDownButton,
+  SelectScrollUpButton,
+  SelectSeparator,
+  SelectTrigger,
+  SelectValue,
+}

--- a/packages/studio/src/features/history/history.contracts.ts
+++ b/packages/studio/src/features/history/history.contracts.ts
@@ -1,10 +1,90 @@
 import type {
   HtmlArtifactMode,
   TestRunComparison,
+  TestRunExportFormat,
   TestRunManifest,
   TestRunStorageInspection,
   TestRunSummary,
 } from '@pickle-spec/runner'
+
+type StudioRunReportFormat = Exclude<TestRunExportFormat, 'html'>
+
+export type StudioRunReportRequest =
+  | {
+      runId: string
+      format: 'html'
+      htmlArtifacts: HtmlArtifactMode
+    }
+  | {
+      runId: string
+      format: StudioRunReportFormat
+      htmlArtifacts?: never
+    }
+
+export type StudioRunReport = string | Uint8Array
+
+interface StudioRunReportDescriptor {
+  format: TestRunExportFormat
+  label: string
+  contentType: string
+  filenameSuffix: string
+}
+
+type StudioRunReportMetadata = Omit<StudioRunReportDescriptor, 'format'>
+type StudioRunReportMetadataEntry = [
+  TestRunExportFormat,
+  StudioRunReportMetadata,
+]
+
+const studioRunReportMetadataByFormat = {
+  json: {
+    label: 'JSON report',
+    contentType: 'application/json; charset=utf-8',
+    filenameSuffix: '.json',
+  },
+  ndjson: {
+    label: 'NDJSON events',
+    contentType: 'application/x-ndjson; charset=utf-8',
+    filenameSuffix: '.ndjson',
+  },
+  junit: {
+    label: 'JUnit report',
+    contentType: 'application/xml; charset=utf-8',
+    filenameSuffix: '.xml',
+  },
+  html: {
+    label: 'HTML report',
+    contentType: 'text/html; charset=utf-8',
+    filenameSuffix: '.html',
+  },
+  archive: {
+    label: 'Run archive',
+    contentType: 'application/json; charset=utf-8',
+    filenameSuffix: '.pickle-run.json',
+  },
+  allure: {
+    label: 'Allure results',
+    contentType: 'application/zip',
+    filenameSuffix: '-allure-results.zip',
+  },
+} as const satisfies Record<TestRunExportFormat, StudioRunReportMetadata>
+
+export const studioRunReportDescriptors = (
+  Object.entries(
+    studioRunReportMetadataByFormat,
+  ) as StudioRunReportMetadataEntry[]
+).map(
+  ([format, metadata]): StudioRunReportDescriptor => ({
+    format,
+    ...metadata,
+  }),
+)
+
+export function studioRunReportDescriptor(
+  value: string,
+): StudioRunReportDescriptor | undefined {
+  return studioRunReportDescriptors.find(({ format }) => format === value)
+}
 
 export interface StudioHistoryGateway {
   list(): Promise<StudioHistory>
@@ -13,9 +93,7 @@ export interface StudioHistoryGateway {
     candidateRunId: string,
   ): Promise<TestRunComparison>
   importArchive(bytes: Uint8Array): Promise<TestRunManifest>
-  exportArchive(runId: string): Promise<string>
-  exportHtml(runId: string, artifacts: HtmlArtifactMode): Promise<string>
-  exportAllure(runId: string): Promise<Uint8Array>
+  exportReport(request: StudioRunReportRequest): Promise<StudioRunReport>
   deleteEligible(): Promise<{
     removed: string[]
     beforeBytes: number

--- a/packages/studio/src/features/history/history.routes.ts
+++ b/packages/studio/src/features/history/history.routes.ts
@@ -5,7 +5,12 @@ import {
   type StudioHttpHandler,
   unavailable,
 } from '../../server/http'
-import type { StudioHistoryGateway, StudioRunsIndex } from './history.contracts'
+import type {
+  StudioHistoryGateway,
+  StudioRunReportRequest,
+  StudioRunsIndex,
+} from './history.contracts'
+import { studioRunReportDescriptor } from './history.contracts'
 
 type HistoryComparisonRequest = {
   baselineRunId?: string
@@ -83,40 +88,36 @@ async function exportHistory(
 ): Promise<Response> {
   if (!options.history) return historyUnavailable()
   const runId = decodeURIComponent(requiredValue(match[1]))
-  const exporters: Record<string, () => Promise<Response>> = {
-    archive: async () =>
-      new Response(await requiredValue(options.history).exportArchive(runId), {
-        headers: {
-          'content-type': 'application/json; charset=utf-8',
-          'content-disposition': `attachment; filename="${runId}.pickle-run.json"`,
-        },
-      }),
-    allure: async () => {
-      const bytes = await requiredValue(options.history).exportAllure(runId)
-      return new Response(bytes.buffer as ArrayBuffer, {
-        headers: {
-          'content-type': 'application/zip',
-          'content-disposition': `attachment; filename="${runId}-allure-results.zip"`,
-        },
-      })
-    },
-    html: async () => {
-      const artifacts =
-        url.searchParams.get('artifacts') === 'all' ? 'all' : 'failures'
-      const html = await requiredValue(options.history).exportHtml(
-        runId,
-        artifacts,
-      )
-      return new Response(html, {
-        headers: {
-          'content-type': 'text/html; charset=utf-8',
-          'content-disposition': `attachment; filename="${runId}.html"`,
-        },
-      })
-    },
+  const format = decodeURIComponent(requiredValue(match[2]))
+  const descriptor = studioRunReportDescriptor(format)
+  if (!descriptor) return new Response('Not found', { status: 404 })
+  try {
+    const request: StudioRunReportRequest =
+      descriptor.format === 'html'
+        ? {
+            runId,
+            format: 'html',
+            htmlArtifacts:
+              url.searchParams.get('artifacts') === 'all' ? 'all' : 'failures',
+          }
+        : { runId, format: descriptor.format }
+    const body = await options.history.exportReport(request)
+    const responseBody =
+      typeof body === 'string'
+        ? body
+        : (body.buffer.slice(
+            body.byteOffset,
+            body.byteOffset + body.byteLength,
+          ) as ArrayBuffer)
+    return new Response(responseBody, {
+      headers: {
+        'content-type': descriptor.contentType,
+        'content-disposition': `attachment; filename="${runId}${descriptor.filenameSuffix}"`,
+      },
+    })
+  } catch (error) {
+    return requestError(error)
   }
-  const exporter = match[2] ? exporters[match[2]] : undefined
-  return exporter ? exporter() : new Response('Not found', { status: 404 })
 }
 
 async function handleHistoryRequest(
@@ -138,9 +139,7 @@ async function handleHistoryRequest(
   if (pinMatch && ['POST', 'DELETE'].includes(request.method)) {
     return pinHistory(options, request, pinMatch)
   }
-  const exportMatch = url.pathname.match(
-    /^\/api\/history\/([^/]+)\/(html|archive|allure)$/,
-  )
+  const exportMatch = url.pathname.match(/^\/api\/history\/([^/]+)\/([^/]+)$/)
   return exportMatch && request.method === 'GET'
     ? exportHistory(options, url, exportMatch)
     : null

--- a/packages/studio/src/features/runs/components/run-history.tsx
+++ b/packages/studio/src/features/runs/components/run-history.tsx
@@ -13,8 +13,7 @@ type RunHistoryProps = Pick<
   | 'filterOptions'
   | 'filters'
   | 'items'
-  | 'openingRunId'
-  | 'openRunAttempt'
+  | 'openRun'
   | 'pinnedRunIds'
   | 'selectedRunIds'
   | 'setFilters'
@@ -58,8 +57,7 @@ export function RunHistory(props: RunHistoryProps) {
           pinnedRunIds={props.pinnedRunIds}
           specificationNames={props.specificationNames}
           runsBlocked={props.runsBlocked}
-          openingRunId={props.openingRunId}
-          onOpen={props.openRunAttempt}
+          onOpen={props.openRun}
           onPin={props.setPinned}
           onRerun={props.onRerun}
           onSelect={props.setSelectedRunIds}

--- a/packages/studio/src/features/runs/components/run-table.tsx
+++ b/packages/studio/src/features/runs/components/run-table.tsx
@@ -4,7 +4,6 @@ import { Badge } from '../../../components/ui/badge'
 import { Button, buttonVariants } from '../../../components/ui/button'
 import { Checkbox } from '../../../components/ui/checkbox'
 import { ResultMark } from '../../../components/ui/result-mark'
-import { Spinner } from '../../../components/ui/spinner'
 import {
   Table,
   TableBody,
@@ -33,7 +32,6 @@ type RunTableProps = {
   pinnedRunIds: ReadonlySet<string>
   specificationNames: ReadonlyMap<string, string>
   runsBlocked: boolean
-  openingRunId?: string
   onOpen: (runId: string) => void
   onPin: (runId: string, pinned: boolean) => void
   onRerun: (request: StudioRunRequest) => Promise<void>
@@ -86,7 +84,6 @@ function RunTableRow(props: Omit<RunTableProps, 'items'> & RunListItem) {
   const { summary, state } = props
   const selected = props.selectedRunIds.includes(summary.id)
   const pinned = props.pinnedRunIds.has(summary.id)
-  const opening = props.openingRunId === summary.id
 
   function handleSelectionChange(checked: boolean) {
     props.onSelect((current) =>
@@ -128,11 +125,7 @@ function RunTableRow(props: Omit<RunTableProps, 'items'> & RunListItem) {
         </Tooltip>
       </TableCell>
       <TableCell>
-        <RunIdentity
-          summary={summary}
-          opening={opening}
-          onOpen={props.onOpen}
-        />
+        <RunIdentity summary={summary} onOpen={props.onOpen} />
       </TableCell>
       <TableCell>
         {summary.specificationUris
@@ -165,7 +158,6 @@ function RunTableRow(props: Omit<RunTableProps, 'items'> & RunListItem) {
 
 function RunIdentity(props: {
   summary: TestRunSummary
-  opening: boolean
   onOpen: (runId: string) => void
 }) {
   function handleOpen() {
@@ -176,14 +168,11 @@ function RunIdentity(props: {
       <Button
         type="button"
         variant="link"
-        aria-label={`Open attempt for ${props.summary.id}`}
-        aria-busy={props.opening}
-        disabled={props.opening}
+        aria-label={`Open run ${props.summary.id}`}
         className="h-auto gap-1.5 p-0 font-mono text-left active:opacity-65"
         onClick={handleOpen}
       >
         {props.summary.id}
-        {props.opening ? <Spinner className="scale-75" /> : null}
       </Button>
       <time
         dateTime={props.summary.startedAt}

--- a/packages/studio/src/features/runs/hooks/use-runs-dashboard.ts
+++ b/packages/studio/src/features/runs/hooks/use-runs-dashboard.ts
@@ -6,13 +6,8 @@ import type {
 import { type Dispatch, type SetStateAction, useMemo, useState } from 'react'
 import { toast } from '../../../components/ui/toast'
 import type { StudioApi } from '../../../lib/studio-api'
-import type {
-  StudioProject,
-  StudioRunSnapshot,
-  StudioRunsIndex,
-} from '../../../server/contracts'
+import type { StudioProject, StudioRunsIndex } from '../../../server/contracts'
 import type { RunsFilters, StudioRoute } from '../../studio/studio-route'
-import { defaultRunAttemptLocation } from '../result/live-result-follow'
 import type { LiveResultInspection } from '../result/live-result-inspection'
 import { reasonMessage } from '../result/result-presentation'
 import {
@@ -36,7 +31,6 @@ export type RunsDashboardModel = {
   filterOptions: RunFilterOptions
   filters: RunsFilters
   items: RunListItem[]
-  openingRunId?: string
   pinnedRunIds: ReadonlySet<string>
   selectedRunIds: readonly string[]
   specificationNames: ReadonlyMap<string, string>
@@ -45,7 +39,7 @@ export type RunsDashboardModel = {
   compareSelected: () => void
   deleteEligible: () => void
   importArchive: (file?: File) => void
-  openRunAttempt: (runId: string) => void
+  openRun: (runId: string) => void
   setFilters: (patch: Partial<RunsFilters>) => void
   setPinned: (runId: string, pinned: boolean) => void
   setSelectedRunIds: Dispatch<SetStateAction<string[]>>
@@ -55,13 +49,12 @@ type RunsDashboardState = Pick<
   RunsDashboardModel,
   | 'comparison'
   | 'error'
-  | 'openingRunId'
   | 'selectedRunIds'
   | 'clearFilters'
   | 'compareSelected'
   | 'deleteEligible'
   | 'importArchive'
-  | 'openRunAttempt'
+  | 'openRun'
   | 'setFilters'
   | 'setPinned'
   | 'setSelectedRunIds'
@@ -126,7 +119,6 @@ function useRunsDashboardState(
   filters: RunsFilters,
 ): RunsDashboardState {
   const [error, setError] = useState<string>()
-  const [openingRunId, setOpeningRunId] = useState<string>()
   const [selectedRunIds, setSelectedRunIds] = useState<string[]>([])
   const [comparison, setComparison] = useState<TestRunComparison>()
   const navigateToFilters = (nextFilters: RunsFilters) =>
@@ -135,7 +127,6 @@ function useRunsDashboardState(
   return {
     comparison,
     error,
-    openingRunId,
     selectedRunIds,
     clearFilters: () => navigateToFilters({}),
     compareSelected: () =>
@@ -154,8 +145,7 @@ function useRunsDashboardState(
         setError,
       ),
     importArchive: (file) => void importRunArchive(options, file, setError),
-    openRunAttempt: (runId) =>
-      void openRunAttempt(options, runId, setOpeningRunId, setError),
+    openRun: (runId) => options.onNavigate({ kind: 'run', runId }),
     setFilters: (patch) => navigateToFilters({ ...filters, ...patch }),
     setPinned: (runId, pinned) =>
       void setRunPinned(options, runId, pinned, setError),
@@ -183,29 +173,6 @@ function useRunCollections(options: UseRunsDashboardOptions) {
     [activeIds, options.index?.runs],
   )
   return { activeIds, allItems, specificationNames }
-}
-
-async function openRunAttempt(
-  options: Pick<UseRunsDashboardOptions, 'api' | 'onNavigate'>,
-  runId: string,
-  setOpeningRunId: Dispatch<SetStateAction<string | undefined>>,
-  setError: (error?: string) => void,
-) {
-  setError(undefined)
-  setOpeningRunId(runId)
-  try {
-    const snapshot = await options.api<StudioRunSnapshot>(
-      `/api/runs/${encodeURIComponent(runId)}`,
-    )
-    const location = defaultRunAttemptLocation(snapshot)
-    options.onNavigate(
-      location ? { kind: 'result', location } : { kind: 'run', runId },
-    )
-  } catch (reason) {
-    setError(reasonMessage(reason))
-  } finally {
-    setOpeningRunId((current) => (current === runId ? undefined : current))
-  }
 }
 
 async function compareSelectedRuns(

--- a/packages/studio/src/features/runs/run-attempts.tsx
+++ b/packages/studio/src/features/runs/run-attempts.tsx
@@ -1,0 +1,223 @@
+import type {
+  ScenarioAttempt,
+  TestResult,
+  TestRunManifest,
+} from '@pickle-spec/runner'
+import { useMemo } from 'react'
+import { Button } from '../../components/ui/button'
+import { Label } from '../../components/ui/label'
+import {
+  Select,
+  SelectContent,
+  SelectGroup,
+  SelectItem,
+  SelectLabel,
+  SelectTrigger,
+  SelectValue,
+} from '../../components/ui/select'
+import type { StudioApi } from '../../lib/studio-api'
+import type {
+  StudioRunRequest,
+  StudioRunSnapshot,
+} from '../../server/contracts'
+import { defaultRunAttemptLocation } from './result/live-result-follow'
+import {
+  type LiveResultInspection,
+  liveViewportFor,
+} from './result/live-result-inspection'
+import { locationFromResult } from './result/live-result-projection'
+import { findInspectedResult } from './result/result-evidence'
+import type { ResultInspectionLocation } from './result/result-inspection'
+import { ResultInspector } from './result/result-inspector'
+
+type RunAttempt = { result: TestResult; attempt: ScenarioAttempt }
+
+type RunAttemptsProps = {
+  api: StudioApi
+  runId: string
+  manifest: TestRunManifest
+  snapshot: StudioRunSnapshot
+  selectedLocation?: ResultInspectionLocation
+  live?: LiveResultInspection
+  running: boolean
+  runsBlocked: boolean
+  onOpenArtifact: (
+    location: ResultInspectionLocation,
+    artifactIndex: number,
+  ) => void
+  onRerun: (request: StudioRunRequest) => Promise<void>
+  onSelectLocation: (location: ResultInspectionLocation) => void
+}
+
+export function RunAttempts(props: RunAttemptsProps) {
+  const attempts = useMemo(
+    () =>
+      props.manifest.results.flatMap((result) =>
+        result.attempts.map((attempt) => ({ result, attempt })),
+      ),
+    [props.manifest.results],
+  )
+  const selectedLocation = selectedAttemptLocation(
+    props.snapshot,
+    props.selectedLocation,
+  )
+  return (
+    <section className="space-y-2" aria-labelledby="run-results-title">
+      <RunAttemptPicker
+        {...props}
+        attempts={attempts}
+        selectedLocation={selectedLocation}
+      />
+      {attempts.length === 0 ? (
+        <div className="rounded-lg border border-dashed border-border px-4 py-5 text-center text-sm text-muted-foreground">
+          {props.running
+            ? 'Waiting for the first Scenario to start.'
+            : 'This Test run has no results.'}
+        </div>
+      ) : (
+        selectedLocation && (
+          <ResultInspector
+            api={props.api}
+            location={selectedLocation}
+            snapshot={props.snapshot}
+            connection={props.live?.connection}
+            liveViewport={
+              props.live
+                ? liveViewportFor(props.live, selectedLocation)
+                : undefined
+            }
+            onOpenArtifact={(artifactIndex) =>
+              props.onOpenArtifact(selectedLocation, artifactIndex)
+            }
+            onTabChange={(tab) =>
+              props.onSelectLocation({ ...selectedLocation, tab })
+            }
+          />
+        )
+      )}
+    </section>
+  )
+}
+
+function RunAttemptPicker(
+  props: RunAttemptsProps & {
+    attempts: readonly RunAttempt[]
+  },
+) {
+  const selectedLocation = props.selectedLocation
+  const selected = selectedLocation
+    ? props.attempts.find(
+        (item) => attemptKey(item) === locationKey(selectedLocation),
+      )
+    : undefined
+  function selectAttempt(value: string | null) {
+    const item = props.attempts.find((attempt) => attemptKey(attempt) === value)
+    if (!item) return
+    props.onSelectLocation(
+      locationFromResult('', props.runId, item.result, item.attempt),
+    )
+  }
+  return (
+    <div className="flex flex-wrap items-end justify-between gap-3 border-b border-border pb-4">
+      <div className="min-w-0 basis-full space-y-2 sm:flex-1">
+        <div className="flex items-baseline gap-2">
+          <h2 id="run-results-title" className="studio-display text-sm">
+            Test results
+          </h2>
+          <span className="text-xs text-muted-foreground">
+            {props.attempts.length}{' '}
+            {props.attempts.length === 1 ? 'attempt' : 'attempts'}
+          </span>
+        </div>
+        {props.attempts.length > 0 ? (
+          <div className="max-w-2xl space-y-1.5">
+            <Label htmlFor="run-attempt-select">Attempt</Label>
+            <Select
+              value={selected ? attemptKey(selected) : null}
+              onValueChange={selectAttempt}
+            >
+              <SelectTrigger
+                id="run-attempt-select"
+                aria-label="Attempt"
+                className="h-auto min-h-9 w-full py-2"
+              >
+                <SelectValue placeholder="Select an attempt">
+                  {selected ? attemptLabel(selected) : undefined}
+                </SelectValue>
+              </SelectTrigger>
+              <SelectContent align="start">
+                <SelectGroup>
+                  <SelectLabel>Scenario attempts</SelectLabel>
+                  {props.attempts.map((item) => (
+                    <SelectItem key={attemptKey(item)} value={attemptKey(item)}>
+                      {attemptLabel(item)}
+                    </SelectItem>
+                  ))}
+                </SelectGroup>
+              </SelectContent>
+            </Select>
+          </div>
+        ) : null}
+      </div>
+      {selected ? <SelectedAttemptActions {...props} {...selected} /> : null}
+    </div>
+  )
+}
+
+function SelectedAttemptActions(props: RunAttemptsProps & RunAttempt) {
+  const { result } = props
+  const rerunScenario = () =>
+    void props.onRerun({
+      rerunId: props.runId,
+      scenarioId: result.scenario.id,
+      scenarioName: result.scenario.id ? undefined : result.scenario.name,
+    })
+  const rerunTarget = () =>
+    void props.onRerun({
+      rerunId: props.runId,
+      profiles: [result.executionTargetProfile.id],
+    })
+  return (
+    <div className="flex flex-wrap gap-2">
+      <Button
+        type="button"
+        size="sm"
+        variant="outline"
+        disabled={props.runsBlocked}
+        onClick={rerunScenario}
+      >
+        Rerun Scenario
+      </Button>
+      <Button
+        type="button"
+        size="sm"
+        variant="outline"
+        disabled={props.runsBlocked}
+        onClick={rerunTarget}
+      >
+        Rerun target
+      </Button>
+    </div>
+  )
+}
+
+function attemptKey({ result, attempt }: RunAttempt): string {
+  return `${result.specification.uri}:${result.scenario.id ?? result.scenario.name}:${result.scenario.examplesRowId ?? ''}:${result.executionTargetProfile.id}:${attempt.attempt}`
+}
+
+function locationKey(location: ResultInspectionLocation): string {
+  return `${location.specificationUri}:${location.scenarioId}:${location.examplesRowId ?? ''}:${location.profileId}:${location.attempt}`
+}
+
+function attemptLabel({ result, attempt }: RunAttempt): string {
+  return `${result.scenario.name} · ${result.executionTargetProfile.id} · Attempt ${attempt.attempt} · ${attempt.state}`
+}
+
+function selectedAttemptLocation(
+  snapshot: StudioRunSnapshot,
+  selected: ResultInspectionLocation | undefined,
+): ResultInspectionLocation | undefined {
+  return selected && findInspectedResult(snapshot, selected)
+    ? selected
+    : defaultRunAttemptLocation(snapshot)
+}

--- a/packages/studio/src/features/runs/run-detail.tsx
+++ b/packages/studio/src/features/runs/run-detail.tsx
@@ -1,10 +1,5 @@
-import type {
-  ScenarioAttempt,
-  TestResult,
-  TestRunExportFormat,
-  TestRunManifest,
-} from '@pickle-spec/runner'
-import { useEffect, useMemo, useState } from 'react'
+import type { TestRunExportFormat, TestRunManifest } from '@pickle-spec/runner'
+import { useEffect, useState } from 'react'
 import { LedgerLoadingSkeleton } from '../../components/loading-skeletons'
 import { Badge } from '../../components/ui/badge'
 import { Button, buttonVariants } from '../../components/ui/button'
@@ -19,15 +14,6 @@ import {
   DropdownMenuTrigger,
 } from '../../components/ui/dropdown-menu'
 import { ResultMark } from '../../components/ui/result-mark'
-import {
-  Table,
-  TableBody,
-  TableCell,
-  TableHead,
-  TableHeader,
-  TableRow,
-} from '../../components/ui/table'
-import { useVirtualWindow } from '../../hooks/use-virtual-window'
 import type { StudioApi } from '../../lib/studio-api'
 import type {
   StudioRunRequest,
@@ -37,21 +23,24 @@ import { studioRunReportDescriptors } from '../history/history.contracts'
 import type { LiveResultInspection } from './result/live-result-inspection'
 import type { ResultInspectionLocation } from './result/result-inspection'
 import { reasonMessage, resultBadgeVariant } from './result/result-presentation'
+import { RunAttempts } from './run-attempts'
 import { durationLabel, inferenceCountLabel } from './run-format'
-import { VirtualTableSpacer } from './virtual-table-spacer'
 
 type RunDetailProps = {
   api: StudioApi
   runId: string
+  location?: ResultInspectionLocation
   live?: LiveResultInspection
   runsBlocked: boolean
   onBack: () => void
   onCancel: (runId: string) => void
-  onInspectResult: (location: ResultInspectionLocation) => void
+  onOpenArtifact: (
+    location: ResultInspectionLocation,
+    artifactIndex: number,
+  ) => void
+  onSelectLocation: (location: ResultInspectionLocation) => void
   onRerun: (request: StudioRunRequest) => Promise<void>
 }
-
-const resultRowHeight = 56
 
 function useFetchedRunSnapshot(props: RunDetailProps) {
   const [snapshot, setSnapshot] = useState<StudioRunSnapshot>()
@@ -103,6 +92,8 @@ export function RunDetail(props: RunDetailProps) {
     <LoadedRunDetail
       {...props}
       manifest={snapshot.manifest}
+      snapshot={snapshot}
+      selectedLocation={props.location}
       includeAllArtifacts={includeAllArtifacts}
       onIncludeAllArtifacts={setIncludeAllArtifacts}
     />
@@ -188,24 +179,15 @@ function RunDetailHeader(
 function LoadedRunDetail(
   props: RunDetailProps & {
     manifest: TestRunManifest
+    snapshot: StudioRunSnapshot
+    selectedLocation?: ResultInspectionLocation
     includeAllArtifacts: boolean
     onIncludeAllArtifacts: (include: boolean) => void
+    onSelectLocation: (location: ResultInspectionLocation) => void
   },
 ) {
   const manifest = props.manifest
-  const attempts = useMemo(
-    () =>
-      manifest.results.flatMap((result) =>
-        result.attempts.map((attempt) => ({ result, attempt })),
-      ),
-    [manifest.results],
-  )
-  const resultWindow = useVirtualWindow<HTMLDivElement>({
-    count: attempts.length,
-    itemSize: resultRowHeight,
-  })
   const running = props.live?.phase === 'running'
-  const visibleAttempts = attempts.slice(resultWindow.start, resultWindow.end)
 
   return (
     <section className="min-h-0 flex-1 space-y-5 overflow-auto px-3 py-4 sm:px-5">
@@ -213,170 +195,9 @@ function LoadedRunDetail(
 
       <RunMetadata manifest={manifest} />
 
-      <RunResults
-        {...props}
-        attempts={attempts}
-        running={running}
-        visibleAttempts={visibleAttempts}
-        window={resultWindow}
-      />
+      <RunAttempts {...props} running={running} />
     </section>
   )
-}
-
-type RunAttempt = { result: TestResult; attempt: ScenarioAttempt }
-
-function RunResults(
-  props: RunDetailProps & {
-    attempts: readonly RunAttempt[]
-    running: boolean
-    visibleAttempts: readonly RunAttempt[]
-    window: ReturnType<typeof useVirtualWindow<HTMLDivElement>>
-  },
-) {
-  return (
-    <section className="space-y-2" aria-labelledby="run-results-title">
-      <div className="flex items-center justify-between gap-3">
-        <h2 id="run-results-title" className="studio-display text-sm">
-          Test results
-        </h2>
-        <span className="text-xs text-muted-foreground">
-          {props.attempts.length}{' '}
-          {props.attempts.length === 1 ? 'attempt' : 'attempts'}
-        </span>
-      </div>
-      {props.attempts.length === 0 ? (
-        <div className="rounded-lg border border-dashed border-border px-4 py-5 text-center text-sm text-muted-foreground">
-          {props.running
-            ? 'Waiting for the first Scenario to start.'
-            : 'This Test run has no results.'}
-        </div>
-      ) : (
-        <RunAttemptsTable {...props} />
-      )}
-    </section>
-  )
-}
-
-function RunAttemptsTable(
-  props: RunDetailProps & {
-    visibleAttempts: readonly RunAttempt[]
-    window: ReturnType<typeof useVirtualWindow<HTMLDivElement>>
-  },
-) {
-  const headings = [
-    'Specification',
-    'Scenario',
-    'Target',
-    'State',
-    'Attempt',
-    'Execution mode',
-    'Cache outcome',
-    'Uncacheable reason',
-    'Inferences',
-    'Duration',
-    'Actions',
-  ]
-  return (
-    <section
-      ref={props.window.containerRef}
-      aria-label="Scrollable Test run results"
-      // biome-ignore lint/a11y/noNoninteractiveTabindex: keyboard users must be able to scroll a virtualized region
-      tabIndex={0}
-      className="max-h-[36rem] overflow-auto rounded-lg border border-border bg-card"
-    >
-      <Table aria-label="Test run results">
-        <TableHeader>
-          <TableRow>
-            {headings.map((heading) => (
-              <TableHead key={heading}>{heading}</TableHead>
-            ))}
-          </TableRow>
-        </TableHeader>
-        <TableBody>
-          <VirtualTableSpacer height={props.window.before} colSpan={11} />
-          {props.visibleAttempts.map((item) => (
-            <RunAttemptRow {...props} {...item} key={attemptKey(item)} />
-          ))}
-          <VirtualTableSpacer height={props.window.after} colSpan={11} />
-        </TableBody>
-      </Table>
-    </section>
-  )
-}
-
-function RunAttemptRow(props: RunDetailProps & RunAttempt) {
-  const { attempt, result } = props
-  return (
-    <TableRow style={{ height: resultRowHeight }}>
-      <TableCell>{result.specification.name}</TableCell>
-      <TableCell>{result.scenario.name}</TableCell>
-      <TableCell>{result.executionTargetProfile.id}</TableCell>
-      <TableCell>{attempt.state}</TableCell>
-      <TableCell>{attempt.attempt}</TableCell>
-      <TableCell>{attempt.executionMode ?? 'Not recorded'}</TableCell>
-      <TableCell>{attempt.cacheOutcome ?? 'Not recorded'}</TableCell>
-      <TableCell>{attempt.cacheUncacheableReason ?? 'Not recorded'}</TableCell>
-      <TableCell>{inferenceCountLabel(attempt.inferenceCount)}</TableCell>
-      <TableCell>{durationLabel(attempt.durationMs)}</TableCell>
-      <TableCell>
-        <RunAttemptActions {...props} />
-      </TableCell>
-    </TableRow>
-  )
-}
-
-function RunAttemptActions(props: RunDetailProps & RunAttempt) {
-  const { attempt, result } = props
-  const inspect = () =>
-    props.onInspectResult({
-      specificationUri: result.specification.uri,
-      runId: props.runId,
-      scenarioId: result.scenario.id ?? result.scenario.name,
-      examplesRowId: result.scenario.examplesRowId,
-      profileId: result.executionTargetProfile.id,
-      attempt: attempt.attempt,
-    })
-  const rerunScenario = () =>
-    void props.onRerun({
-      rerunId: props.runId,
-      scenarioId: result.scenario.id,
-      scenarioName: result.scenario.id ? undefined : result.scenario.name,
-    })
-  const rerunTarget = () =>
-    void props.onRerun({
-      rerunId: props.runId,
-      profiles: [result.executionTargetProfile.id],
-    })
-  return (
-    <div className="flex gap-2">
-      <Button type="button" size="sm" variant="outline" onClick={inspect}>
-        Inspect result
-      </Button>
-      <Button
-        type="button"
-        size="sm"
-        variant="outline"
-        disabled={props.runsBlocked}
-        onClick={rerunScenario}
-      >
-        Rerun Scenario
-      </Button>
-      <Button
-        type="button"
-        size="sm"
-        variant="outline"
-        disabled={props.runsBlocked}
-        onClick={rerunTarget}
-      >
-        Rerun target
-      </Button>
-    </div>
-  )
-}
-
-function attemptKey({ result, attempt }: RunAttempt): string {
-  return `${result.specification.uri}:${result.scenario.id ?? result.scenario.name}:${result.scenario.examplesRowId ?? ''}:${result.executionTargetProfile.id}:${attempt.attempt}`
 }
 
 function RunDetailMessage(props: {

--- a/packages/studio/src/features/runs/run-detail.tsx
+++ b/packages/studio/src/features/runs/run-detail.tsx
@@ -1,22 +1,23 @@
 import type {
   ScenarioAttempt,
   TestResult,
+  TestRunExportFormat,
   TestRunManifest,
 } from '@pickle-spec/runner'
 import { useEffect, useMemo, useState } from 'react'
 import { LedgerLoadingSkeleton } from '../../components/loading-skeletons'
 import { Badge } from '../../components/ui/badge'
 import { Button, buttonVariants } from '../../components/ui/button'
-import { Checkbox } from '../../components/ui/checkbox'
 import {
   DropdownMenu,
+  DropdownMenuCheckboxItem,
   DropdownMenuContent,
   DropdownMenuGroup,
   DropdownMenuItem,
   DropdownMenuLabel,
+  DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from '../../components/ui/dropdown-menu'
-import { Label } from '../../components/ui/label'
 import { ResultMark } from '../../components/ui/result-mark'
 import {
   Table,
@@ -32,6 +33,7 @@ import type {
   StudioRunRequest,
   StudioRunSnapshot,
 } from '../../server/contracts'
+import { studioRunReportDescriptors } from '../history/history.contracts'
 import type { LiveResultInspection } from './result/live-result-inspection'
 import type { ResultInspectionLocation } from './result/result-inspection'
 import { reasonMessage, resultBadgeVariant } from './result/result-presentation'
@@ -111,7 +113,6 @@ function RunDetailHeader(
   props: RunDetailProps & {
     manifest: TestRunManifest
     running: boolean
-    artifactMode: 'all' | 'failures'
     includeAllArtifacts: boolean
     onIncludeAllArtifacts: (include: boolean) => void
   },
@@ -167,7 +168,6 @@ function RunDetailHeader(
         ) : (
           <ExportMenu
             runId={props.manifest.id}
-            artifactMode={props.artifactMode}
             includeAllArtifacts={props.includeAllArtifacts}
             onIncludeAllArtifacts={props.onIncludeAllArtifacts}
           />
@@ -193,7 +193,6 @@ function LoadedRunDetail(
   },
 ) {
   const manifest = props.manifest
-  const includeAllArtifacts = props.includeAllArtifacts
   const attempts = useMemo(
     () =>
       manifest.results.flatMap((result) =>
@@ -206,17 +205,11 @@ function LoadedRunDetail(
     itemSize: resultRowHeight,
   })
   const running = props.live?.phase === 'running'
-  const artifactMode = includeAllArtifacts ? 'all' : 'failures'
   const visibleAttempts = attempts.slice(resultWindow.start, resultWindow.end)
 
   return (
     <section className="min-h-0 flex-1 space-y-5 overflow-auto px-3 py-4 sm:px-5">
-      <RunDetailHeader
-        {...props}
-        manifest={manifest}
-        running={running}
-        artifactMode={artifactMode}
-      />
+      <RunDetailHeader {...props} manifest={manifest} running={running} />
 
       <RunMetadata manifest={manifest} />
 
@@ -492,62 +485,61 @@ function Metadata(props: { label: string; value: string; mono?: boolean }) {
 
 function ExportMenu(props: {
   runId: string
-  artifactMode: 'all' | 'failures'
   includeAllArtifacts: boolean
   onIncludeAllArtifacts: (checked: boolean) => void
 }) {
   return (
-    <>
-      <DropdownMenu>
-        <DropdownMenuTrigger
-          type="button"
-          className={buttonVariants({ variant: 'outline' })}
-        >
-          Export
-        </DropdownMenuTrigger>
-        <DropdownMenuContent align="end">
-          <DropdownMenuGroup>
-            <DropdownMenuLabel>Test run export</DropdownMenuLabel>
+    <DropdownMenu>
+      <DropdownMenuTrigger
+        type="button"
+        className={buttonVariants({ variant: 'outline' })}
+      >
+        Download report
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end">
+        <DropdownMenuGroup>
+          <DropdownMenuLabel>Report format</DropdownMenuLabel>
+          {studioRunReportDescriptors.map((descriptor) => (
             <ExportItem
-              runId={props.runId}
-              kind="archive"
-              label="Run archive"
+              key={descriptor.format}
+              href={reportDownloadHref(
+                props.runId,
+                descriptor.format,
+                props.includeAllArtifacts,
+              )}
+              label={descriptor.label}
             />
-            <ExportItem
-              runId={props.runId}
-              kind={`html?artifacts=${props.artifactMode}`}
-              label="HTML report"
-            />
-            <ExportItem
-              runId={props.runId}
-              kind="allure"
-              label="Allure results"
-            />
-          </DropdownMenuGroup>
-        </DropdownMenuContent>
-      </DropdownMenu>
-      <span className="flex items-center gap-2">
-        <Checkbox
-          id="complete-artifacts"
-          checked={props.includeAllArtifacts}
-          onCheckedChange={props.onIncludeAllArtifacts}
-        />
-        <Label htmlFor="complete-artifacts">Include all artifacts</Label>
-      </span>
-    </>
+          ))}
+          <DropdownMenuSeparator />
+          <DropdownMenuLabel>HTML options</DropdownMenuLabel>
+          <DropdownMenuCheckboxItem
+            checked={props.includeAllArtifacts}
+            closeOnClick={false}
+            onCheckedChange={props.onIncludeAllArtifacts}
+          >
+            Include all artifacts in HTML report
+          </DropdownMenuCheckboxItem>
+        </DropdownMenuGroup>
+      </DropdownMenuContent>
+    </DropdownMenu>
   )
 }
 
-function ExportItem(props: { runId: string; kind: string; label: string }) {
+function reportDownloadHref(
+  runId: string,
+  format: TestRunExportFormat,
+  includeAllArtifacts: boolean,
+): string {
+  const artifacts =
+    format === 'html' && includeAllArtifacts ? '?artifacts=all' : ''
+  return `/api/history/${encodeURIComponent(runId)}/${format}${artifacts}`
+}
+
+function ExportItem(props: { href: string; label: string }) {
   return (
     <DropdownMenuItem
       nativeButton={false}
-      render={
-        <a
-          href={`/api/history/${encodeURIComponent(props.runId)}/${props.kind}`}
-          download
-        />
-      }
+      render={<a href={props.href} download />}
     >
       {props.label}
     </DropdownMenuItem>

--- a/packages/studio/src/features/runs/runs.tsx
+++ b/packages/studio/src/features/runs/runs.tsx
@@ -104,6 +104,7 @@ function SingleRunRoute(
   },
 ) {
   if (props.route.kind !== 'run') return null
+  const runId = props.route.runId
   const onRerun = async (request: StudioRunRequest) => {
     await props.onRerun(request)
     props.onNavigate({ kind: 'runs', filters: {} })
@@ -111,13 +112,20 @@ function SingleRunRoute(
   return (
     <RunDetail
       api={props.api}
-      runId={props.route.runId}
-      live={props.inspections.get(props.route.runId)}
+      runId={runId}
+      location={props.route.location}
+      live={props.inspections.get(runId)}
       runsBlocked={props.runsBlocked}
       onBack={() => props.onNavigate({ kind: 'runs', filters: {} })}
       onCancel={props.onCancel}
-      onInspectResult={(location) =>
-        props.onNavigate({ kind: 'result', location })
+      onOpenArtifact={(location, artifactIndex) =>
+        props.onNavigate({
+          kind: 'artifact',
+          location: { result: location, artifactIndex },
+        })
+      }
+      onSelectLocation={(location) =>
+        props.onNavigate({ kind: 'run', runId, location }, true)
       }
       onRerun={onRerun}
     />

--- a/packages/studio/src/features/studio/studio-route.ts
+++ b/packages/studio/src/features/studio/studio-route.ts
@@ -36,7 +36,11 @@ export type StudioRoute =
       scenarioId: string
     }
   | { kind: 'runs'; filters: RunsFilters }
-  | { kind: 'run'; runId: string }
+  | {
+      kind: 'run'
+      runId: string
+      location?: ResultInspectionLocation
+    }
   | { kind: 'result'; location: ResultInspectionLocation }
   | { kind: 'artifact'; location: ResultArtifactLocation }
   | { kind: 'not-found' }
@@ -69,10 +73,7 @@ export function parseStudioRoute(input: string): StudioRoute {
   if (resultMatch) return parseResultRoute(resultMatch, url.searchParams)
 
   const runMatch = url.pathname.match(runRoutePattern)
-  if (runMatch) {
-    const runId = decodeSegment(runMatch[1])
-    return runId ? { kind: 'run', runId } : { kind: 'not-found' }
-  }
+  if (runMatch) return parseRunRoute(runMatch, url.searchParams)
   return { kind: 'not-found' }
 }
 
@@ -90,10 +91,19 @@ export function studioRouteHref(
     const query = runsFilterQuery(route.filters)
     return query ? `/runs?${query}` : '/runs'
   }
-  if (route.kind === 'run') return `/runs/${encodeURIComponent(route.runId)}`
+  if (route.kind === 'run') return runRouteHref(route)
   if (route.kind === 'result') return resultRouteHref(route.location)
+  return artifactRouteHref(route.location)
+}
 
-  const { result, artifactIndex } = route.location
+function runRouteHref(route: Extract<StudioRoute, { kind: 'run' }>): string {
+  const path = `/runs/${encodeURIComponent(route.runId)}`
+  const query = route.location ? resultSelectionQuery(route.location) : ''
+  return query ? `${path}?${query}` : path
+}
+
+function artifactRouteHref(location: ResultArtifactLocation): string {
+  const { result, artifactIndex } = location
   const path = `${resultRoutePath(result)}/artifacts/${artifactIndex}`
   return result.tab ? `${path}?tab=${result.tab}` : path
 }
@@ -123,6 +133,55 @@ function parseRunsFilters(parameters: URLSearchParams): RunsFilters {
     profile: parameters.get('profile') ?? undefined,
     suite: parameters.get('suite') ?? undefined,
   })
+}
+
+function parseRunRoute(
+  match: RegExpMatchArray,
+  parameters: URLSearchParams,
+): StudioRoute {
+  const runId = decodeSegment(match[1])
+  if (!runId) return { kind: 'not-found' }
+  const selection = parseResultSelection(runId, parameters)
+  if (selection === 'invalid') return { kind: 'not-found' }
+  return selection
+    ? { kind: 'run', runId, location: selection }
+    : { kind: 'run', runId }
+}
+
+function parseResultSelection(
+  runId: string,
+  parameters: URLSearchParams,
+): ResultInspectionLocation | undefined | 'invalid' {
+  const identityKeys = [
+    'specification',
+    'scenario',
+    'examplesRow',
+    'profile',
+    'attempt',
+  ]
+  if (!identityKeys.some((key) => parameters.has(key))) return undefined
+  const specificationUri = parameters.get('specification')
+  const scenarioId = parameters.get('scenario')
+  const examplesRowId = parameters.get('examplesRow') ?? undefined
+  const profileId = parameters.get('profile')
+  const attempt = positiveInteger(parameters.get('attempt') ?? undefined)
+  if (!specificationUri || !scenarioId || !profileId || !attempt) {
+    return 'invalid'
+  }
+  const requestedTab = parameters.get('tab')
+  const tab = resultInspectorTabs.find(
+    (candidate) => candidate === requestedTab,
+  )
+  const location: ResultInspectionLocation = {
+    runId,
+    specificationUri,
+    scenarioId,
+    profileId,
+    attempt,
+  }
+  if (examplesRowId) location.examplesRowId = examplesRowId
+  if (tab) location.tab = tab
+  return location
 }
 
 function compactFilters(filters: RunsFilters): RunsFilters {
@@ -196,6 +255,18 @@ function hasLegacyResultIdentity(parameters: URLSearchParams): boolean {
 function resultRouteHref(location: ResultInspectionLocation): string {
   const path = resultRoutePath(location)
   return location.tab ? `${path}?tab=${location.tab}` : path
+}
+
+function resultSelectionQuery(location: ResultInspectionLocation): string {
+  const query = new URLSearchParams({
+    specification: location.specificationUri,
+    scenario: location.scenarioId,
+    profile: location.profileId,
+    attempt: String(location.attempt),
+  })
+  if (location.examplesRowId) query.set('examplesRow', location.examplesRowId)
+  if (location.tab) query.set('tab', location.tab)
+  return query.toString()
 }
 
 function resultRoutePath(location: ResultInspectionLocation): string {

--- a/packages/studio/src/features/studio/studio-topbar.tsx
+++ b/packages/studio/src/features/studio/studio-topbar.tsx
@@ -14,10 +14,22 @@ type StudioTopbarProps = {
 }
 
 export function StudioTopbar(props: StudioTopbarProps) {
+  function handleHomeClick() {
+    props.onAreaChange('Specifications')
+  }
+
   return (
     <header className="studio-topbar flex min-h-11 shrink-0 flex-wrap items-center gap-2 border-b border-border px-3 py-1.5 sm:flex-nowrap sm:px-4">
       <div className="flex min-w-0 items-center gap-2.5">
-        <span className="studio-wordmark shrink-0">Pickle Spec</span>
+        <Button
+          type="button"
+          size="sm"
+          variant="ghost"
+          className="studio-wordmark -ml-1.5 shrink-0 px-1.5 text-foreground"
+          onClick={handleHomeClick}
+        >
+          Pickle Spec
+        </Button>
         <span aria-hidden="true" className="h-5 w-px bg-border" />
         <span className="studio-project-name hidden truncate sm:block">
           {props.projectName}

--- a/packages/studio/src/features/studio/use-studio-controller.ts
+++ b/packages/studio/src/features/studio/use-studio-controller.ts
@@ -70,7 +70,7 @@ export function useStudioController() {
     onClearError: data.clearError,
     onError: data.reportError,
     onInspectResult: (location) =>
-      navigation.navigate({ kind: 'result', location }),
+      navigation.navigate({ kind: 'run', runId: location.runId, location }),
     registerActiveRun: data.registerActiveRun,
     reloadRunsIndex: data.reloadRunsIndex,
     runsIndex: data.runsIndex,

--- a/packages/studio/tests/unit/runs/run-detail.test.tsx
+++ b/packages/studio/tests/unit/runs/run-detail.test.tsx
@@ -1,0 +1,90 @@
+import type { ScenarioAttempt, TestResult } from '@pickle-spec/runner'
+import { renderToStaticMarkup } from 'react-dom/server'
+import { expect, test } from 'vitest'
+import type { LiveResultInspection } from '../../../src/features/runs/result/live-result-inspection'
+import { RunDetail } from '../../../src/features/runs/run-detail'
+import type { StudioRunSnapshot } from '../../../src/server/contracts'
+
+function attempt(number: number, state: 'passed' | 'failed'): ScenarioAttempt {
+  return {
+    attempt: number,
+    startedAt: '2026-08-30T12:00:00.000Z',
+    finishedAt: '2026-08-30T12:00:01.000Z',
+    durationMs: 1_000,
+    state,
+    steps: [],
+    evidenceAvailability: [],
+  }
+}
+
+function result(name: string, state: 'passed' | 'failed'): TestResult {
+  const scenarioAttempt = attempt(1, state)
+  return {
+    schemaVersion: 2,
+    specification: {
+      name: 'Checkout',
+      uri: 'features/checkout.feature',
+    },
+    scenario: { id: `scenario-${state}`, name },
+    executionTargetProfile: { id: 'chrome' },
+    state,
+    startedAt: scenarioAttempt.startedAt,
+    finishedAt: scenarioAttempt.finishedAt,
+    durationMs: scenarioAttempt.durationMs,
+    attempts: [scenarioAttempt],
+  }
+}
+
+const snapshot: StudioRunSnapshot = {
+  id: 'run-42',
+  events: [],
+  manifest: {
+    schemaVersion: 2,
+    id: 'run-42',
+    startedAt: '2026-08-30T12:00:00.000Z',
+    finishedAt: '2026-08-30T12:00:02.000Z',
+    state: 'failed',
+    results: [
+      result('Complete a purchase', 'passed'),
+      result('Pay for the order', 'failed'),
+    ],
+  },
+}
+
+const live: LiveResultInspection = {
+  specificationUri: 'features/checkout.feature',
+  runId: 'run-42',
+  phase: 'finished',
+  events: [],
+  schedule: [],
+  liveDiagnostics: [],
+  liveViewports: new Map(),
+  snapshot,
+  connection: { kind: 'connected' },
+  following: false,
+  pinned: false,
+}
+
+test('keeps run actions and selects an attempt on the run page', () => {
+  const markup = renderToStaticMarkup(
+    <RunDetail
+      api={async <Value,>() => snapshot as Value}
+      runId="run-42"
+      live={live}
+      runsBlocked={false}
+      onBack={() => {}}
+      onCancel={() => {}}
+      onOpenArtifact={() => {}}
+      onRerun={async () => {}}
+      onSelectLocation={() => {}}
+    />,
+  )
+
+  expect(markup).toContain('Test run run-42')
+  expect(markup).toContain('Download report')
+  expect(markup).toContain('Rerun failures')
+  expect(markup).toContain('id="run-attempt-select"')
+  expect(markup).toContain('Pay for the order · chrome')
+  expect(markup).toContain('Rerun Scenario')
+  expect(markup).toContain('Rerun target')
+})

--- a/packages/studio/tests/unit/runs/runs.test.tsx
+++ b/packages/studio/tests/unit/runs/runs.test.tsx
@@ -76,7 +76,7 @@ test('composes the Runs dashboard without duplicating active runs in history', (
   expect(markup).toContain('Active Runs')
   expect(markup).toContain('run-active')
   expect(markup).toContain('aria-label="Test run history"')
-  expect(markup).toContain('Open attempt for run-failed')
+  expect(markup).toContain('Open run run-failed')
   expect(markup.match(/run-active/g)).toHaveLength(1)
   expect(markup).toContain('Local Test run storage')
 })

--- a/packages/studio/tests/unit/server/server-runs.test.ts
+++ b/packages/studio/tests/unit/server/server-runs.test.ts
@@ -92,13 +92,7 @@ test('serves the Runs index, active lifecycle, compatibility alias, and deep lin
       async importArchive() {
         throw new Error('not used')
       },
-      async exportArchive() {
-        throw new Error('not used')
-      },
-      async exportHtml() {
-        throw new Error('not used')
-      },
-      async exportAllure() {
+      async exportReport() {
         throw new Error('not used')
       },
       async deleteEligible() {

--- a/packages/studio/tests/unit/studio/studio-route.test.ts
+++ b/packages/studio/tests/unit/studio/studio-route.test.ts
@@ -29,6 +29,19 @@ describe('Studio route contract', () => {
     },
     { kind: 'run', runId: 'run/slash space % 測試' },
     {
+      kind: 'run',
+      runId: 'run/slash space % 測試',
+      location: {
+        runId: 'run/slash space % 測試',
+        specificationUri: 'features/payment flows %.feature',
+        scenarioId: 'scenario/pay now % 東京',
+        examplesRowId: 'row/slash space % café',
+        profileId: 'Pixel 9 / API 36 %',
+        attempt: 2,
+        tab: 'timeline',
+      },
+    },
+    {
       kind: 'result',
       location: {
         runId: 'run/slash space % 測試',
@@ -75,6 +88,22 @@ describe('Studio route contract', () => {
   }
 
   test('writes the canonical entity grammar', () => {
+    expect(
+      studioRouteHref({
+        kind: 'run',
+        runId: 'run-42',
+        location: {
+          runId: 'run-42',
+          specificationUri: 'features/checkout.feature',
+          scenarioId: 'scenario-pay',
+          profileId: 'chrome desktop',
+          attempt: 3,
+          tab: 'timeline',
+        },
+      }),
+    ).toBe(
+      '/runs/run-42?specification=features%2Fcheckout.feature&scenario=scenario-pay&profile=chrome+desktop&attempt=3&tab=timeline',
+    )
     expect(
       studioRouteHref({
         kind: 'scenario',


### PR DESCRIPTION
## Summary

- Add JSON, NDJSON, JUnit, HTML, archive, and Allure report downloads.
- Consolidate report export handling behind a typed gateway contract.
- Add HTML artifact inclusion controls and end-to-end export coverage.
- Remove redundant package TypeScript path overrides.

## Testing

- Unit coverage for all Studio report formats and unfinished-run rejection.
- Studio end-to-end coverage for report contents, headers, filenames, and artifact options.