### PR TITLE
Migrate agent guidance to AGENTS.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,8 +7,12 @@ This repository is a Bun + Turborepo monorepo:
 - `packages/cli` — executable package composition
 - `packages/studio` — local Studio UI
 - `apps/example` — sample Specifications
+- `apps/docs` — Next.js + Fumadocs documentation site
 
-Use `bun run lint`, `bun run typecheck`, and `bun run test` from the repo root. Typecheck and test run through Turborepo. Lint and format use Biome from the repo root.
+Root checks are `bun run lint`, `bun run typecheck`, and `bun run test`.
+Typecheck and package tests run through Turborepo; the test script also runs
+script tests and a Vitest migration check. Use package test scripts for focused
+runs so their Vitest runner flags and build prerequisites are preserved.
 
 Default to using Bun instead of Node.js.
 
@@ -20,7 +24,9 @@ Default to using Bun instead of Node.js.
 - Use `bunx <package> <command>` instead of `npx <package> <command>`
 - Bun automatically loads .env, so don't use dotenv.
 
-## APIs
+## Bun APIs
+
+For Bun runtime code:
 
 - `Bun.serve()` supports WebSockets, HTTPS, and routes. Don't use `express`.
 - `bun:sqlite` for SQLite. Don't use `better-sqlite3`.
@@ -30,150 +36,54 @@ Default to using Bun instead of Node.js.
 - Prefer `Bun.file` over `node:fs`'s readFile/writeFile
 - Bun.$`ls` instead of execa.
 
-## Testing
-
-Use Vitest through Bun to run tests.
-
-```ts#index.test.ts
-import { test, expect } from "vitest";
-
-test("hello world", () => {
- expect(1).toBe(1);
-});
-```
+For Bun API details, consult `node_modules/bun-types/docs/**.mdx` when available.
 
 ## Lint and format
 
-Use Biome from the repo root. Do not add ESLint or Prettier.
+Use the root scripts: `bun run lint` checks with Oxlint and Oxfmt;
+`bun run format` applies their fixes. Configuration lives in `.oxlintrc.json`
+and `.oxfmtrc.jsonc`. Do not add a parallel ESLint or Prettier setup.
+After changing TypeScript or JSON files, run `bun run lint` before finishing.
 
-```sh
-bun run lint
-bun run format
-```
-
-`bun run lint` checks formatting, import order, and lint rules. `bun run format` applies safe fixes. Configuration lives in `biome.json`.
-
-Write new TypeScript with 2-space indent, single quotes, and semicolons only when needed. Name variables in camelCase. Do not declare `SCREAMING_SNAKE_CASE` constants. Object keys may use CONSTANT_CASE when they match external names such as environment variables.
+Name variables in camelCase. Do not declare `SCREAMING_SNAKE_CASE` constants.
+Object keys may use CONSTANT_CASE when matching external names such as
+environment variables.
 
 ## TypeScript
 
-When casting to a shape that library types do not expose, declare a named `type` near the top of the file. Do not inline anonymous object types in `as { ... }` casts.
+When casting to a shape that library types do not expose, declare a named
+`type` near the top of the file. Do not inline anonymous object types in
+`as { ... }` casts. Cast at the point of use (`value as MyType`); do not add
+a one-line helper whose only job is wrapping that cast.
 
-Cast at the point of use (`value as MyType`). Do not add a one-line helper whose only job is wrapping that cast.
+## Contextual guidance
 
-After you change TypeScript or JSON files, run `bun run lint` before you finish.
+- For Studio architecture and UI, use [packages/studio/AGENTS.md](packages/studio/AGENTS.md).
+  This also applies when changing CLI integration with Studio: the CLI owns
+  process lifecycle and injects project gateways.
+- For documentation-site framework work, use [apps/docs/AGENTS.md](apps/docs/AGENTS.md).
+- For complex refactors or code-quality reviews, consult the local
+  [10x-coder skill](.agents/skills/10x-coder/SKILL.md). It is not a prerequisite
+  for every edit; use its boundary and React references when those concerns apply.
 
-## Frontend
+## Decision boundaries and completion
 
-Studio uses TanStack Start with Rsbuild. Use file routes for pages, typed server
-functions for same-origin application RPC, and server routes for raw HTTP or
-external contracts such as downloads. Keep route and server-function modules
-thin. Put transport-free behavior in focused services.
+Local implementation, refactoring, and validation within the requested scope
+can proceed without approval between steps. Continue through relevant checks
+and fixing issues introduced by the change until the requested behavior works,
+or a decision requiring user input blocks progress. Report exact checks and
+results, including any unverified runtime behavior or environmental blockers.
 
-Organize Studio application code by feature under `src/features/<feature>`.
-Colocate each feature's contracts, server functions, HTTP routes, and focused
-server-side behavior. Keep `src/server` limited to transport, security,
-composition, and lifecycle concerns; do not create cross-feature API or
-server-function grab bags.
+If the task has not already authorized it, get approval before:
 
