### PR TITLE
feat(studio): explain replay divergence in result inspector

### DIFF
--- a/.hallmark/preflight.json
+++ b/.hallmark/preflight.json
@@ -1,0 +1,25 @@
+{
+  "scanDate": "2026-08-30",
+  "designSystem": {
+    "path": "DESIGN.md",
+    "locked": true
+  },
+  "fonts": {
+    "application": "Inter Variable",
+    "machineContent": "JetBrains Mono Variable",
+    "source": "packages/studio/src/styles.css"
+  },
+  "palette": {
+    "format": "OKLCH custom properties",
+    "source": "packages/studio/src/styles.css"
+  },
+  "motion": {
+    "stance": "motion-cut",
+    "detail": "Quiet CSS state transitions with prefers-reduced-motion support"
+  },
+  "spacing": {
+    "scale": "4px",
+    "source": "DESIGN.md"
+  },
+  "framework": ["TanStack Start", "React 19", "Tailwind CSS 4"]
+}

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -61,7 +61,7 @@ Phase 2 makes concurrent execution understandable during and after a run. The li
 - [x] Live device mirror: stream Android emulator and iOS simulator frames through the existing Node worker protocol. Render the active device beside the step timeline.
 - [x] Web diagnostics: capture redacted traces, recordings, network activity, and console output. Link each artifact to its step and event range.
 - [x] Time-travel inspector: connect each action to target state, diagnostics, source evidence, retries, and before-and-after screenshots. Use the same view for live and completed runs.
-- [ ] Replay divergence explainer: show the divergence step, sealed prefix, and Adaptive fallback. Use the existing `replay-diverged` and `adaptive-fallback-started` events.
+- [x] Replay divergence explainer: show the divergence step, sealed prefix, and Adaptive fallback. Use the existing `replay-diverged` and `adaptive-fallback-started` events.
 - [ ] Operator controls: let an operator pin or cancel a scenario, open its live session, and capture evidence. Add pause-after-step only after the runner defines a safe suspension contract.
 - [ ] Follow mode and picture-in-picture: follow the worst result or a pinned scenario across the matrix. Show a filmstrip of concurrent targets for parallel workers.
 - [ ] Live step timeline: append screenshots, execution mode, cache provenance, retries, and elapsed time as step events arrive.

--- a/packages/studio/src/features/runs/result/replay-divergence-explainer.tsx
+++ b/packages/studio/src/features/runs/result/replay-divergence-explainer.tsx
@@ -1,0 +1,85 @@
+/* Hallmark · component: result explainer card · genre: technical · theme: DESIGN.md
+ * states: non-interactive · contrast: pass
+ * pre-emit critique: P5 H4 E4 S5 R5 V4
+ */
+import { Badge } from '../../../components/ui/badge'
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from '../../../components/ui/card'
+import type { ReplayDivergenceExplanation } from './replay-divergence'
+
+type ReplayDivergenceExplainerProps = {
+  explanation: ReplayDivergenceExplanation
+}
+
+function stepCountLabel(stepCount: number): string {
+  if (stepCount === 0) return 'No steps replayed'
+  return `${stepCount} ${stepCount === 1 ? 'step' : 'steps'} replayed and sealed`
+}
+
+export function ReplayDivergenceExplainer(
+  props: ReplayDivergenceExplainerProps,
+) {
+  const { divergence, sealedPrefix, fallback } = props.explanation
+  const prefixDetail = sealedPrefix.boundaryStepText
+    ? `Through ${sealedPrefix.boundaryStepText}`
+    : 'Replay diverged at the first Scenario step.'
+  const fallbackTitle =
+    fallback.kind === 'continued-same-attempt'
+      ? `Continued in attempt ${fallback.attempt}`
+      : `Restarted as attempt ${fallback.attempt}`
+  const fallbackDetail =
+    fallback.kind === 'continued-same-attempt'
+      ? 'Adaptive continued from the divergence step without restarting the Scenario.'
+      : 'Adaptive restarted the Scenario after the Replay attempt ended.'
+
+  return (
+    <Card size="sm" className="mb-4" aria-labelledby="replay-divergence-title">
+      <CardHeader>
+        <div className="flex min-w-0 flex-wrap items-center gap-2">
+          <CardTitle id="replay-divergence-title" role="heading" aria-level={4}>
+            Replay divergence
+          </CardTitle>
+          <Badge>Adaptive fallback</Badge>
+        </div>
+        <CardDescription>
+          Replay stopped matching at this step. Adaptive execution took over.
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        <ol className="grid min-w-0 gap-3 lg:grid-cols-[repeat(3,minmax(0,1fr))]">
+          <li className="min-w-0 space-y-2 border-t border-border pt-3">
+            <Badge>1 · Divergence</Badge>
+            <p className="break-words font-mono text-xs text-foreground">
+              {divergence.stepText}
+            </p>
+            <p className="text-xs text-muted-foreground">
+              Scenario step {divergence.stepIndex + 1} · Replay attempt{' '}
+              {divergence.attempt}
+            </p>
+          </li>
+          <li className="min-w-0 space-y-2 border-t border-border pt-3">
+            <Badge>2 · Sealed prefix</Badge>
+            <p className="text-sm font-medium text-foreground">
+              {stepCountLabel(sealedPrefix.stepCount)}
+            </p>
+            <p className="break-words font-mono text-xs text-muted-foreground">
+              {prefixDetail}
+            </p>
+          </li>
+          <li className="min-w-0 space-y-2 border-t border-border pt-3">
+            <Badge>3 · Adaptive</Badge>
+            <p className="text-sm font-medium text-foreground">
+              {fallbackTitle}
+            </p>
+            <p className="text-xs text-muted-foreground">{fallbackDetail}</p>
+          </li>
+        </ol>
+      </CardContent>
+    </Card>
+  )
+}

