### PR TITLE
Add AI engineering action plan and launch growth roadmap

### DIFF
--- a/docs/ai-engineering-action-plan.md
+++ b/docs/ai-engineering-action-plan.md
@@ -1,0 +1,463 @@
+# AI engineering action plan
+
+Created on 2026-09-04. This backlog translates the
+[QA and UX review](roadmap-qa-ux-review.md) and
+[launch and growth plan](launch-and-growth.md) into assignable engineering tasks.
+It includes the QA request to inspect, manually edit, and autonomously repair
+AI-generated execution plans. All tasks are pending. This document does not
+certify features, authorize publication, or start implementation.
+
+## Delivery outcome
+
+A QA engineer can connect an application, run a meaningful Scenario, diagnose a
+failure, correct a generated interaction, validate the correction, and reuse the
+accepted plan through Replay. Human edits survive cache eviction and refresh.
+AI-assisted and autonomous repair use the same validation and activation rules.
+
+Keep these concepts distinct:
+
+| Concept | Responsibility |
+| --- | --- |
+| Specification | Gherkin intent and expected business outcomes |
+| Coverage plan | Proposed journeys and risks to test; deferred from the first delivery |
+| Execution plan | Ordered interactions and checks mapped to Specification steps |
+| Execution cache | Disposable runtime entries for applicable execution paths |
+| Plan revision | Proposed durable authored change, with provenance and validation |
+
+Plan revision storage and APIs are design work in ENG-03. They are not existing
+contracts. A passing run alone cannot prove that an edited assertion preserved
+intent; interaction repair must also protect the original checks.
+
+## How to execute a task
+
+Assign one engineer or coding agent to a task ID. Read the relevant implementation,
+tests, local AGENTS.md, and 10x-coder skill before changing code. The module lists
+below are entry points, not permission to rewrite every listed package.
+
+Start with the requested outcome, non-goals, smallest expected file set, and
+proof. Inspect existing behavior before adding it. A task can close as already
+implemented only with acceptance evidence at the current revision.
+
+Deliver a focused change with its task ID, acceptance results, exact commands,
+revision, and remaining limitations. Record unavailable credentials or devices as
+blocked verification. Do not substitute mocks for real-target claims. Update the
+checkbox only when the stated exit checks pass.
+
+Respect repository approval rules for new public APIs, storage/wire formats,
+dependencies, or destructive operations when the active implementation request
+has not authorized them. Complete a concrete design proposal first. This backlog
+is a planning artifact, not blanket approval for those changes.
+
+## Ordered backlog
+
+Priority P0 covers the core QA loop and manual maintenance. P1 covers expanded
+repair and target reach. P2 requires evidence from returning users. Dependencies
+are task IDs; independent tasks may be assigned separately after their shared
+contracts are settled. No delivery dates or effort estimates are assumed.
+
+| Done | ID | Priority | Task | Depends on |
+| --- | --- | --- | --- | --- |
+| [ ] | ENG-01 | P0 | Reconcile capability status and release evidence | None |
+| [ ] | ENG-02 | P0 | Create a repeatable QA acceptance fixture | ENG-01 |
+| [ ] | ENG-03 | P0 | Decide execution-plan ownership and contracts | ENG-01 |
+| [ ] | ENG-04 | P0 | Expose a readable execution plan | ENG-03 |
+| [ ] | ENG-05 | P0 | Persist durable drafts and revisions | ENG-03 |
+| [ ] | ENG-06 | P0 | Add manual web interaction editing | ENG-04, ENG-05 |
+| [ ] | ENG-07 | P0 | Validate a candidate without activating it | ENG-02, ENG-05, ENG-06 |
+| [ ] | ENG-08 | P0 | Activate, roll back, and preserve edited plans | ENG-07 |
+| [ ] | ENG-09 | P0 | Explain failures and Replay divergence | ENG-01, ENG-02 |
+| [ ] | ENG-10 | P0 | Fix first-run and setup recovery gaps | ENG-02 |
+| [ ] | ENG-11 | P0 | Prove CI failure handoff and exports | ENG-02, ENG-09 |
+| [ ] | ENG-12 | P0 | Verify accessible, stable QA workflows | ENG-08, ENG-09, ENG-10, ENG-11 |
+| [ ] | ENG-13 | P0 | Complete manual-maintenance release verification | ENG-12 |
+| [ ] | ENG-14 | P0 | Prepare pilot and launch evidence assets | ENG-13 |
+| [ ] | ENG-15 | P1 | Generate an AI repair proposal | ENG-08, ENG-09 |
+| [ ] | ENG-16 | P1 | Add bounded autonomous repair policy | ENG-15 |
+| [ ] | ENG-17 | P1 | Extend plan maintenance to mobile | ENG-08 |
+| [ ] | ENG-18 | P1 | Close second-journey authoring gaps | ENG-14, pilot feedback |
+| [ ] | ENG-19 | P2 | Scope later capabilities from observed demand | ENG-14, return-use evidence |
+
+Start with ENG-01, then ENG-02 and ENG-03. The critical maintenance path is
+ENG-03 through ENG-08. Diagnosis, onboarding, and CI work can advance alongside
+that path without inventing alternative plan contracts.
+
+## P0 task details
+
+### ENG-01: Reconcile capability status and release evidence
+
+Entry points: [ROADMAP.md](../ROADMAP.md), [README.md](../README.md),
+[DESIGN.md](../DESIGN.md), [release policy](releasing.md), and the owning Studio
+features and adapter tests discovered from them.
+
+Work:
+
+- Resolve the contradictory live-view and diagnostic status statements.
+- Split compound items such as follow mode, filmstrip, and picture-in-picture.
+- Produce a task-based matrix for local web, attached CDP, Browserbase, Android
+  Emulator, and iOS Simulator. Cover setup, assertions, artifacts, Replay,
+  cancellation, CI, and plan inspection/editing.
+- Record implemented, verified, unsupported, or unverified with revision and
+  evidence. Link to DESIGN.md rather than copying obsolete color tokens.
+
+Done when every advertised capability has a supported scope and evidence status.
+No feature implementation belongs in this inventory task. Turn discovered gaps
+into the relevant task below or a separately scoped follow-up.
+
+### ENG-02: Create a repeatable QA acceptance fixture
+
+Entry points: `apps/example`, existing web/runner test fixtures, and the documented
+quick-start examples under `apps/docs`.
+
+Work:
+
+- Extend an existing small application with an authenticated journey, isolated
+  synthetic data, a meaningful assertion, and a known reset path.
+- Provide separate reproducible variants for a changed interaction target and
+  a genuine incorrect business outcome. Preserve the original expectation.
+- Include clean setup, repeat run, failure evidence, and cache-only outcomes.
+  Use existing test infrastructure and avoid introducing a new fixture service.
+
+Done when the original Scenario passes, the target-change variant fails in the
+expected place, and the business-regression variant stays failed after an
+interaction-only repair. Record application and Scenario revisions for each.
+Prove two runs do not contaminate each other's data.
+
+### ENG-03: Decide execution-plan ownership and contracts
+
+Read [cache contracts](../packages/runner/src/execution-cache/execution-cache.ts),
+[web instruction schema](../packages/web/src/execution-cache/web-cache-schema.ts),
+[mobile cache implementation](../packages/mobile/src/execution-cache/mobile-execution-cache.ts),
+and [Studio cache gateway](../packages/cli/src/studio/studio-cache.ts).
+
+Work:
+
+- Write a focused design decision describing durable repository-owned revisions
+  and their relationship to disposable cache entries. Specify actual proposed
+  types and lifecycle operations, with examples for one edited web interaction.
+- Define step identity, supported operations, draft/validated/active states,
+  author attribution, source and validation runs, and rollback behavior.
+- Define compatibility with existing caches and immutable historical runs,
+  including what happens when a new plan format is unavailable or unsupported.
+- Preserve cache applicability across project, Scenario revision, profile,
+  configuration fingerprint, application revision, and adapter schema.
+- Decide how edits, refresh, eviction, branches/worktrees, concurrent writers,
+  invalidation, and validation-to-activation races behave.
+- Protect assertion semantics: reject removal, weakening, or bypass of checks
+  through interaction repair. Treat uncertain equivalence as requiring explicit
+  Specification review. A target edit is not automatically semantically safe.
+- Specify a no-inference path for complete supported plans. Partial plans must
+  explain why complete Replay validation is unavailable instead of silently
+  invoking a model.
+
+Done when the design contains concrete contracts, failure cases, migration
+behavior, and acceptance examples, and required contract approval is recorded.
+Avoid a generic workflow engine or a second action language. Use adapter-owned
+representations and the smallest shared contract the actual callers require.
+
+### ENG-04: Expose a readable execution plan
+
+Entry points: `packages/studio/src/features/execution-cache`,
+`packages/studio/src/features/runs/result`, the CLI Studio gateway, and adapter
+cache parsers. Follow ENG-03's approved ownership.
+
+Work:
+
+- Project parsed actions into a read-only view grouped by Gherkin step.
+- Show action target, variable references, checks, source evidence, applicability,
+  and any uncached tail. Redact secrets before returning data to the UI.
+- Open this view from the Scenario and failing-step context, using Mira controls.
+- Handle absent, incompatible, or unsupported plans with an explicit next action.
+
+Done when a QA user can identify the failed interaction and its Scenario step
+without reading raw payloads. Verify complete and partial web paths, unsupported
+payloads, and secrets in inputs. This task adds no mutation endpoint.
+
+### ENG-05: Persist durable drafts and revisions
+
+Entry points: the approved domain owner from ENG-03, runner cache coordination,
+and CLI project composition. Keep storage outside presentation components.
+
+Work:
+
+- Implement draft creation, validated revision persistence, history lookup, and
+  conflict detection under the approved format.
+- Keep authored revisions independent of cache eviction and cache clearing.
+- Parse untrusted files at the boundary; preserve variable references instead of
+  storing bound secrets. Prevent project-path escape.
+- Preserve existing user edits and reject stale writes. Recover from interrupted
+  writes without publishing incomplete revisions.
+
+Done when restart, eviction, concurrent edits, malformed input, and interrupted
+writes preserve the last valid state. Existing cache-only projects continue to
+work without creating authored plans automatically.
+
+### ENG-06: Add manual web interaction editing
+
+Entry points: the execution-plan feature from ENG-04/05 and web cache schema.
+
+Work:
+
+- Add contextual fields for supported navigation, locator, and input operations.
+  Support insertion, deletion, and reordering where the approved semantics allow.
+- Show the candidate diff beside its Gherkin step and original checks.
+- Keep assertion changes outside interaction repair. Explain unsupported edits.
+- Preserve unsaved work and provide discard and save-draft actions. Saving a
+  draft must not change active execution.
+
+Done when the ENG-02 changed-target interaction can be edited without model
+credentials or raw cache editing. Verify invalid locators/variables, protected
+checks, keyboard interaction, and navigation with unsaved changes.
+
+### ENG-07: Validate a candidate without activating it
+
+Entry points: runner Scenario execution, adapter Replay, and existing Studio run
+requests. Extend approved contracts rather than introducing another runner.
+
+Work:
+
+- Run the affected complete Scenario against a known reset state using the exact
+  candidate revision. Preserve the original Specification and expected outcomes.
+- Bind the validation result to the candidate digest and all applicability inputs.
+- Keep candidate execution isolated from active cache publication. Failed,
+  cancelled, timed-out, or subsequently edited candidates cannot become active.
+- Label side effects before validation. Model-free validation must fail clearly
+  when a candidate is incomplete or unsupported, with no Adaptive fallback.
+
+Done when a corrected target validates, a business regression fails, and editing
+a candidate after validation invalidates its validation status. Prove the active
+plan/cache remains unchanged after every unsuccessful validation outcome.
+
+### ENG-08: Activate, roll back, and preserve edited plans
+
+Entry points: plan persistence, runner cache selection/coordination, and Studio
+plan history. Use ENG-07's exact validation binding.
+
+Work:
+
+- Activate a validated revision atomically only if its applicability and baseline
+  still match. Record revision attribution in runs through the approved contract.
+- Materialize applicable runtime entries from accepted plans without requiring
+  model inference. Do not weaken existing cache key checks.
+- Preserve authored plans through eviction/clear. Make refresh produce a candidate
+  or conflict for edited plans instead of overwriting them silently.
+- Add rollback to an eligible earlier revision. Require revalidation when its
+  target or other applicability inputs have changed.
+
+Done when edit → validate → activate → Replay → evict → Replay succeeds for the
+fixture with zero inference in the supported path. Verify refresh conflict,
+stale activation, rollback, application revision change, and unchanged historical
+run evidence. Finish this vertical workflow before adding AI repair.
+
+### ENG-09: Explain failures and Replay divergence
+
+Entry points: `packages/studio/src/features/runs/result`, existing run events,
+and live/completed evidence projections.
+
+Work:
+
+- Show expected/observed evidence, failing step, execution mode, applicable cached
+  prefix, and the reason for missing artifacts.
+- Reuse `replay-diverged` and `adaptive-fallback-started`; explain when fallback
+  occurred and when partial side effects prevented safe continuation.
+- Keep the selected evidence stable as live events arrive. Link to a selective
+  rerun and, once available, the relevant plan interaction.
+
+Done when seeded application, setup, infrastructure, and Replay failures have
+consistent live and persisted explanations. Unknown causes remain unknown;
+a passed fallback is not mislabeled as pure Replay. Prove refreshed deep links.
+
+### ENG-10: Fix first-run and setup recovery gaps
+
+Entry points: `packages/studio/src/features/onboarding`,
+`packages/cli/src/studio/studio-project.ts`, and existing readiness/run ownership.
+
+Work:
+
+- Walk through empty project, missing target, invalid credentials, first failure,
+  and successful completion. Fix only reproduced gaps.
+- Separate credential-free demonstration from testing a real application.
+- Preserve edits and target selection during recovery. Explain when Run may use
+  inference and when cache-only execution cannot proceed.
+
+Done when the fixture can move from blocked to ready to completed using the
+existing readiness flow. Record total setup time and assistance, including failed
+attempts. Human timing targets require ENG-14 participant evidence.
+
+### ENG-11: Prove CI failure handoff and exports
+
+Entry points: existing CLI run/export/import commands, Studio artifact viewing,
+`docs/releasing.md`, and existing CI workflows.
+
+Work:
+
+- Add or repair one documented CI recipe for cache-only behavior and output
+  preservation on failure, using existing export formats.
+- Verify the actual downloaded HTML and archive bytes in a separate workspace.
+- Keep report actions beside the run that produced them. Distinguish local deep
+  links from portable files and explain missing or retained artifacts.
+
+Done when a deliberate CI failure remains a failed job while its evidence can be
+downloaded, imported, and understood without the original workspace. No hosted
+sharing service, PR annotation framework, or shard merging is part of this task.
+
+### ENG-12: Verify accessible, stable QA workflows
+
+Entry points: the UI changed by ENG-04–11, DESIGN.md, and existing Studio browser
+coverage. Search/add registry primitives before creating controls.
+
+Work:
+
+- Exercise select, run, cancel, inspect, edit, validate, activate, rollback, export,
+  and recovery by keyboard. Inspect screen-reader labels and live announcements.
+- Check focus after dialogs and updates, 200% zoom, a narrow viewport, long names,
+  missing artifacts, and concurrent run events.
+- Fix reproduced overlap, focus loss, inaccessible controls, and unexpected
+  selection changes. Preserve one clear primary action per context.
+
+Done when the rendered workflow passes these checks with recorded viewport and
+interaction evidence. Unit tests alone do not close this task.
+
+### ENG-13: Complete manual-maintenance release verification
+
+Entry points: [Release validation](releasing.md), existing package tests,
+`scripts/release-packages.ts`, and `scripts/replay-performance-gate.ts`.
+
+Work:
+
+- Run focused regression tests, then required repository and release gates.
+- Verify the installable artifacts outside the monorepo. Verify the exact public
+  package after publication is separately authorized and performed.
+- Run the full fixture on real advertised targets and capture revision, OS,
+  application revision, inference behavior, and result artifacts.
+- Verify compatibility for projects without authored plans and historical exports.
+
+Done when the release evidence identifies which claims have live proof and which
+remain unavailable. A blocked target cannot be marked verified. Publication is a
+separate owner action; package packing is not evidence of registry availability.
+
+### ENG-14: Prepare pilot and launch evidence assets
+
+Entry points: ENG-02's fixture, verified release evidence, and the launch plan.
+
+Work:
+
+- Prepare the tested quick start, maintenance walkthrough, portable failure report,
+  support matrix, and release limitations using one exact version.
+- Prepare a five-participant session script covering setup, diagnosis, manual
+  editing, validation, rollback, and repeat use.
+- Create a simple local results template with project alias, assistance, timings,
+  completion, blockers, and seven-day follow-up status. No hosted telemetry.
+- Hand the materials to the product/launch owner for recruitment and publication.
+
+Engineering delivery is done when another engineer can reproduce the assets.
+Product acceptance remains pending until real participants meet the companion
+review's criteria. Never fabricate sessions or treat an agent walkthrough as user
+research. Engineering can prepare outreach drafts, but must not send them without
+authorization.
+
+## P1 and P2 task details
+
+### ENG-15: Generate an AI repair proposal
+
+Depends on ENG-08 and ENG-09. Use existing configured model integration and the
+same plan draft, diff, validation, and activation operations as manual editing.
+
+- Supply only relevant redacted evidence and supported operations to the model.
+- Produce a structured candidate scoped to the failing interaction. Reject
+  unsupported operations and assertion changes at the boundary.
+- Show the proposed diff and rationale grounded in observable evidence. Retain
+  human acceptance and the full Scenario validation requirement.
+- Handle invalid output, unavailable credentials, cancellation, and provider
+  failure without changing the active plan or losing a manual draft.
+
+Done when a real model proposes a valid correction for the changed-target case,
+the candidate passes the same validation, and the business-regression case stays
+failed. Report controlled tests and real-model evidence separately. No private
+chain-of-thought is stored or displayed.
+
+### ENG-16: Add bounded autonomous repair policy
+
+Depends on ENG-15. Write the concrete project-policy proposal first and obtain
+any required configuration-contract approval before implementation.
+
+- Default automatic activation off. Define permitted scope, maximum attempts,
+  cancellation, retry/cost limits where measurable, and attribution.
+- Route automatic activation through ENG-08. Stop on uncertain intent, stale
+  validation, repeated failures, or a broad shared outage.
+- Keep every failed attempt visible and every accepted revision recoverable.
+  Do not quarantine tests or change expected behavior implicitly.
+
+Done when policy-off prevents automatic activation, limits stop the loop, an
+outage does not trigger repeated suite-wide repair, and every accepted repair has
+a diff and exact validation evidence. Reuse the same seeded regressions as ENG-15.
+
+### ENG-17: Extend plan maintenance to mobile
+
+Depends on ENG-08. Entry points: mobile execution-cache and agent-device Replay.
+
+- Map supported mobile operations into the existing plan interaction workflow.
+- Preserve application launch identity, variable handling, and the mobile
+  complete-Scenario Replay requirement. Do not imply partial-prefix parity.
+- Verify manual editing, validation, activation, and rollback on provisioned
+  Android Emulator and iOS Simulator targets, recording each separately.
+
+Done when target-specific evidence supports each advertised editing operation.
+Unsupported operations remain explicit. No physical-device work is included.
+
+### ENG-18: Close second-journey authoring gaps
+
+Depends on ENG-14 and actual pilot feedback. Entry points: Specification editing,
+existing syntax, configuration, and example setup.
+
+Select the most frequent observed blocker, then implement one bounded improvement:
+a template, assertion diagnostic, repeated setup extraction, or draft-generation
+step. Reuse existing mechanisms before introducing shared-flow syntax. Any new
+public authoring contract needs a concrete proposal under repository rules.
+
+Done when a participant adds a second meaningful journey without maintainer
+operation and can explain the expected result. Broad coverage planning and
+grounded autocomplete are not automatic dependencies.
+
+### ENG-19: Scope later capabilities from observed demand
+
+Depends on ENG-14 and evidence of returning projects. Deliver scoped issue briefs,
+not a batch implementation, for the highest demonstrated needs:
+
+| Candidate | Evidence needed before implementation | Required acceptance direction |
+| --- | --- | --- |
+| Visual comparison | Users cannot diagnose a visual regression with current artifacts | Compatible baselines and deliberate visual changes produce understandable differences |
+| Classification and quarantine | Repeated ambiguous failures or flakes block useful CI | Provenance, explicit override, visible ownership/expiry, no false green |
+| Trends and suite health | Returning teams cannot prioritize failing or slow Scenarios | Explainable measures from existing history, with missing data explicit |
+| Read-and-run MCP | Coding-agent users are blocked by manual handoffs | Same readiness, run, result, and artifact contracts as CLI/Studio |
+| AI coverage planning | Users cannot identify or author their next useful journey | Approved plan, traceable draft, validated Scenario, unchanged review ownership |
+| Change-impact selection and shard merging | Measured CI duration or scale bottleneck | Explained selection/merge, full-suite fallback, regression comparison |
+
+Each brief needs the observed problem, smallest scope, owners, dependencies,
+contract decisions, and proof. Keep picture-in-picture, filmstrip, physical
+devices, and hosted collaboration deferred until their own need is demonstrated.
+
+## Verification and handoff record
+
+Use the narrowest existing Vitest suite through Bun for each changed behavior.
+Run `bun run lint`, `bun run typecheck`, and `bun run test` from the root as
+required by repository instructions. Follow the release guide for
+`bun run release:check`, `bun run benchmark:replay`, dependency installation, and
+provisioned smoke commands. Read current package scripts before selecting a
+focused command; do not assume `bun test` is equivalent.
+
+Attach this record to each completed task:
+
+```text
+Task ID:
+Revision:
+Changed files and why:
+Acceptance checks: passed / failed / blocked, with evidence
+Exact commands and results:
+Real target / controlled fixture / rendered UI evidence:
+Public or storage contract decisions, if applicable:
+Remaining limitations and dependent tasks:
+```
+
+For this document, local paths and the current cache/schema/gateway entry points
+were inspected. No backlog task was executed, no new public contract was selected,
+and no runtime or launch claim was verified.