-Keep TanStack route files composition-only. React pages, feature-specific
-components, hooks, models, tests, and server modules belong to their owning
-feature. Keep only proven cross-feature primitives and infrastructure in
-`src/components`, `src/hooks`, and `src/lib`; do not recreate flat `app`,
-`runs`, `settings`, or page-specific shared folders.
+- Materially expanding scope or changing a public API, compatibility contract,
+  schema, storage format, or wire format.
+- Adding a dependency, framework, service, or new test infrastructure. Adding
+  registry primitives required by an authorized Studio UI task follows the
+  scoped Studio guidance.
+- Deleting or overwriting user data, discarding uncommitted work, rewriting
+  history, or running irreversible migrations.
+- Production changes, publishing, or other external side effects.
 
-The CLI still owns Studio process lifecycle and injects project gateways. The
-embedded srvx host is limited to binding, security headers, static assets, and
-WebSocket upgrades. Do not add application routing back to a `Bun.serve`
-callback.
-
-## Studio UI
-
-Studio lives in `packages/studio`. Visual style is shadcn Mira on Base UI (`style: "base-mira"` in `packages/studio/components.json`).
-
-Every UI control must be a shadcn Mira primitive (or compose those primitives). Do not hand-roll a styled `<button>`, `<a>`, `<span>`, table chrome, or layout block that duplicates a registry component. Wrapping `@base-ui/react` yourself is not a substitute for adding the shadcn primitive — Mira only applies when the component comes from the registry.
-
-Before creating a new component or block:
-
-1. Search the shadcn registry for an existing primitive (`search_items_in_registries` / `view_items_in_registries`, or `bunx shadcn@latest search <name>` from `packages/studio`).
-2. If it exists, add it with `bunx shadcn@latest add <name>` from `packages/studio` so Mira is applied.
-3. Extend the generated file in `packages/studio/src/components/ui` only when the product needs a domain variant (for example result-state chips). Do not fork a parallel component.
-
-Product screens under `src/routes` and their composed page components import from `./components/ui/*`. They do not invent a second button, badge, or control vocabulary.
-
-For more information, read the Bun API docs in `node_modules/bun-types/docs/**.mdx`.
-
-## Coding standards
-
-Use the local `10x-coder` skill before writing or reviewing code. Apply its
-final evidence gate before reporting the task complete.
-
-## Before editing
-
-- Read the relevant code, tests, and configuration directly. Do not work from search snippets or guesses.
-- If the requirement is ambiguous or the premise is unverified, resolve that before building on it.
-- State a minimal plan:
-  - **Outcome** — the exact behavior requested
-  - **Non-goals** — what this task will not do
-  - **Files** — the smallest set expected to change
-  - **Proof** — the check that will prove the change works
-- Start with one implementation path. Split work only when the task has genuinely independent parts.
-
-## While editing
-
-- Reuse existing code, helpers, patterns, and test setup before adding anything new.
-- Fix bugs at the root cause. Do not stack patches around a wrong premise.
-- Add an abstraction, adapter, or config layer only for a second real caller in this task or a stated requirement.
-- Preserve behavior outside the requested change.
-- Do not design for rare or future cases nobody asked about.
-- Remove code you replace. Keep an old path only when compatibility is an explicit requirement.
-
-## Context-first refactoring
-
-- Understand the current responsibility, callers, and behavior before changing the structure.
-- Refactor from the domain context. Do not preserve an accidental structure because the existing code uses it.
-- Name code for what it does now. Avoid transitional names such as `legacyX`, `newX`, `temporaryX`, or `willChangeLaterX`.
-- Use a transitional name only when two real contracts must coexist during an explicit migration.
-- Do not add wrappers, aliases, flags, or adapters only to avoid completing the refactor.
-- Fix the incorrect abstraction and migrate its callers. Do not stack another abstraction on top of it.
-- Design for current requirements and real callers. Do not add a speculative path for a possible future change.
-- Split code by cohesive responsibility and context, not by line count or arbitrary categories.
-- Keep a helper near its only caller when moving it would make the behavior harder to follow.
-- Remove replaced code and obsolete names in the same change unless compatibility is an explicit requirement.
-- Preserve observable behavior. Change tests only when names or organization must follow the refactor.
-- Inspect more context instead of introducing a placeholder when the correct ownership or name is unclear.
-- Leave the code describing the current system. The reader must not need the refactor history to understand it.
-- Follow **Pause and confirm** before a refactor changes a public API or compatibility contract.
-
-## Pause and confirm
-
-Read-only discovery is always allowed. If the task has not already authorized it, get approval before:
-
-- Materially expanding the scope or touching unrelated files
-- Adding a dependency, framework, service, or new test infrastructure
-- Changing a public API, schema, storage format, or wire format
-- Deleting or overwriting user data, discarding uncommitted work, rewriting history, or dropping data
-- Keeping two implementations of the same behavior alive
-
-## Testing
-
-- Run the narrowest existing tests that exercise the changed behavior.
-- Extend the most relevant existing test before creating a new test file.
-- Add a test only when changed user-observable behavior is not covered, or when the user asks for one.
-- Each new test must protect a clear acceptance criterion or regression risk.
-- Do not backfill unrelated coverage or introduce test infrastructure for one task alone.
-- Do not use passing tests as justification for extra abstractions or scope.
-
-## If the plan grows
-
-Stop when the work starts adding future-use layers, workaround stacks,
-unrelated cleanup, or tests for unstated behavior. Rewrite a smaller plan
-and confirm the new scope.
-
-## Done means
-
-- The requested behavior works and the acceptance criteria are met
-- Relevant checks pass, with the exact commands and results reported
-- Every touched file is necessary and the diff contains nothing unrelated
-- No debug code, backup copies, dead paths, or scratch files remain
-- Assumptions, limitations, and unverified runtime behavior are stated plainly
+Keep parallel implementations only when compatibility or migration is part of
+the requested scope; routine internal refactors do not need separate approval.

