### PR TITLE
feat(studio): add downloads for completed run reports

### DIFF
--- a/packages/studio/src/features/specifications/specification-header.tsx
+++ b/packages/studio/src/features/specifications/specification-header.tsx
@@ -1,5 +1,5 @@
 import type { RefObject } from 'react'
-import { Button } from '../../components/ui/button'
+import { Button, ButtonLink } from '../../components/ui/button'
 import type { StudioApi } from '../../lib/studio-api'
 import { cn } from '../../lib/utils'
 import type {
@@ -27,6 +27,7 @@ type SpecificationHeaderProps = {
   runId?: string
   running: boolean
   runReasons?: readonly string[]
+  reportHref?: string
   specification: StudioSpecification
 }
 
@@ -97,14 +98,17 @@ export function SpecificationHeader(props: SpecificationHeaderProps) {
           )}
         >
           {props.authoring ? null : (
-            <SpecificationRunActions
-              canRun={props.canRun}
-              hasRunId={Boolean(props.runId)}
-              onCancel={handleCancel}
-              onRun={handleRun}
-              origin={props.origin}
-              running={props.running}
-            />
+            <>
+              <ReportDownload href={props.reportHref} />
+              <SpecificationRunActions
+                canRun={props.canRun}
+                hasRunId={Boolean(props.runId)}
+                onCancel={handleCancel}
+                onRun={handleRun}
+                origin={props.origin}
+                running={props.running}
+              />
+            </>
           )}
           <SpecificationEditor
             uri={props.specification.uri}
@@ -119,6 +123,15 @@ export function SpecificationHeader(props: SpecificationHeaderProps) {
         </div>
       </div>
     </header>
+  )
+}
+
+function ReportDownload(props: { href?: string }) {
+  if (!props.href) return null
+  return (
+    <ButtonLink variant="outline" href={props.href} download>
+      Download report
+    </ButtonLink>
   )
 }
 

--- a/packages/studio/src/features/specifications/specification-list.tsx
+++ b/packages/studio/src/features/specifications/specification-list.tsx
@@ -7,7 +7,7 @@ import {
   useEffect,
   useState,
 } from 'react'
-import { Button } from '../../components/ui/button'
+import { Button, ButtonLink } from '../../components/ui/button'
 import { useVirtualWindow } from '../../hooks/use-virtual-window'
 import { cn } from '../../lib/utils'
 import type { StudioSpecification } from '../../server/contracts'