--- a/packages/studio/src/features/runs/result/replay-divergence.ts
+++ b/packages/studio/src/features/runs/result/replay-divergence.ts
@@ -1,0 +1,193 @@
+import type {
+  ExecutionCacheKey,
+  RunEvent,
+  ScenarioAttempt,
+  TestResult,
+  TestStepResult,
+} from '@pickle-spec/runner'
+
+type ReplayDivergenceEvent = Extract<RunEvent, { type: 'replay-diverged' }>
+type AdaptiveFallbackEvent = Extract<
+  RunEvent,
+  { type: 'adaptive-fallback-started' }
+>
+type ReplayLifecycleEvent = ReplayDivergenceEvent | AdaptiveFallbackEvent
+
+export type ReplayDivergenceExplanation = {
+  divergence: {
+    attempt: number
+    stepIndex: number
+    stepText: string
+  }
+  sealedPrefix: {
+    stepCount: number
+    boundaryStepText?: string
+  }
+  fallback:
+    | { kind: 'continued-same-attempt'; attempt: number }
+    | { kind: 'restarted-next-attempt'; attempt: number }
+}
+
+type ProjectReplayDivergenceInput = {
+  events: readonly RunEvent[]
+  result: TestResult
+  selectedAttemptNumber: number
+}
+
+function sameCacheKey(
+  left: ExecutionCacheKey,
+  right: ExecutionCacheKey,
+): boolean {
+  return (
+    left.projectKey === right.projectKey &&
+    left.scenarioId === right.scenarioId &&
+    left.scenarioRevision === right.scenarioRevision &&
+    left.executionTargetProfileId === right.executionTargetProfileId &&
+    left.targetConfigurationFingerprint ===
+      right.targetConfigurationFingerprint &&
+    left.applicationRevision === right.applicationRevision &&
+    left.adapterKind === right.adapterKind &&
+    left.adapterCacheSchemaVersion === right.adapterCacheSchemaVersion
+  )
+}
+
+function belongsToResult(
+  event: ReplayDivergenceEvent | AdaptiveFallbackEvent,
+  result: TestResult,
+): boolean {
+  return (
+    event.scope.scenarioId === (result.scenario.id ?? result.scenario.name) &&
+    event.scope.examplesRowId === result.scenario.examplesRowId &&
+    event.scope.executionTargetProfileId === result.executionTargetProfile.id
+  )
+}
+
+function stepText(step: TestStepResult): string {
+  return `${step.step.keyword.trim()} ${step.step.text}`
+}
+
+function divergenceStep(
+  attempt: ScenarioAttempt,
+  sameAttemptFallback: boolean,
+): TestStepResult | undefined {
+  if (sameAttemptFallback) {
+    const divergenceIndex = attempt.prefixStepCount ?? 0
+    return attempt.steps.find((step) => step.index === divergenceIndex)
+  }
+  return (
+    attempt.steps.find(
+      (step) =>
+        step.state === 'failed' || step.state === 'infrastructure-error',
+    ) ?? attempt.steps.at(-1)
+  )
+}
+
+function explanationFor(
+  divergence: ReplayDivergenceEvent,
+  fallback: AdaptiveFallbackEvent,
+  result: TestResult,
+): ReplayDivergenceExplanation | undefined {
+  const attempt = result.attempts.find(
+    (candidate) => candidate.attempt === divergence.scope.attempt,
+  )
+  if (!attempt) return undefined
+
+  const sameAttemptFallback =
+    fallback.scope.attempt === divergence.scope.attempt
+  const step = divergenceStep(attempt, sameAttemptFallback)
+  if (!step) return undefined
+
+  const boundary = attempt.steps
+    .filter((candidate) => candidate.index < step.index)
+    .sort((left, right) => right.index - left.index)[0]
+
+  return {
+    divergence: {
+      attempt: divergence.scope.attempt,
+      stepIndex: step.index,
+      stepText: stepText(step),
+    },
+    sealedPrefix: {
+      stepCount: step.index,
+      boundaryStepText: boundary ? stepText(boundary) : undefined,
+    },
+    fallback: sameAttemptFallback
+      ? {
+          kind: 'continued-same-attempt',
+          attempt: fallback.scope.attempt,
+        }
+      : {
+          kind: 'restarted-next-attempt',
+          attempt: fallback.scope.attempt,
+        },
+  }
+}
+
+function orderedReplayEvents(
+  events: readonly RunEvent[],
+  result: TestResult,
+): ReplayLifecycleEvent[] {
+  return [...events]
+    .sort((left, right) => left.sequence - right.sequence)
+    .filter(
+      (event): event is ReplayLifecycleEvent =>
+        (event.type === 'replay-diverged' ||
+          event.type === 'adaptive-fallback-started') &&
+        belongsToResult(event, result),
+    )
+}
+
+function pairedDivergence(
+  events: readonly ReplayLifecycleEvent[],
+  fallbackIndex: number,
+  fallback: AdaptiveFallbackEvent,
+): ReplayDivergenceEvent | undefined {
+  return events
+    .slice(0, fallbackIndex)
+    .findLast(
+      (event): event is ReplayDivergenceEvent =>
+        event.type === 'replay-diverged' &&
+        sameCacheKey(event.cacheKey, fallback.cacheKey) &&
+        (fallback.scope.attempt === event.scope.attempt ||
+          fallback.scope.attempt === event.scope.attempt + 1),
+    )
+}
+
+function pairInvolvesAttempt(
+  divergence: ReplayDivergenceEvent,
+  fallback: AdaptiveFallbackEvent,
+  attemptNumber: number,
+): boolean {
+  return (
+    divergence.scope.attempt === attemptNumber ||
+    fallback.scope.attempt === attemptNumber
+  )
+}
+
+export function projectReplayDivergenceExplanation(
+  input: ProjectReplayDivergenceInput,
+): ReplayDivergenceExplanation | undefined {
+  if (
+    !input.result.attempts.some(
+      (attempt) => attempt.attempt === input.selectedAttemptNumber,
+    )
+  ) {
+    return undefined
+  }
+
+  const events = orderedReplayEvents(input.events, input.result)
+
+  for (const [index, event] of events.entries()) {
+    if (event.type !== 'adaptive-fallback-started') continue
+    const divergence = pairedDivergence(events, index, event)
+    if (
+      !divergence ||
+      !pairInvolvesAttempt(divergence, event, input.selectedAttemptNumber)
+    ) {
+      continue
+    }
+    return explanationFor(divergence, event, input.result)
+  }
+
+  return undefined
+}