--- a/apps/docs/AGENTS.md
+++ b/apps/docs/AGENTS.md
@@ -1,9 +1,15 @@
 <!-- BEGIN:nextjs-agent-rules -->
 
-# This is NOT the Next.js you know
+# Next.js documentation site
 
-This version has breaking changes — APIs, conventions, and file structure may all differ from your training data. Read the relevant guide in `node_modules/next/dist/docs/` (resolved from this file's directory; in monorepos the `next` package may not be visible from the repo root) before writing any code. Heed deprecation notices.
+When changing Next.js APIs, routing, configuration, or framework conventions,
+consult the relevant guide in `node_modules/next/dist/docs/`, resolved from this
+directory, and heed deprecation notices. This version has breaking changes;
+installed documentation takes precedence over assumptions from older versions.
+Content-only edits do not require reading framework guides.
 
-This block is written and re-added by `next dev` — verify at `node_modules/next/dist/server/lib/generate-agent-files.js`. Removing it from a diff only re-creates the uncommitted change; committing it with your work keeps the tree clean.
+If `next dev` regenerates this block, inspect the installed
+`node_modules/next/dist/server/lib/generate-agent-files.js` before reconciling
+the change. Do not include unrelated generated instruction changes in a commit.
 
 <!-- END:nextjs-agent-rules -->

--- a/packages/studio/AGENTS.md
+++ b/packages/studio/AGENTS.md
@@ -1,0 +1,41 @@
+# Studio
+
+Paths below are relative to `packages/studio`.
+
+## Architecture
+
+Studio uses TanStack Start with Rsbuild. Use file routes for pages, typed server
+functions for same-origin application RPC, and server routes for raw HTTP or
+external contracts such as downloads. Keep route and server-function modules
+thin. Put transport-free behavior in focused services.
+
+Organize Studio application code by feature under `src/features/<feature>`.
+Colocate each feature's contracts, server functions, HTTP routes, and focused
+server-side behavior. Keep `src/server` limited to transport, security,
+composition, and lifecycle concerns; do not create cross-feature API or
+server-function grab bags.
+
+Keep TanStack route files composition-only. React pages, feature-specific
+components, hooks, models, tests, and server modules belong to their owning
+feature. Keep only proven cross-feature primitives and infrastructure in
+`src/components`, `src/hooks`, and `src/lib`; do not recreate flat `app`,
+`runs`, `settings`, or page-specific shared folders.
+
+The CLI still owns Studio process lifecycle and injects project gateways. The
+embedded srvx host is limited to binding, security headers, static assets, and
+WebSocket upgrades. Do not add application routing back to a `Bun.serve`
+callback.
+
+## Studio UI
+
+Visual style is shadcn Mira on Base UI (`style: "base-mira"` in `components.json`).
+
+Every UI control must be a shadcn Mira primitive (or compose those primitives). Do not hand-roll a styled `<button>`, `<a>`, `<span>`, table chrome, or layout block that duplicates a registry component. Wrapping `@base-ui/react` yourself is not a substitute for adding the shadcn primitive — Mira only applies when the component comes from the registry.
+
+When adding a UI component or block not already available in `src/components/ui`:
+
+1. Search the shadcn registry for an existing primitive (`search_items_in_registries` / `view_items_in_registries`, or `bunx shadcn@latest search <name>` from `packages/studio`).
+2. If it exists, add it with `bunx shadcn@latest add <name>` from `packages/studio` so Mira is applied.
+3. Extend the generated file in `src/components/ui` only when the product needs a domain variant (for example result-state chips). Do not fork a parallel component.
+
+Product screens and their composed page components import primitives from `@/components/ui/*`. They do not invent a second button, badge, or control vocabulary.

--- a/packages/studio/CLAUDE.md
+++ b/packages/studio/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md


### PR DESCRIPTION
## Summary

- Update repository guidance for Bun, Turborepo, linting, and testing
- Move Studio architecture and UI instructions into `packages/studio/AGENTS.md`
- Add a Studio `CLAUDE.md` compatibility reference
- Refresh Next.js documentation guidance

## Testing

Not run (not requested)