### PR TITLE
feat(studio): add artifact preview and download actions

### DIFF
--- a/packages/cli/tests/e2e/studio/studio.test.ts
+++ b/packages/cli/tests/e2e/studio/studio.test.ts
@@ -1063,9 +1063,24 @@ export default {
       expect(await timeline.textContent()).toContain('Then payment is captured')
       expect(await timeline.textContent()).not.toContain('Payment was declined')
       await page.getByRole('tab', { name: 'Artifacts' }).click()
-      expect(
-        await page.getByRole('img', { name: /screenshot/ }).count(),
-      ).toBeGreaterThan(0)
+      const previewArtifact = page.getByRole('button', {
+        name: /^Preview screenshot artifact/,
+      })
+      const artifactRow = previewArtifact.locator('xpath=ancestor::li')
+      await previewArtifact.click()
+      await artifactRow.getByRole('img', { name: /screenshot/ }).waitFor()
+      const [artifactDownload] = await Promise.all([
+        page.waitForEvent('download'),
+        artifactRow
+          .getByRole('link', { name: /^Download screenshot artifact/ })
+          .click(),
+      ])
+      expect(artifactDownload.suggestedFilename()).toBe(
+        'scnpaybbbbbbbbbb-chrome-attempt-1-step-1.png',
+      )
+      expect(await Bun.file(await artifactDownload.path()).bytes()).toEqual(
+        await Bun.file(join(project, 'failure.png')).bytes(),
+      )
       await page.getByRole('tab', { name: 'Diagnostics' }).click()
       expect(
         await page.getByText('Payment was declined').count(),

--- a/packages/studio/src/features/specifications/specifications-workbench-focus.tsx
+++ b/packages/studio/src/features/specifications/specifications-workbench-focus.tsx
@@ -8,6 +8,11 @@ import {
 } from '../../components/ui/accordion'
 import { Badge } from '../../components/ui/badge'
 import { Button, ButtonLink } from '../../components/ui/button'
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from '../../components/ui/collapsible'
 import { ResultMark } from '../../components/ui/result-mark'
 import { Spinner } from '../../components/ui/spinner'
 import { Switch } from '../../components/ui/switch'
@@ -24,6 +29,7 @@ import type {
 } from '../../server/contracts'
 import { ArtifactViewer } from '../runs/result/artifact-viewer'
 import {
+  artifactDownloadUrl,
   type TimelineEntry,
   timelineEntriesOfKinds,
 } from '../runs/result/result-evidence'
@@ -301,23 +307,61 @@ function selectedWorkbenchTimelineEntry(
 
 function CompactArtifacts(props: { model: SpecificationsWorkbenchModel }) {
   if (props.model.kind === 'browse') return <EmptyArtifacts />
-  const artifacts = props.model.focus?.artifacts ?? []
-  if (artifacts.length === 0) {
+  const focus = props.model.focus
+  if (!focus || focus.artifacts.length === 0) {
     return (
       <p className="text-sm text-muted-foreground">No artifacts retained.</p>
     )
   }
+  const artifacts = focus.artifacts
   return (
     <ul className="space-y-2">
-      {artifacts.map((evidence) => (
-        <li
-          key={evidence.index}
-          className="flex items-center justify-between gap-3 border-b border-border pb-2 text-sm"
-        >
-          <span className="min-w-0 truncate">{evidence.stepText}</span>
-          <Badge>{evidence.artifact.kind}</Badge>
-        </li>
-      ))}
+      {artifacts.map((evidence) => {
+        const downloadHref = artifactDownloadUrl(
+          evidence.artifact.path,
+          evidence.artifact.name,
+        )
+        return (
+          <li key={evidence.index} className="border-b border-border pb-2">
+            <Collapsible>
+              <div className="flex items-center gap-2 text-sm">
+                <CollapsibleTrigger
+                  render={
+                    <Button
+                      type="button"
+                      variant="ghost"
+                      aria-label={`Preview ${evidence.artifact.kind} artifact from ${evidence.stepText}`}
+                      className="min-w-0 flex-1 justify-between gap-3 px-2"
+                    />
+                  }
+                >
+                  <span className="min-w-0 truncate text-left">
+                    {evidence.stepText}
+                  </span>
+                  <Badge>{evidence.artifact.kind}</Badge>
+                </CollapsibleTrigger>
+                <ButtonLink
+                  variant="outline"
+                  size="sm"
+                  href={downloadHref}
+                  download={evidence.artifact.name ?? true}
+                  aria-label={`Download ${evidence.artifact.kind} artifact from ${evidence.stepText}`}
+                >
+                  Download
+                </ButtonLink>
+              </div>
+              <CollapsibleContent className="pt-2">
+                <ArtifactViewer
+                  artifact={evidence.artifact}
+                  scenarioName={focus.inspected.result.scenario.name}
+                  resultState={focus.resultState}
+                  stepText={evidence.stepText}
+                />
+              </CollapsibleContent>
+            </Collapsible>
+          </li>
+        )
+      })}
     </ul>
   )
 }

--- a/packages/studio/tests/unit/specifications/specifications-workbench-model.test.ts
+++ b/packages/studio/tests/unit/specifications/specifications-workbench-model.test.ts
@@ -119,6 +119,15 @@ function workbenchInspection(): LiveResultInspection {
               },
             },
             resolvedActions: [],
+            artifacts: [
+              {
+                kind: 'screenshot',
+                path: '/artifacts/checkout.png',
+                name: 'checkout.png',
+                mediaType: 'image/png',
+                capturedAt: '2026-09-02T12:00:01.000Z',
+              },
+            ],
           },
         ],
       },