--- a/docs/launch-and-growth.md
+++ b/docs/launch-and-growth.md
@@ -1,0 +1,233 @@
+# Pickle Spec launch and growth plan
+
+Drafted on 2026-09-04. This plan proposes a focused technical preview followed
+by a broader launch after external projects demonstrate repeat use. It is not
+a claim that release gates have passed. Product priorities are in the
+[QA and UX roadmap review](roadmap-qa-ux-review.md); package validation remains
+owned by [Release validation](releasing.md).
+
+## Audience and promise
+
+Start with QA engineers, SDETs, and developers who own a small web regression
+suite and can install a Bun project. The initial use case is a source-controlled
+smoke journey whose failures need understandable, portable evidence.
+
+Lead with web because it gives this campaign one setup path and one demonstration.
+Offer a separate mobile track to teams with provisioned emulators or simulators.
+This is a campaign choice, not a proposal to remove mobile support. Treat demand
+from manual-only QA teams, large enterprises, and coding-agent users as hypotheses
+to investigate before broadening the onboarding promise.
+
+Suggested positioning:
+
+> Write a Gherkin scenario, run it against your application, and inspect what
+> happened in local Studio. Reuse applicable execution paths through Replay and
+> take the failure evidence with you.
+
+Explain the boundaries near the install instructions. Adaptive execution needs a
+configured model provider and can incur provider charges. Applicable Replay runs
+without model inference; cache-only mode fails on misses or divergence. Replay
+does not guarantee a passing application. Local-first storage does not mean
+configured model or remote-browser providers receive no data.
+
+Avoid claims of zero flakiness, universal browser support, complete Cucumber
+compatibility, perfect healing, or unique AI testing. Planned authoring and repair
+must not appear as available features in launch copy.
+
+## Maintenance feedback to validate
+
+A QA engineer, through the project owner, asked for easy maintenance of the
+AI-generated cached interactions, either manually or through autonomous repair.
+The proposed product response is an editable execution plan linked to Gherkin
+steps, with validated revisions and recoverable human changes. See the
+[execution-plan review](roadmap-qa-ux-review.md#high-qa-needs-ownership-of-the-generated-execution-plan)
+for the workflow and acceptance criteria.
+
+Add a maintenance task to pilot interviews: change a UI interaction while keeping
+the expected business outcome unchanged, then ask the participant to repair it.
+Record whether they prefer manual editing, an AI proposal, or policy-controlled
+autonomous repair, and why. Measure task completion, assistance, time to a
+validated revision, and confidence explaining the change. Distinguish a
+prototype session from a working released editor.
+
+Manual execution-plan maintenance is a proposed core QA milestone. Broad launch
+positioning around maintainability should wait for its acceptance checks. A
+technical preview can still disclose the limitation. Do not advertise editable
+plans or autonomous repair until the exact released workflow is verified.
+
+Once available, demonstrate the complete loop: AI creates interactions, QA
+corrects one, the Scenario validates without weakening its assertions, and
+Replay uses the accepted revision. Test whether this helps activated projects
+return after their application changes. One engineer's feedback justifies testing
+this workflow, not claiming that every QA team wants autonomous changes.
+
+## What counts as activation
+
+Track the funnel by distinct external project, excluding internal fixtures and
+maintainer demonstrations. Do not infer activation from package downloads.
+
+| Stage | Evidence |
+| --- | --- |
+| Attention | A source-tagged visit or response; only a distribution signal |
+| Setup started | A participant attempts installation in their own project |
+| Ready | Target and configuration checks pass |
+| First value | A real-application scenario with a meaningful assertion runs and the participant inspects its result |
+| Activated | The participant also explains a deliberate failure and repeats an eligible scenario through Replay |
+| Retained | The project runs again on a different day within seven days of activation |
+| Expanded | The project adds a second meaningful journey or uses the suite in CI |
+
+Record why a scenario is not Replay-eligible. Report those users' first value and
+return behavior separately so the definition does not erase useful adoption.
+Track assisted activation separately from unassisted activation. A copied example
+is a demonstration completion, not an activated external project.
+
+Start with a consent-based research log, using project aliases, source channel,
+release, dates, stage reached, assistance, and blocker. No new hosted telemetry
+is required. Do not collect application contents, credentials, or test artifacts
+by default. Ask before retaining interview recordings or customer examples.
+
+## Launch gates
+
+The release owner records a pass, failure, or explicit limitation beside each
+gate, with the exact revision and evidence location. An unchecked gate is pending.
+
+- [ ] Run the required commands in the release guide and retain their output.
+- [ ] Verify the intended published package version and dist-tag from a clean external project. Package packing alone does not prove registry installation works.
+- [ ] Run the published README path through initialization, Studio, a real assertion, a deliberate failure, and evidence inspection.
+- [ ] Verify Adaptive followed by applicable Replay, and cache-only miss behavior. Record inference counts without claiming unmeasured dollar savings.
+- [ ] Complete the export/download/import handoff on another workspace or machine, with no original project access.
+- [ ] Record live smoke evidence for every target advertised in this launch. Mark other targets unverified for this release or omit the claim.
+- [ ] Publish prerequisites, provider-data boundaries, supported environments, and known limitations beside the quick start.
+- [ ] Confirm package metadata, license terms, repository links, issue reporting, and install instructions for the release. This review did not establish published availability or license readiness.
+- [ ] Complete the QA acceptance session in the companion review, including keyboard use, error recovery, and manual execution-plan maintenance. A preview without the editor must record that task as unavailable, not passed.
+- [ ] Before advertising plan maintenance, verify manual edit, validation, activation, rollback, and preservation through refresh and cache eviction. Verify AI repair separately before advertising it.
+- [ ] Assign someone to handle install failures and feedback during the launch window, with a documented workaround or previous-version recovery path.
+
+A technical preview may proceed with disclosed limitations and assisted setup.
+Defer broad promotion if the primary web path is broken, evidence is misleading,
+regressions become passes, or external users cannot recover from common failures.
+Do not delay the preview for AI authoring, autonomous repair, trends, or hosted
+collaboration. Keep the manual-maintenance gap visible in preview limitations.
+
+## Launch package
+
+Use one tested scenario and one exact release across the assets. Prefer a small
+application with login and one meaningful state change. Use synthetic data.
+
+| Asset | Content | Completion check |
+| --- | --- | --- |
+| Quick start | Prerequisites, install, configure, run, inspect, repeat, troubleshooting | An external tester follows it without undocumented commands |
+| Short demo | Gherkin, real execution, failed expectation, evidence, applicable Replay | Every displayed capability works on the named release; provider calls and edits are disclosed |
+| Example repository | Small application, assertion, seeded failure, CI recipe | Clean checkout produces the documented outcomes |
+| Failure report | Portable HTML and importable archive from the demonstration | Another person opens the report and explains the failure |
+| Support matrix | Verified targets and task-level limitations | Each supported claim links to release evidence |
+| Release notes | Available capabilities, exclusions, known issues, recovery instructions | Claims match the release and roadmap status |
+| Feedback form or issue template | Task attempted, environment, version, expected/actual result, optional sanitized evidence | Reporter can describe a blocker without sending secrets |
+
+Keep package ownership details available for library consumers. The launch
+landing page should first explain the QA task, show the result, and provide the
+verified install path. Use the repository's current package name,
+`@pickle-spec/cli`, after checking the published artifact.
+
+## Rollout sequence and ownership
+
+One person may own several roles. Assign names before starting. The periods
+below are proposed working windows, not release commitments.
+
+| Window | Owner | Work and decision |
+| --- | --- | --- |
+| Preparation | Release owner | Complete package gates and the primary example; keep the launch date unset until blockers are understood |
+| First pilot week | Product owner | Recruit five qualified external testers through existing contacts; observe the QA journey and record every blocker |
+| Second pilot week | Product and release owners | Fix repeated blockers, retest, and check seven-day return behavior; decide whether to broaden the preview |
+| Public preview week | Launch owner | Publish the tested quick start, example, demo, and limitations; remain available for support |
+| Following four weeks | Product and launch owners | Run one acquisition experiment at a time, review weekly cohorts, and prioritize recurring activation or retention failures |
+
+Outreach and publication are future owner actions. This document does not send
+messages, publish posts, buy ads, or schedule campaigns.
+
+## Distribution experiments
+
+Start with existing contacts and one public channel. The following sample sizes
+and decision rules are proposed learning thresholds, not forecasts. Small samples
+provide qualitative direction, not reliable conversion benchmarks.
+
+| Experiment | Hypothesis and asset | Measure and decision |
+| --- | --- | --- |
+| Assisted QA pilot | People maintaining smoke tests value clearer failure evidence; use the example plus a guided session | Five participants; if fewer than four finish the core journey, improve the repeated blocker before increasing traffic |
+| Technical walkthrough | A concrete failure-to-diagnosis demo attracts qualified evaluators; publish one walkthrough on the channel where pilot users already participate | Track source to setup attempts and activation; after ten qualified attempts, compare blockers and returns with the pilot |
+| Replay explanation | Explaining applicability and cache-only failure behavior reduces setup confusion; add one focused guide | Compare the next five sessions with the previous five; keep the guide if misunderstandings fall without new setup steps |
+| Execution-plan maintenance | QA control over generated interactions helps projects survive application changes; use a working editor or an explicitly labeled prototype | Observe five maintenance sessions; assess the companion review criteria and seven-day return before making maintainability claims |
+| CI recipe | Returning projects need unattended execution and portable failures; provide one tested workflow | Try it with three retained projects; prioritize CI work if at least two use it again without maintainer operation |
+| Mobile pilot | Existing emulator users value the same evidence workflow; publish a separate target-specific example | Recruit three provisioned teams only after the web journey is stable; record target-specific blockers separately |
+
+Possible public channels include a technical blog, existing QA communities,
+LinkedIn, and Show HN. Choose from participant behavior rather than posting
+identical content everywhere. Confirm each community's current rules before
+posting. No paid acquisition budget is assumed; defer spending until unassisted
+activation and repeat use are observable.
+
+Show HN is suitable only once readers can try the product. Its official guidance
+excludes landing pages alone and emphasizes accessible experimentation. Prepare
+a working example and a factual founder explanation before choosing this channel.
+[Show HN guidelines](https://news.ycombinator.com/showhn.html), checked 2026-09-04.
+
+## Initial content sequence
+
+Each item uses the same verified example and links to the next useful task.
+Publish when its evidence is ready; this is not a daily posting obligation.
+
+1. Show a real failed assertion and how Studio explains it. Invite readers to run the example.
+2. Explain Adaptive, applicable Replay, and cache-only misses with recorded outcomes. Link the configuration recipe.
+3. Walk through an authenticated journey with isolated test data. Ask evaluators which setup step blocked their own application.
+4. Move a CI failure into local Studio and a portable report. Show what the recipient needs to open it.
+5. Publish the most common pilot blocker, the change made, and its retest result. Use customer material only with permission.
+
+For the first announcement, use this structure after verifying the release:
+
+> Pickle Spec runs Gherkin scenarios against your application and keeps the run
+> evidence in local Studio. This example shows a failed assertion, the step that
+> produced it, and a report you can open separately. Applicable Replay reuses a
+> stored execution path without model inference. The quick start lists the
+> prerequisites and current limitations. We are looking for QA practitioners to
+> try one real smoke journey and tell us where setup or diagnosis gets confusing.
+
+Attach the actual quick-start and example links when published. Do not substitute
+invented user counts, performance numbers, or testimonials for the demonstration.
+
+## Weekly review
+
+For each source and activation week, report setup attempts, ready projects,
+first-value projects, activated projects, and seven-day retained projects as
+counts and fractions. Calculate retention only for cohorts old enough to have a
+full seven-day observation window. Record unknown follow-up outcomes separately.
+
+Also report median setup time, total observed attempts, abandonment reasons,
+assistance frequency, correct failure diagnoses, and support time per activated
+project. With a small cohort, list individual timings rather than relying on
+percentiles. Keep provider cost unknown unless measured; inference count is a
+useful separate measure, not a dollar estimate.
+
+Use the observed failure point to choose the next action:
+
+- Attention without setup attempts calls for clearer positioning or a better-qualified audience.
+- Setup attempts without first value call for installation, readiness, or example improvements.
+- First value without return calls for interviews about real usefulness and maintenance burden.
+- Return without expansion calls for examining data setup, authoring friction, and CI needs.
+- Repeated successful independent use supports another distribution experiment.
+
+Do not use stars, impressions, or downloads as substitutes for retained projects.
+Pause a channel after two focused experiments yield no qualified setup attempts.
+Keep support manageable before adding another channel.
+
+## Decisions to revisit after the pilot
+
+Decide whether the strongest demand is QA-led, developer-led, or coding-agent-led;
+whether web and mobile need different onboarding; and which second journey users
+actually add. Investigate willingness to pay only after repeated value is visible.
+Do not invent pricing, a hosted service, or paid-tier boundaries to complete a
+launch checklist.
+
+The audience, channel choices, thresholds, and rollout windows are hypotheses.
+Current repository documentation supports the product description, but no release
+installation, live target run, user research, or growth result was verified as part
+of writing this plan.

--- a/docs/roadmap-qa-ux-review.md
+++ b/docs/roadmap-qa-ux-review.md
@@ -1,0 +1,272 @@
+# Roadmap review: QA workflows, usability, reach, and simplicity
+
+Reviewed on 2026-09-04. This is a proposed revision strategy for
+[ROADMAP.md](../ROADMAP.md), not a replacement roadmap or an implementation
+status certification. The companion [launch and growth plan](launch-and-growth.md)
+turns the adoption priorities into release and distribution work.
+
+## Recommendation
+
+Finish the everyday QA loop before expanding autonomous authoring and repair:
+connect a real application, write a meaningful assertion, run it, understand a
+failure, maintain the generated interactions, rerun the affected scenario, and
+give a teammate useful evidence.
+
+The roadmap is strong on inspectable execution and source ownership. It is less
+specific about the work that makes a QA practitioner return tomorrow. Prioritize
+authentication, repeatable test data, assertion quality, failure recovery, and CI
+handoff ahead of picture-in-picture, broad exploration, and autonomous repair.
+Feature reach should mean more real journeys successfully tested with the same
+few concepts, rather than more modes and dashboards.
+
+## Findings by impact
+
+### High: completion status is internally inconsistent
+
+The platform summary at ROADMAP.md line 16 says live target video and web traces
+are absent. Lines 60–63 mark browser viewing, device mirroring, diagnostics, and
+time-travel inspection complete. Neither statement establishes which targets and
+artifact types have passed a real release test.
+
+The unchecked follow-mode item at line 66 also combines existing behavior with
+future work. The inspected [live follow model](../packages/studio/src/features/runs/result/live-result-follow.ts)
+already selects failing attempts, preserves a pinned location, and follows
+timeline entries. That proves implementation exists, not that picture-in-picture
+or the full user journey is complete.
+
+Split compound items and attach a release revision, supported target list, and
+verification link to each completed capability. Distinguish implemented,
+verified on a real target, and planned. Reconcile the summary only after that
+inventory. Do not restart features merely because their checkbox is stale.
+
+### High: QA needs ownership of the generated execution plan
+
+A QA engineer's feedback, relayed by the project owner, identifies a missing
+workflow: AI produces cached interactions, and a human must be able to edit and
+maintain them, with autonomous repair available when appropriate. This is one
+qualitative signal, not a measured demand rate, but it directly affects whether
+a team can maintain a suite after its first successful run.
+
+Use execution plan for the ordered actions and checks used by Replay. The
+coverage plan in Phase 3 describes what to test; the execution plan describes
+how a Scenario runs. Keep the Gherkin Specification as the source of expected
+behavior. Editing a click target must not silently change what the test asserts.
+
+Promote execution-plan inspection and manual maintenance into the core QA loop.
+Provide one workflow with two ways to prepare a change: the QA engineer edits
+an interaction, or AI proposes a repair. Both use the same diff, validation,
+version history, and activation rules. Autonomous application can follow later
+through explicit project policy and bounded attempts.
+
+The proposed interaction is:
+
+1. Open the execution plan from a Scenario or failing step. Show ordered actions
+   grouped by Gherkin step, with targets, non-secret inputs, checks, and the
+   evidence used to generate them. Explain complete and partial cached paths.
+2. Edit supported action fields directly, or insert, remove, and reorder
+   supported interactions. Offer contextual controls for targets and inputs;
+   do not require QA to edit SQLite or an opaque adapter payload. Label any
+   unsupported operation and explain the available recovery path.
+3. Alternatively, request an AI repair for the failing interaction. Show its
+   proposed changes and evidence. Preserve a manual path that needs no model
+   credentials for editing or Replay validation.
+4. Validate the candidate against the affected Scenario from a known initial
+   state. Keep the original expected outcomes. An isolated action preview is
+   useful feedback, but cannot establish that the Scenario still works.
+5. Activate only the validated revision, recording the human or AI author,
+   change diff, source run, and validation result. Keep the previous revision
+   available for rollback. Existing runs retain their original evidence.
+
+Human edits are authored work. They must survive cache eviction and must not be
+silently overwritten by Cache refresh. Before implementation, decide how durable
+repository-owned plan revisions produce disposable runtime cache entries, how
+refresh reconciles edits, and how changes to the Specification, application,
+profile, or adapter invalidate applicability. Reuse existing cache eligibility
+rules. This review proposes the requirement without selecting a new storage
+format or changing the current cache contract.
+
+Start with inspection and manual editing, then AI-assisted repair through that
+same workflow. Autonomous repair must obey the same validation gate, preserve
+assertions, stop on uncertain or repeated failures, and retain a rollback path.
+A real application regression stays failed. Changes to expected behavior belong
+in an explicit Specification review, not interaction repair.
+
+### High: first green is too weak an activation criterion
+
+Phase 1 measures two minutes only after credentials and target access are ready.
+That excludes much of the likely setup friction. A passing example also does
+not establish that someone can test their own application or detect a defect.
+
+Keep the two-minute ready-to-example goal as a diagnostic metric. Add total
+setup time, blocked and abandoned attempts, first real-application assertion,
+and a deliberate failure that the user can explain. Separate credential-free
+demonstration from successful Adaptive execution and applicable Replay.
+
+The [onboarding model](../packages/studio/src/features/onboarding/first-run-onboarding-model.ts)
+has explicit empty, blocked, ready, running, failed, and complete states. Use
+those states as the starting point for a journey audit instead of adding another
+onboarding system. No timing or user completion rate was measured in this review.
+
+### High: repeatable QA setup is buried in a large authoring phase
+
+Phase 3 line 81 bundles authentication, setup, data, variables, and reusable
+journeys. These are prerequisites for testing ordinary logged-in applications,
+including manually authored Specifications. They should not depend on a coverage
+planner or built-in generation.
+
+First document and verify what existing configuration and Gherkin support.
+Then close observed gaps for login, data isolation, cleanup, and state reset.
+Extract reusable flows only after two actual scenarios need the same behavior.
+A payment journey needs an explicit expected result and controlled test data
+before it needs an agent-generated plan.
+
+### High: failure diagnosis and CI arrive too late
+
+Phase 4 line 101 makes diagnosis without rerunning an exit criterion. Phase 5
+line 110 delays cache-only CI guidance and archived-failure handoff. These are
+core adoption tasks for a QA tool, even when repair and suite analytics are absent.
+
+Move basic diagnosis and a single-run CI recipe into launch readiness. Existing
+[CLI exports, selective reruns, and cache rules](../README.md) provide a starting
+point. Show expected versus observed behavior, the relevant step and artifact,
+application revision, execution mode, and a useful next action. Missing evidence
+must have an explicit reason. Keep unknown causes unknown.
+
+Basic CI use should not wait for PR annotations, shard merging, or a hosted
+service. Verify one failed CI run exported, downloaded, imported, and understood
+in local Studio without access to the original workspace.
+
+### Medium: the roadmap lacks a usable feature-reach boundary
+
+Web and mobile adapter names do not answer which journeys a QA team can trust.
+The README already records meaningful asymmetry: web can replay a stored prefix,
+while mobile Replay requires a complete Scenario. A parity promise hides that
+important difference.
+
+Publish a task-based support matrix before broad launch. For local web, attached
+CDP, Browserbase, Android Emulator, and iOS Simulator, record authentication,
+isolation, assertions, uploads/downloads where applicable, live viewing,
+artifacts, Replay, cancellation, and CI setup. Each cell needs a status and a
+reproducible example. Use unsupported and unverified distinctly. Audit existing
+support before adding functionality. Keep physical devices and hosted
+collaboration explicitly outside the initial release promise.
+
+### Medium: authoring and operator features need smaller contracts
+
+Phase 2 combines follow mode, pinning, filmstrip, picture-in-picture, capture,
+and cancellation. Phase 3 adds planning, generation, preview, semantic review,
+project knowledge, reusable state, health analysis, and autocomplete.
+
+Start with one selected scenario and one evidence inspector. Explain Run,
+Replay, and Cache refresh where users choose them. Put advanced diagnostics
+behind the failing step; preserve the selected evidence while new events arrive.
+
+For authoring, start with an editable template, clear assertion guidance, and
+full-scenario validation. A step preview must explain its initial state, setup,
+side effects, and whether it changed the live application. A green isolated step
+must not imply a green scenario. Keep generated drafts and acceptance when AI
+is added, but require the full planner only for workflows that need exploration.
+
+### Medium: accessibility and recovery are absent from release gates
+
+The existing gates cover security and portability but do not establish keyboard
+completion, focus recovery, zoom, readable narrow layouts, or streaming behavior.
+Add keyboard and screen-reader checks for selecting, running, inspecting,
+cancelling, and exporting. Verify focus after dialogs, failures, and rerenders.
+Live updates must not steal focus or continuously flood announcements.
+
+Also test invalid credentials, missing targets, stale live connections, cancelled
+runs, unavailable artifacts, and unsaved edits. Every blocked state should say
+what happened, preserve useful work, and expose the next supported action.
+
+### Medium: visual guidance and scheduling have drifted
+
+ROADMAP.md line 41 names Bone, teal, oxide, and amber. Current
+[DESIGN.md](../DESIGN.md) specifies neutral hierarchy, near-white primary
+controls, and written green/red result states. Refer to DESIGN.md as the visual
+source of truth rather than repeating tokens in the roadmap.
+
+The overlapping week ranges have no start date, capacity, or estimates. Replace
+them with ordered milestones and dependencies until the remaining work is sized.
+Watching a run is useful, but the share of watched runs is not a success measure
+by itself. An efficient team may need to watch fewer runs.
+
+## Proposed sequence
+
+These are recommendations for the next roadmap revision, not new delivery dates.
+
+| Milestone | Work to include | Exit evidence |
+| --- | --- | --- |
+| 1. Trust the release | Reconcile status, support matrix, installation, setup recovery, evidence availability | Exact release installed outside the monorepo; every advertised target has recorded real-target proof |
+| 2. Complete the QA loop | Meaningful assertions, authenticated example, isolated data, failure explanation, manual execution-plan maintenance, selective rerun, export and basic CI | External users repair a changed interaction through a validated plan revision; a seeded regression remains failed |
+| 3. Grow useful coverage | Templates, needed shared setup, manual Specification health, smallest draft/review/validate flow | A user adds a second independent journey and can explain its expected results |
+| 4. Reduce maintenance | Compatible visual comparison, evidenced classification, visible quarantine, AI-assisted and policy-controlled autonomous plan repair | Known app regressions remain failures; every accepted change has source and validation evidence |
+| 5. Scale proven usage | Trends, PR annotations, shard merging, agent workflows, change-impact experiments | Returning projects demonstrate a specific bottleneck and the change improves it |
+
+Continue using the current shared runner and evidence contracts throughout.
+Read-and-run MCP can move earlier if active coding-agent users demonstrate that
+it is their adoption blocker. It should not delay the human QA loop.
+
+Defer picture-in-picture, a concurrent-target filmstrip, broad autonomous
+exploration, physical devices, and hosted collaboration until observed use makes
+them necessary. Keep safe cancellation, live/completed evidence consistency, and
+explicit Replay divergence in the near-term scope.
+
+## QA acceptance session
+
+Recruit five external QA practitioners or developers with testing responsibility.
+Use their own small applications when access permits. Record assistance,
+completion, elapsed time, and blockers for each task. The following thresholds
+are proposed planning gates, not measured product performance or statistical
+proof of market readiness.
+
+| Task | Acceptance check |
+| --- | --- |
+| Install and connect | Four of five reach a ready target without maintainer intervention; report total setup time and all failed attempts |
+| Write and run | Four of five create a real assertion and explain why it passed; record time separately from example completion |
+| Detect a regression | A seeded incorrect application outcome fails every time in the test fixture; no fallback weakens the assertion |
+| Diagnose | Four of five identify the seeded cause within five minutes from persisted evidence without rerunning |
+| Repeat | Eligible scenarios Replay without inference; misses, partial prefixes, and divergence are explained accurately |
+| Maintain interactions | Four of five locate and edit a changed interaction without raw cache editing, validate the Scenario with unchanged assertions, and activate the revision; record time and assistance |
+| Preserve ownership | A validated manual change survives cache eviction; refresh exposes conflicts rather than overwriting it; rollback restores the previous plan revision |
+| Reject an unsafe repair | A candidate that skips or weakens the failed assertion cannot be activated as an interaction repair; failed validation leaves the active revision unchanged |
+| Recover | An invalid credential or disconnected target gives a usable recovery path without losing edits |
+| Hand off | A second person opens the exported failure and identifies the failed expectation without the author's help |
+| Return | At least three projects run again on a different day within seven days; assisted and unassisted returns stay separate |
+
+Run the core journey with keyboard alone, at 200% zoom, and at a narrow viewport.
+Inspect long names, large histories, unavailable artifacts, and concurrent events.
+A walkthrough or DOM check is not evidence that these sessions passed.
+
+For diagnosis measurements, use an explicit case set covering application
+regression, assertion defect, setup/data failure, infrastructure failure, and
+Replay divergence. Report correct answers and denominators by cause. The
+roadmap's 80% target should not be reported against only easy example failures.
+
+## Simplicity rules for the revision
+
+- Keep the existing navigation. Put new actions beside the task that needs them.
+- Show one clear primary action and progressively disclose advanced controls.
+- Keep Scenario result, execution mode, and cache outcome distinct, with short explanations.
+- Separate local Studio links from portable reports; a localhost URL is not a teammate-sharing mechanism.
+- Reuse the same failed-step evidence for live viewing, history, reruns, and exports.
+- Prefer a documented existing configuration path before creating a new wizard or abstraction.
+- Add a feature only with a named QA task, an observed gap, and a completion check.
+
+## Evidence and limits
+
+The execution-plan maintenance requirement incorporates QA feedback supplied by
+the project owner after the initial review. It is proposed product work; no plan
+editor, durable revision format, or repair workflow was implemented or verified.
+
+This review read the roadmap, README, DESIGN.md, release policy, onboarding
+model, and live follow implementation. It did not run Studio, test a published
+package, provision execution targets, or conduct usability interviews. Gaps in
+the roadmap are not automatically missing runtime features.
+
+The earlier [competitive review](roadmap-competitive-review.md) remains historical
+context. Current [Playwright documentation](https://playwright.dev/docs/test-agents)
+was checked on 2026-09-04 and describes planner, generator, and healer roles.
+That supports treating AI authoring as an existing competitive capability; it
+does not establish demand, quality, or a reason to match every feature before
+launch. The priority choices above are product judgments to test with users.


### PR DESCRIPTION
## Summary

- Add an actionable AI engineering backlog covering execution-plan inspection, editing, validation, activation, rollback, and repair.
- Document launch positioning, audience, activation stages, maintenance feedback, and evidence-based growth criteria.
- Clarify supported capabilities, deferred work, verification requirements, and product limitations.

## Testing

Not run (documentation-only changes).