--- a/packages/studio/src/features/runs/result/result-inspector.tsx
+++ b/packages/studio/src/features/runs/result/result-inspector.tsx
@@ -25,6 +25,8 @@ import {
   isAttemptInProgress,
   type LiveConnectionStatus,
 } from './live-result-inspection'
+import { projectReplayDivergenceExplanation } from './replay-divergence'
+import { ReplayDivergenceExplainer } from './replay-divergence-explainer'
 import {
   artifactsFor,
   defaultResultInspectorTab,
@@ -295,6 +297,11 @@ function InspectedResultView(props: InspectedResultViewProps) {
     props.location,
     actions,
   )
+  const replayDivergence = projectReplayDivergenceExplanation({
+    events: snapshot.events,
+    result: inspected.result,
+    selectedAttemptNumber: inspected.attempt.attempt,
+  })
   if (props.artifactIndex !== undefined) {
     const artifact = artifacts[props.artifactIndex]
     return (
@@ -314,6 +321,9 @@ function InspectedResultView(props: InspectedResultViewProps) {
       className="min-h-0 flex-1 overflow-auto px-3 py-4 sm:px-5"
     >
       <ResultInspectorHeader {...props} displayState={displayState} />
+      {replayDivergence ? (
+        <ReplayDivergenceExplainer explanation={replayDivergence} />
+      ) : null}
       <ResultInspectorTabs
         {...props}
         activeTab={activeTab}

--- a/packages/studio/tests/unit/runs/result/replay-divergence-explainer.test.tsx
+++ b/packages/studio/tests/unit/runs/result/replay-divergence-explainer.test.tsx
@@ -1,0 +1,68 @@
+import { renderToStaticMarkup } from 'react-dom/server'
+import { expect, test } from 'vitest'
+import { ReplayDivergenceExplainer } from '../../../../src/features/runs/result/replay-divergence-explainer'
+
+function stagePositions(markup: string): number[] {
+  return [
+    markup.indexOf('1 · Divergence'),
+    markup.indexOf('2 · Sealed prefix'),
+    markup.indexOf('3 · Adaptive'),
+  ]
+}
+
+test('renders an ordered same-attempt continuation without cache identity', () => {
+  const markup = renderToStaticMarkup(
+    <ReplayDivergenceExplainer
+      explanation={{
+        divergence: {
+          attempt: 1,
+          stepIndex: 2,
+          stepText: 'Then payment is captured',
+        },
+        sealedPrefix: {
+          stepCount: 2,
+          boundaryStepText: 'When the customer checks out',
+        },
+        fallback: { kind: 'continued-same-attempt', attempt: 1 },
+      }}
+    />,
+  )
+
+  const positions = stagePositions(markup)
+  expect(positions.every((position) => position >= 0)).toBe(true)
+  expect(positions).toEqual([...positions].sort((left, right) => left - right))
+  expect(markup).toContain('Then payment is captured')
+  expect(markup).toContain('2 steps replayed and sealed')
+  expect(markup).toContain('Through When the customer checks out')
+  expect(markup).toContain('Continued in attempt 1')
+  expect(markup).toContain(
+    'Adaptive continued from the divergence step without restarting the Scenario.',
+  )
+  expect(markup).not.toContain('project-key-do-not-render')
+})
+
+test('renders an ordered next-attempt restart', () => {
+  const markup = renderToStaticMarkup(
+    <ReplayDivergenceExplainer
+      explanation={{
+        divergence: {
+          attempt: 1,
+          stepIndex: 0,
+          stepText: 'Given an order exists',
+        },
+        sealedPrefix: { stepCount: 0 },
+        fallback: { kind: 'restarted-next-attempt', attempt: 2 },
+      }}
+    />,
+  )
+
+  const positions = stagePositions(markup)
+  expect(positions.every((position) => position >= 0)).toBe(true)
+  expect(positions).toEqual([...positions].sort((left, right) => left - right))
+  expect(markup).toContain('No steps replayed')
+  expect(markup).toContain('Replay diverged at the first Scenario step.')
+  expect(markup).toContain('Restarted as attempt 2')
+  expect(markup).toContain(
+    'Adaptive restarted the Scenario after the Replay attempt ended.',
+  )
+})

--- a/packages/studio/tests/unit/runs/result/replay-divergence.test.ts
+++ b/packages/studio/tests/unit/runs/result/replay-divergence.test.ts
@@ -1,0 +1,249 @@
+import type {
+  ExecutionCacheKey,
+  RunEvent,
+  ScenarioAttempt,
+  TestResult,
+  TestResultState,
+} from '@pickle-spec/runner'
+import { expect, test } from 'vitest'
+import { projectReplayDivergenceExplanation } from '../../../../src/features/runs/result/replay-divergence'
+
+const evidenceAvailability: ScenarioAttempt['evidenceAvailability'] = [
+  { kind: 'screenshot', state: 'not-requested' },
+  { kind: 'trace', state: 'not-requested' },
+  { kind: 'recording', state: 'not-requested' },
+  { kind: 'device-log', state: 'not-requested' },
+  { kind: 'diagnostics', state: 'not-supported' },
+]
+
+const cacheKey: ExecutionCacheKey = {
+  projectKey: 'project-key-do-not-render',
+  scenarioId: 'scenario-checkout',
+  scenarioRevision: 'revision-1',
+  executionTargetProfileId: 'chrome',
+  targetConfigurationFingerprint: 'target-1',
+  applicationRevision: 'application-1',
+  adapterKind: 'web',
+  adapterCacheSchemaVersion: '1',
+}
+
+function step(
+  index: number,
+  text: string,
+  state: TestResultState = 'passed',
+): ScenarioAttempt['steps'][number] {
+  return {
+    index,
+    startedAt: `2026-08-30T12:00:0${index}.000Z`,
+    finishedAt: `2026-08-30T12:00:0${index}.500Z`,
+    durationMs: 500,
+    step: {
+      keyword: index === 0 ? 'Given ' : 'Then ',
+      text,
+      type: index === 0 ? 'context' : 'outcome',
+    },
+    state,
+    resolvedActions: [],
+  }
+}
+
+function attempt(
+  attemptNumber: number,
+  steps: ScenarioAttempt['steps'],
+  options: Pick<ScenarioAttempt, 'prefixStepCount' | 'cacheOutcome'> = {},
+): ScenarioAttempt {
+  return {
+    attempt: attemptNumber,
+    startedAt: '2026-08-30T12:00:00.000Z',
+    finishedAt: '2026-08-30T12:00:10.000Z',
+    durationMs: 10_000,
+    state: steps.some(
+      (item) =>
+        item.state === 'failed' || item.state === 'infrastructure-error',
+    )
+      ? 'failed'
+      : 'passed',
+    steps,
+    prefixStepCount: options.prefixStepCount,
+    cacheOutcome: options.cacheOutcome,
+    evidenceAvailability,
+  }
+}
+
+function result(attempts: ScenarioAttempt[]): TestResult {
+  return {
+    schemaVersion: 2,
+    specification: {
+      name: 'Checkout',
+      uri: 'features/checkout.feature',
+    },
+    scenario: {
+      id: 'scenario-checkout',
+      name: 'Pay for the order',
+      examplesRowId: 'row-1',
+    },
+    executionTargetProfile: { id: 'chrome' },
+    state: attempts.at(-1)?.state ?? 'cancelled',
+    startedAt: '2026-08-30T12:00:00.000Z',
+    finishedAt: '2026-08-30T12:00:10.000Z',
+    durationMs: 10_000,
+    attempts,
+  }
+}
+
+function cacheEvent(
+  type: 'replay-diverged' | 'adaptive-fallback-started',
+  sequence: number,
+  attemptNumber: number,
+  options: {
+    key?: ExecutionCacheKey
+    scenarioId?: string
+  } = {},
+): RunEvent {
+  return {
+    schemaVersion: 2,
+    sequence,
+    occurredAt: `2026-08-30T12:00:0${sequence}.000Z`,
+    type,
+    cacheKey: options.key ?? cacheKey,
+    scope: {
+      scenarioId: options.scenarioId ?? 'scenario-checkout',
+      examplesRowId: 'row-1',
+      executionTargetProfileId: 'chrome',
+      attempt: attemptNumber,
+    },
+  }
+}
+
+test('explains a mixed partial hit from its sealed prefix', () => {
+  const testResult = result([
+    attempt(
+      1,
+      [
+        step(0, 'an order exists'),
+        step(1, 'the customer checks out'),
+        step(2, 'payment is captured'),
+      ],
+      { prefixStepCount: 2, cacheOutcome: 'partial-hit' },
+    ),
+  ])
+
+  expect(
+    projectReplayDivergenceExplanation({
+      events: [
+        cacheEvent('adaptive-fallback-started', 3, 1),
+        cacheEvent('replay-diverged', 2, 1),
+      ],
+      result: testResult,
+      selectedAttemptNumber: 1,
+    }),
+  ).toEqual({
+    divergence: {
+      attempt: 1,
+      stepIndex: 2,
+      stepText: 'Then payment is captured',
+    },
+    sealedPrefix: {
+      stepCount: 2,
+      boundaryStepText: 'Then the customer checks out',
+    },
+    fallback: { kind: 'continued-same-attempt', attempt: 1 },
+  })
+})
+
+test('treats a missing mixed prefix count as first-step divergence', () => {
+  const testResult = result([
+    attempt(1, [step(0, 'an order exists'), step(1, 'payment is captured')], {
+      cacheOutcome: 'miss',
+    }),
+  ])
+
+  expect(
+    projectReplayDivergenceExplanation({
+      events: [
+        cacheEvent('replay-diverged', 1, 1),
+        cacheEvent('adaptive-fallback-started', 2, 1),
+      ],
+      result: testResult,
+      selectedAttemptNumber: 1,
+    }),
+  ).toMatchObject({
+    divergence: { stepIndex: 0, stepText: 'Given an order exists' },
+    sealedPrefix: { stepCount: 0, boundaryStepText: undefined },
+  })
+})
+
+test('shows a cross-attempt restart from either involved attempt', () => {
+  const testResult = result([
+    attempt(1, [
+      step(0, 'an order exists'),
+      step(1, 'payment is captured', 'failed'),
+    ]),
+    attempt(2, [step(0, 'an order exists'), step(1, 'payment is captured')]),
+  ])
+  const events = [
+    cacheEvent('replay-diverged', 5, 1),
+    cacheEvent('adaptive-fallback-started', 6, 2),
+  ]
+
+  const fromReplay = projectReplayDivergenceExplanation({
+    events,
+    result: testResult,
+    selectedAttemptNumber: 1,
+  })
+  const fromAdaptive = projectReplayDivergenceExplanation({
+    events,
+    result: testResult,
+    selectedAttemptNumber: 2,
+  })
+
+  expect(fromReplay).toEqual(fromAdaptive)
+  expect(fromReplay).toEqual({
+    divergence: {
+      attempt: 1,
+      stepIndex: 1,
+      stepText: 'Then payment is captured',
+    },
+    sealedPrefix: {
+      stepCount: 1,
+      boundaryStepText: 'Given an order exists',
+    },
+    fallback: { kind: 'restarted-next-attempt', attempt: 2 },
+  })
+})
+
+test('does not pair events across result scope or cache identity', () => {
+  const testResult = result([attempt(1, [step(0, 'an order exists')])])
+  const otherCacheKey = { ...cacheKey, applicationRevision: 'application-2' }
+
+  expect(
+    projectReplayDivergenceExplanation({
+      events: [
+        cacheEvent('replay-diverged', 1, 1, {
+          scenarioId: 'another-scenario',
+        }),
+        cacheEvent('adaptive-fallback-started', 2, 1),
+        cacheEvent('replay-diverged', 3, 1),
+        cacheEvent('adaptive-fallback-started', 4, 1, {
+          key: otherCacheKey,
+        }),
+      ],
+      result: testResult,
+      selectedAttemptNumber: 1,
+    }),
+  ).toBeUndefined()
+})
+
+test('does not explain an unpaired cache-only divergence', () => {
+  const testResult = result([
+    attempt(1, [step(0, 'an order exists', 'failed')]),
+  ])
+
+  expect(
+    projectReplayDivergenceExplanation({
+      events: [cacheEvent('replay-diverged', 1, 1)],
+      result: testResult,
+      selectedAttemptNumber: 1,
+    }),
+  ).toBeUndefined()
+})


### PR DESCRIPTION
## Summary

- Add replay divergence projection for sealed prefixes and Adaptive fallback attempts.
- Render divergence explanations in the Studio result inspector.
- Add unit coverage for partial hits, restarts, scope matching, and unpaired events.
- Mark the replay divergence explainer roadmap item complete.
- Remove redundant package-specific TypeScript path mappings.

## Testing

- Not run.