@@ -454,7 +463,7 @@ describe('Specifications workbench model', () => {
     )
     expect(markup).toContain('aria-pressed="true"')
     expect(markup).toContain('data-timeline-entry-id=')
-    expect(markup).toContain('Artifacts 0')
+    expect(markup).toContain('Artifacts 1')
     expect(markup).toContain('When the customer signs in')
     expect(markup).toMatch(/Total.*Queued.*Passed.*Failed/s)
     expect(markup).toMatch(/Run all 4.*Cancel run/s)
@@ -462,6 +471,47 @@ describe('Specifications workbench model', () => {
     expect(markup).not.toContain('Current step')
     const removedContent = />Running<\/dt>|<footer|Run selected|Concurrency/
     expect(markup).not.toMatch(removedContent)
+  })
+
+  test('renders artifact preview and download actions', () => {
+    const live = workbenchInspection()
+    if (!live.location) throw new Error('Expected a focused Workbench result')
+    const model = specificationsWorkbenchModel({
+      specifications: [],
+      live: {
+        ...live,
+        location: { ...live.location, tab: 'artifacts' },
+      },
+    })
+    const markup = renderToStaticMarkup(
+      createElement(SpecificationsWorkbench, {
+        canRunAll: true,
+        model,
+        onCancel: () => undefined,
+        onDismissFinishedRun: () => undefined,
+        onInspectLocation: () => undefined,
+        onInspectTimelineEntry: () => undefined,
+        onPauseFollowing: () => undefined,
+        onEditSpecification: () => undefined,
+        onResumeFollowing: () => undefined,
+        onRun: () => undefined,
+        onSelectInspectorTab: () => undefined,
+        onSelectScenario: () => undefined,
+        onSelectSpecification: () => undefined,
+        running: true,
+      }),
+    )
+
+    expect(markup).toContain(
+      'aria-label="Preview screenshot artifact from When the customer signs in"',
+    )
+    expect(markup).toContain(
+      'aria-label="Download screenshot artifact from When the customer signs in"',
+    )
+    expect(markup).toContain(
+      'href="/api/artifact?path=%2Fartifacts%2Fcheckout.png&amp;download=true&amp;name=checkout.png"',
+    )
+    expect(markup).toContain('download="checkout.png"')
   })
 
   test('offers report downloads after the workbench run finishes', () => {


### PR DESCRIPTION
## Summary

- Add expandable artifact previews in the Specifications workbench.
- Add download actions with artifact-specific filenames and URLs.
- Extend unit and E2E coverage to verify preview rendering and downloaded bytes.

## Testing

- `bun run lint`
- Specifications workbench model unit coverage for preview and download actions.
- Studio E2E coverage for artifact preview, suggested filename, and downloaded content.