@@ -21,6 +21,7 @@ type SpecificationListProps = {
   onRunAll: () => void
   onSelect: (id: string) => void
   origin?: RunOrigin
+  reportHref?: string
   running: boolean
   selectedId?: string
   specifications: readonly StudioSpecification[]
@@ -28,7 +29,7 @@ type SpecificationListProps = {
 
 function RunAllSpecifications(props: SpecificationListProps) {
   return (
-    <div className="border-t border-border p-2">
+    <div className="space-y-2 border-t border-border p-2">
       {props.canRun ? (
         <RunControlButton
           variant="outline"
@@ -39,6 +40,17 @@ function RunAllSpecifications(props: SpecificationListProps) {
         >
           Run all Specifications
         </RunControlButton>
+      ) : null}
+      {props.reportHref ? (
+        <ButtonLink
+          variant="outline"
+          className="w-full"
+          href={props.reportHref}
+          download
+          aria-label="Download latest report for all Specifications"
+        >
+          Download latest report
+        </ButtonLink>
       ) : null}
     </div>
   )

--- a/packages/studio/src/features/specifications/specification-run-report.ts
+++ b/packages/studio/src/features/specifications/specification-run-report.ts
@@ -1,0 +1,52 @@
+import type { StudioRunsIndex } from '../history/history.contracts'
+
+export type SpecificationRunReport = {
+  href: string
+  scope: 'all-specifications' | 'partial'
+  specificationUris: readonly string[]
+}
+
+type SpecificationRunReportInput = {
+  projectSpecificationUris: readonly string[]
+  runId?: string
+  runsIndex?: StudioRunsIndex
+}
+
+export function specificationRunReport(
+  input: SpecificationRunReportInput,
+): SpecificationRunReport | undefined {
+  if (!input.runId || input.runsIndex?.activeRunIds.includes(input.runId)) {
+    return
+  }
+
+  const summary = input.runsIndex?.runs.find((run) => run.id === input.runId)
+  if (!summary?.finishedAt) return
+
+  const projectUris = new Set(input.projectSpecificationUris)
+  const reportUris = new Set(summary.specificationUris)
+  const coversAllSpecifications =
+    projectUris.size > 0 &&
+    projectUris.size === reportUris.size &&
+    [...projectUris].every((uri) => reportUris.has(uri))
+
+  return {
+    href: `/api/history/${encodeURIComponent(input.runId)}/html`,
+    scope: coversAllSpecifications ? 'all-specifications' : 'partial',
+    specificationUris: summary.specificationUris,
+  }
+}
+
+export function specificationReportHref(
+  report: SpecificationRunReport | undefined,
+  specificationUri: string,
+): string | undefined {
+  return report?.specificationUris.includes(specificationUri)
+    ? report.href
+    : undefined
+}
+
+export function allSpecificationsReportHref(
+  report: SpecificationRunReport | undefined,
+): string | undefined {
+  return report?.scope === 'all-specifications' ? report.href : undefined
+}

--- a/packages/studio/src/features/specifications/specifications-screen.tsx
+++ b/packages/studio/src/features/specifications/specifications-screen.tsx
@@ -7,6 +7,7 @@ import type {
   StudioScenario,
   StudioSpecification,
 } from '../../server/contracts'
+import type { StudioRunsIndex } from '../history/history.contracts'
 import type { LiveResultInspection } from '../runs/result/live-result-inspection'
 import type { ResultInspectorTab } from '../runs/result/result-inspection'
 import type { MatrixCell } from '../runs/result/run-view'
@@ -14,6 +15,12 @@ import type { RunOrigin } from '../runs/run-origin'
 import { SpecificationHeader } from './specification-header'
 import { SpecificationList } from './specification-list'
 import { SpecificationResults } from './specification-results'
+import {
+  allSpecificationsReportHref,
+  type SpecificationRunReport,
+  specificationReportHref,
+  specificationRunReport,
+} from './specification-run-report'
 import type { MissingSpecificationSelection } from './use-specification-selection'
 
 type SpecificationSelection = {
@@ -54,12 +61,22 @@ type SpecificationsScreenProps = {
   onError: (message: string | undefined) => void
   onReloadProject: () => Promise<StudioProject>
   project: StudioProject
+  runsIndex?: StudioRunsIndex
   run: SpecificationRun
   selection: SpecificationSelection
 }
 
 export function SpecificationsScreen(props: SpecificationsScreenProps) {
   const canRunAll = props.project.readiness?.ready ?? true
+  const report = props.run.running
+    ? undefined
+    : specificationRunReport({
+        projectSpecificationUris: props.project.specifications.map(
+          (specification) => specification.uri,
+        ),
+        runId: props.run.runId,
+        runsIndex: props.runsIndex,
+      })
 
   function handleRunAll() {
     props.run.onRun({})
@@ -81,17 +98,19 @@ export function SpecificationsScreen(props: SpecificationsScreenProps) {
           origin={props.run.origin}
           running={props.run.running}
           canRun={canRunAll}
+          reportHref={allSpecificationsReportHref(report)}
           onSelect={props.selection.onSelect}
           onRunAll={handleRunAll}
         />
       )}
-      <SpecificationDetail {...props} canRunAll={canRunAll} />
+      <SpecificationDetail {...props} canRunAll={canRunAll} report={report} />
     </div>
   )
 }
 
 type SpecificationDetailProps = SpecificationsScreenProps & {
   canRunAll: boolean
+  report?: SpecificationRunReport
 }
 
 function MissingSpecification(props: {
@@ -144,13 +163,11 @@ function specificationRunReasons(
 }
 
 function SpecificationDetail(props: SpecificationDetailProps) {
-  const { selected } = props.selection
+  const specification = props.selection.selected
   if (props.selection.missing) {
     return <MissingSpecification missing={props.selection.missing} />
   }
-  if (!selected) return <EmptySpecificationSelection />
-
-  const specification = selected
+  if (!specification) return <EmptySpecificationSelection />
   const canRun = specification.canRun ?? props.canRunAll
   const runReasons = specificationRunReasons(specification, props)
 
@@ -178,6 +195,7 @@ function SpecificationDetail(props: SpecificationDetailProps) {
         runId={props.run.runId}
         running={props.run.running}
         runReasons={runReasons}
+        reportHref={specificationReportHref(props.report, specification.uri)}
         specification={specification}
       />
       {props.authoring ? null : (

--- a/packages/studio/src/features/studio/studio-app.tsx
+++ b/packages/studio/src/features/studio/studio-app.tsx
@@ -34,6 +34,7 @@ function StudioSpecificationsArea(props: { studio: StudioController }) {
       onError={data.setErrorMessage}
       onReloadProject={data.reloadProject}
       project={data.project}
+      runsIndex={data.runsIndex}
       run={{
         cells: studio.run.cells,
         live: studio.run.live,

--- a/packages/studio/tests/unit/specifications/specification-report-actions.test.tsx
+++ b/packages/studio/tests/unit/specifications/specification-report-actions.test.tsx
@@ -1,0 +1,77 @@
+import { createRef } from 'react'
+import { renderToStaticMarkup } from 'react-dom/server'
+import { expect, test, vi } from 'vitest'
+import { SpecificationHeader } from '../../../src/features/specifications/specification-header'
+import { SpecificationList } from '../../../src/features/specifications/specification-list'
+import type { StudioApi } from '../../../src/lib/studio-api'
+import type { StudioSpecification } from '../../../src/server/contracts'
+
+vi.mock('../../../src/features/documents/specification-editor', () => ({
+  SpecificationEditor: () => null,
+}))
+
+const specification: StudioSpecification = {
+  id: 'checkout',
+  name: 'Checkout',
+  uri: 'features/checkout.feature',
+  scenarios: [],
+}
+
+const api: StudioApi = async () => {
+  throw new Error('Unexpected API call')
+}
+
+function renderHeader(reportHref?: string) {
+  return renderToStaticMarkup(
+    <SpecificationHeader
+      api={api}
+      authoring={false}
+      canRun
+      headingRef={createRef<HTMLHeadingElement>()}
+      namespaces={[]}
+      onAuthoringChange={() => {}}
+      onCancelRun={() => {}}
+      onCatalogChange={async () => {}}
+      onCreated={() => {}}
+      onError={() => {}}
+      onRun={() => {}}
+      reportHref={reportHref}
+      running={false}
+      specification={specification}
+    />,
+  )
+}
+
+test('renders a direct report download in the selected Specification header', () => {
+  const markup = renderHeader('/api/history/run%2Fone/html')
+
+  expect(markup).toContain('href="/api/history/run%2Fone/html"')
+  expect(markup).toContain('download=""')
+  expect(markup).toContain('Download report')
+})
+
+test('does not render a report action in the header without a matching report', () => {
+  expect(renderHeader()).not.toContain('Download report')
+})
+
+test('keeps Run all before the report and labels the download for all Specifications', () => {
+  const markup = renderToStaticMarkup(
+    <SpecificationList
+      canRun
+      onRunAll={() => {}}
+      onSelect={() => {}}
+      reportHref="/api/history/run-all/html"
+      running={false}
+      specifications={[specification]}
+    />,
+  )
+
+  expect(markup.indexOf('Run all Specifications')).toBeLessThan(
+    markup.indexOf('Download latest report'),
+  )
+  expect(markup).toContain('Run all Specifications')
+  expect(markup).toContain(
+    'aria-label="Download latest report for all Specifications"',
+  )
+  expect(markup).toContain('href="/api/history/run-all/html" download=""')
+})

--- a/packages/studio/tests/unit/specifications/specification-run-report.test.ts
+++ b/packages/studio/tests/unit/specifications/specification-run-report.test.ts
@@ -1,0 +1,106 @@
+import type { TestRunSummary } from '@pickle-spec/runner'
+import { expect, test } from 'vitest'
+import type { StudioRunsIndex } from '../../../src/features/history/history.contracts'
+import {
+  allSpecificationsReportHref,
+  specificationReportHref,
+  specificationRunReport,
+} from '../../../src/features/specifications/specification-run-report'
+
+const finishedRun: TestRunSummary = {
+  id: 'run/with spaces',
+  startedAt: '2026-08-31T12:00:00.000Z',
+  finishedAt: '2026-08-31T12:00:01.000Z',
+  executionTargetProfileIds: ['chrome'],
+  specificationUris: ['features/checkout.feature'],
+  state: 'passed',
+  resultCount: 1,
+}
+
+function runsIndex(
+  runs: readonly TestRunSummary[],
+  activeRunIds: readonly string[] = [],
+): StudioRunsIndex {
+  return {
+    activeRunIds,
+    retention: {},
+    runs,
+    storage: {
+      pinnedRunIds: [],
+      totalBytes: 0,
+      warning: false,
+      warningThresholdBytes: 0,
+    },
+  }
+}
+
+test('builds an encoded HTML report URL for a completed indexed run', () => {
+  const report = specificationRunReport({
+    projectSpecificationUris: ['features/checkout.feature'],
+    runId: finishedRun.id,
+    runsIndex: runsIndex([finishedRun]),
+  })
+
+  expect(report?.href).toBe('/api/history/run%2Fwith%20spaces/html')
+})
+
+test('exposes the selected Specification action only for a matching run', () => {
+  const report = specificationRunReport({
+    projectSpecificationUris: [
+      'features/checkout.feature',
+      'features/search.feature',
+    ],
+    runId: finishedRun.id,
+    runsIndex: runsIndex([finishedRun]),
+  })
+
+  expect(specificationReportHref(report, 'features/checkout.feature')).toBe(
+    report?.href,
+  )
+  expect(specificationReportHref(report, 'features/search.feature')).toBe(
+    undefined,
+  )
+  expect(allSpecificationsReportHref(report)).toBe(undefined)
+})
+
+test('does not expose a stale, active, or unindexed run report', () => {
+  const input = {
+    projectSpecificationUris: ['features/checkout.feature'],
+    runId: finishedRun.id,
+  }
+
+  expect(specificationRunReport(input)).toBe(undefined)
+  expect(specificationRunReport({ ...input, runsIndex: runsIndex([]) })).toBe(
+    undefined,
+  )
+  expect(
+    specificationRunReport({
+      ...input,
+      runsIndex: runsIndex([finishedRun], [finishedRun.id]),
+    }),
+  ).toBe(undefined)
+})
+
+test('exposes the all-Specifications action only for an exact current scope', () => {
+  const allRun = {
+    ...finishedRun,
+    specificationUris: ['features/search.feature', 'features/checkout.feature'],
+  }
+  const report = specificationRunReport({
+    projectSpecificationUris: [
+      'features/checkout.feature',
+      'features/search.feature',
+    ],
+    runId: allRun.id,
+    runsIndex: runsIndex([allRun]),
+  })
+
+  expect(allSpecificationsReportHref(report)).toBe(report?.href)
+
+  const staleScope = specificationRunReport({
+    projectSpecificationUris: ['features/checkout.feature'],
+    runId: allRun.id,
+    runsIndex: runsIndex([allRun]),
+  })
+  expect(allSpecificationsReportHref(staleScope)).toBe(undefined)
+})


### PR DESCRIPTION
## Summary

- Add report download actions for completed Specification runs.
- Support selected-Specification and all-Specifications report links.
- Hide stale, active, unindexed, or scope-mismatched report actions.
- Add unit coverage for report URL and action behavior.

## Testing

- Added unit tests for report selection and download actions.
- Not run: repository-wide lint, typecheck, and test commands.